### PR TITLE
fix: add check for tools capability on server

### DIFF
--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -453,6 +453,9 @@ func (c *Client) GetPrompt(ctx context.Context, name string, args map[string]str
 
 func (c *Client) ListTools(ctx context.Context) (*ListToolsResult, error) {
 	var tools ListToolsResult
+	if c.Session.InitializeResult.Capabilities.Tools == nil {
+		return &tools, nil
+	}
 	err := c.Session.Exchange(ctx, "tools/list", struct{}{}, &tools)
 	return &tools, err
 }


### PR DESCRIPTION
Nanobot always listed clients even if the MCP server did not return the tool capability.