### PR TITLE
enhance: store new OAuth tokens for later use

### DIFF
--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -275,7 +275,7 @@ func NewSession(ctx context.Context, serverName string, config Server, opts ...C
 			}
 			header["Mcp-Session-Id"] = opt.SessionState.ID
 		}
-		wire = newHTTPClient(ctx, serverName, config.BaseURL, opt.OAuthClientName, opt.OAuthRedirectURL, opt.CallbackHandler, opt.ClientCredLookup, opt.TokenStorage, envvar.ReplaceMap(opt.Env, config.Headers))
+		wire = newHTTPClient(serverName, config.BaseURL, opt.OAuthClientName, opt.OAuthRedirectURL, opt.CallbackHandler, opt.ClientCredLookup, opt.TokenStorage, envvar.ReplaceMap(opt.Env, config.Headers))
 	} else {
 		wire, err = newStdioClient(ctx, opt.Roots, opt.Env, serverName, config, opt.Runner)
 		if err != nil {


### PR DESCRIPTION
Some services will issue a new refresh token when refreshing an OAuth token. This change ensures that we also have the latest token information in storage.