### PR TITLE
chore: use too early status for healthz

### DIFF
--- a/pkg/mcp/httpserver.go
+++ b/pkg/mcp/httpserver.go
@@ -126,7 +126,7 @@ func (h *HTTPServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			h.healthMu.RUnlock()
 
 			if healthErr == nil {
-				http.Error(rw, "waiting for startup", http.StatusServiceUnavailable)
+				http.Error(rw, "waiting for startup", http.StatusTooEarly)
 			} else if *healthErr != nil {
 				http.Error(rw, (*healthErr).Error(), http.StatusServiceUnavailable)
 			} else {


### PR DESCRIPTION
This is to distiguish between "we don't know if the server is healthy" and "the server is not healthy"