### PR TITLE
enhance: list tools in healthz endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .cursorrules
 .envrc
 .idea
+.zed
 .venv
 .vscode
 bin/*


### PR DESCRIPTION
Listing tools and handing errors will tie Kubernetes pod health to MCP server health.