### PR TITLE
fix: return a 200 when deleting sessions

### DIFF
--- a/pkg/mcp/httpserver.go
+++ b/pkg/mcp/httpserver.go
@@ -167,7 +167,7 @@ func (h *HTTPServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 
 		sseSession.Close(true)
-		rw.WriteHeader(http.StatusNoContent)
+		rw.WriteHeader(http.StatusOK)
 		return
 	}
 


### PR DESCRIPTION
Inspector expects a 200 here, so it's probably best to just always return a 200 for this.