### PR TITLE
fix: correctly parse hook definition

### DIFF
--- a/pkg/mcp/hooks.go
+++ b/pkg/mcp/hooks.go
@@ -109,7 +109,12 @@ func parseHookDefinition(data string) (HookDefinition, error) {
 		}
 	}
 
-	method := values.Get("method")
+	parts = strings.Split(parts[0], ":")
+	var method string
+	if len(parts) > 1 {
+		method = parts[1]
+	}
+
 	name := values.Get("name")
 	direction := values.Get("direction")
 	if direction != "" && direction != "in" && direction != "out" {

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -540,13 +540,8 @@ func (s *Service) runBefore(ctx context.Context, config types.Config, target, se
 type hookCtx struct{}
 
 func (s *Service) RunHook(ctx context.Context, msg, target string) (bool, string, *mcp.Message, error) {
-	// Don't call hooks recursively
-	if ctx.Value(hookCtx{}) != nil {
-		return true, "", nil, nil
-	}
-
 	server, tool, _ := strings.Cut(target, "/")
-	result, err := s.Call(context.WithValue(ctx, hookCtx{}, struct{}{}), server, tool, map[string]string{"message": msg})
+	result, err := s.Call(ctx, server, tool, map[string]string{"message": msg})
 	if err != nil {
 		return false, "", nil, err
 	}


### PR DESCRIPTION
The method was not correctly parsed.