### PR TITLE
fix: correctly determine UUIDs in path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/dop251/goja v0.0.0-20250630131328-58d95d85e994
 	github.com/glebarez/sqlite v1.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/google/uuid v1.6.0
 	github.com/hexops/autogold/v2 v2.3.0
 	github.com/modelcontextprotocol/go-sdk v0.2.0
 	github.com/obot-platform/mcp-oauth-proxy v0.0.3-0.20250916000024-e4d621ab46e1
@@ -35,7 +36,6 @@ require (
 	github.com/go-sql-driver/mysql v1.9.3 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20250630185457-6e76a2b096b5 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/handlers v1.5.2 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/hexops/valast v1.5.0 // indirect

--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -99,7 +99,7 @@ func (o *oauth) oauthClient(ctx context.Context, c *HTTPClient, connectURL, auth
 	var protectedResourceMetadata protectedResourceMetadata
 	if protectedResourceResp.StatusCode != http.StatusOK && protectedResourceResp.StatusCode != http.StatusNotFound {
 		body, _ := io.ReadAll(protectedResourceResp.Body)
-		return nil, fmt.Errorf("unexpeted status getting protected resource metadata (%d): %s", protectedResourceResp.StatusCode, string(body))
+		return nil, fmt.Errorf("unexpected status getting protected resource metadata (%d): %s", protectedResourceResp.StatusCode, string(body))
 	} else if protectedResourceResp.StatusCode == http.StatusOK {
 		protectedResourceMetadata, err = parseProtectedResourceMetadata(protectedResourceResp.Body)
 		if err != nil {

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/nanobot-ai/nanobot/pkg/mcp"
 	"github.com/nanobot-ai/nanobot/pkg/types"
+	"github.com/nanobot-ai/nanobot/pkg/uuid"
 	"gorm.io/gorm"
 )
 
@@ -155,7 +156,8 @@ func (m *Manager) ExtractID(req *http.Request) string {
 		if i > 0 && parts[i-1] == "agents" {
 			continue
 		}
-		if len(strings.Split(part, "-")) == 5 {
+
+		if uuid.ValidUUID(part) {
 			return part
 		}
 	}

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -4,6 +4,8 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"io"
+
+	"github.com/google/uuid"
 )
 
 func String() string {
@@ -27,4 +29,9 @@ func String() string {
 	hex.Encode(dst[24:], uuid[10:])
 
 	return string(dst[:])
+}
+
+func ValidUUID(s string) bool {
+	_, err := uuid.Parse(s)
+	return err == nil
 }


### PR DESCRIPTION
The check for UUID in the path was too simple. This change will parse the possible UUID to ensure they are a valid UUID.