### PR TITLE
fix: save session after the initialization request is made

### DIFF
--- a/pkg/mcp/httpserver.go
+++ b/pkg/mcp/httpserver.go
@@ -218,15 +218,15 @@ func (h *HTTPServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	maps.Copy(session.session.EnvMap(), h.getEnv(req))
-	if err := h.sessions.Store(req, session.ID(), session); err != nil {
-		http.Error(rw, "Failed to store session: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
 	resp, err := session.Exchange(req.Context(), msg)
 	if err != nil {
 		http.Error(rw, "Failed to handle message: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	maps.Copy(session.session.EnvMap(), h.getEnv(req))
+	if err := h.sessions.Store(req, session.ID(), session); err != nil {
+		http.Error(rw, "Failed to store session: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
This will save the initialize request and response objects with the session.