### PR TITLE
Fix: force sse to reconnect when it is initialize

### DIFF
--- a/pkg/mcp/httpclient.go
+++ b/pkg/mcp/httpclient.go
@@ -417,6 +417,7 @@ func (s *HTTPClient) initialize(ctx context.Context, msg Message) error {
 		streamError := fmt.Errorf("failed to initialize HTTP Streaming client: %s: %s", resp.Status, streamingErrorMessage)
 
 		s.sse = true
+		s.needReconnect = true
 		if err := s.ensureSSE(ctx, &msg, ""); err != nil {
 			s.sse = false
 			return errors.Join(streamError, err)


### PR DESCRIPTION
From obot client, when doing oauth check to initialize client. we disable event watching. This will stop getting events from SSE mcp server and block calls, making oauth-url api call from obot stuck forever. 

https://github.com/obot-platform/obot/issues/4988

Credit to donnie for helping to find this out!