### PR TITLE
fix: pass an oauth client name during registration

### DIFF
--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -37,6 +37,7 @@ type ClientOption struct {
 	ParentSession    *Session
 	Session          *SessionState
 	Runner           *Runner
+	OAuthClientName  string
 	OAuthRedirectURL string
 	CallbackHandler  CallbackHandler
 	ClientCredLookup ClientCredLookup
@@ -52,6 +53,9 @@ func (c ClientOption) Complete() ClientOption {
 	}
 	if c.TokenStorage == nil {
 		c.TokenStorage = NewDefaultLocalStorage()
+	}
+	if c.OAuthClientName == "" {
+		c.OAuthClientName = "Nanobot MCP Client"
 	}
 	return c
 }
@@ -94,6 +98,7 @@ func (c ClientOption) Merge(other ClientOption) (result ClientOption) {
 		result.TokenStorage = other.TokenStorage
 	}
 	result.OAuthRedirectURL = complete.Last(c.OAuthRedirectURL, other.OAuthRedirectURL)
+	result.OAuthClientName = complete.Last(c.OAuthClientName, other.OAuthClientName)
 	result.Env = complete.MergeMap(c.Env, other.Env)
 	result.Session = complete.Last(c.Session, other.Session)
 	result.ParentSession = complete.Last(c.ParentSession, other.ParentSession)
@@ -263,7 +268,7 @@ func NewSession(ctx context.Context, serverName string, config Server, opts ...C
 			}
 			header["Mcp-Session-Id"] = opt.Session.ID
 		}
-		wire = NewHTTPClient(ctx, serverName, config.BaseURL, opt.OAuthRedirectURL, opt.CallbackHandler, opt.ClientCredLookup, opt.TokenStorage, envvar.ReplaceMap(opt.Env, config.Headers))
+		wire = NewHTTPClient(ctx, serverName, config.BaseURL, opt.OAuthClientName, opt.OAuthRedirectURL, opt.CallbackHandler, opt.ClientCredLookup, opt.TokenStorage, envvar.ReplaceMap(opt.Env, config.Headers))
 	} else {
 		wire, err = newStdioClient(ctx, opt.Roots, opt.Env, serverName, config, opt.Runner)
 		if err != nil {

--- a/pkg/mcp/httpclient.go
+++ b/pkg/mcp/httpclient.go
@@ -39,11 +39,11 @@ type HTTPClient struct {
 	needReconnect bool
 }
 
-func NewHTTPClient(ctx context.Context, serverName, baseURL, oauthRedirectURL string, callbackHandler CallbackHandler, clientCredLookup ClientCredLookup, tokenStorage TokenStorage, headers map[string]string) *HTTPClient {
+func NewHTTPClient(ctx context.Context, serverName, baseURL, oauthClientName, oauthRedirectURL string, callbackHandler CallbackHandler, clientCredLookup ClientCredLookup, tokenStorage TokenStorage, headers map[string]string) *HTTPClient {
 	_, initialized := headers[SessionIDHeader]
 	h := &HTTPClient{
 		httpClient:    http.DefaultClient,
-		oauthHandler:  newOAuth(callbackHandler, clientCredLookup, tokenStorage, oauthRedirectURL),
+		oauthHandler:  newOAuth(callbackHandler, clientCredLookup, tokenStorage, oauthClientName, oauthRedirectURL),
 		baseURL:       baseURL,
 		messageURL:    baseURL,
 		serverName:    serverName,


### PR DESCRIPTION
Some services require a client name.

Also, some services aren't returning an expiration for the client secret, so stop validating it.