### PR TITLE
fix: handle empty initialized response

### DIFF
--- a/pkg/mcp/httpclient.go
+++ b/pkg/mcp/httpclient.go
@@ -304,7 +304,8 @@ func (s *HTTPClient) Send(ctx context.Context, msg Message) error {
 		return fmt.Errorf("failed to send message: %s", resp.Status)
 	}
 
-	if s.sse || resp.ContentLength == 0 {
+	// It is possible for the ContentLength here to be -1.
+	if s.sse || (resp.ContentLength <= 0 && resp.Header.Get("Content-Type") != "text/event-stream") {
 		return nil
 	}
 


### PR DESCRIPTION
An MCP server can respond with content types application/json or text/event-stream. Typically, if a server responds with text/event-stream, then the content length is -1. However, if the response body is empty with no content type, then the content length could still be -1.

This change better detects when we should read a response.