### PR TITLE
enhance: ensure message request IDs are 32-bit integers

### DIFF
--- a/pkg/mcp/session.go
+++ b/pkg/mcp/session.go
@@ -9,9 +9,9 @@ import (
 	"reflect"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/nanobot-ai/nanobot/pkg/complete"
-	"github.com/nanobot-ai/nanobot/pkg/uuid"
 )
 
 var ErrNoResult = errors.New("no result in response")
@@ -483,8 +483,8 @@ func (s *Session) toRequest(method string, in any, opt ExchangeOption) (*Message
 		}
 	}
 
-	if req.ID == nil || req.ID == "" {
-		req.ID = uuid.String()
+	if req.ID == nil || req.ID == "" || req.ID == 0 || req.ID == 0.0 {
+		req.ID = float64(time.Now().Unix())
 	}
 	if opt.ProgressToken != nil {
 		if err := req.SetProgressToken(opt.ProgressToken); err != nil {


### PR DESCRIPTION
Some MCP servers only work with request IDs that are 32-bit integers. Note that the JSON unmarshaling will set the type of such IDs to float64.

This change opaquely converts the request ID to a 32-bit integer if it is not one to appease such MCP servers. The caller is unaware of this conversion.