### PR TITLE
feat: add audit logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/obot-platform/mcp-oauth-proxy v0.0.3-0.20250916000024-e4d621ab46e1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.9.1
+	github.com/tidwall/gjson v1.18.0
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.16.0
 	golang.org/x/term v0.34.0
@@ -54,6 +55,8 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/spf13/pflag v1.0.7 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/crypto v0.41.0 // indirect
 	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,12 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
 go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
 go.yaml.in/yaml/v3 v3.0.3 h1:bXOww4E/J3f66rav3pX3m8w6jDE4knZjGOw8b5Y6iNE=

--- a/pkg/confirm/confirm.go
+++ b/pkg/confirm/confirm.go
@@ -46,7 +46,7 @@ func (*Service) HandleAuthURL(ctx context.Context, mcpServerName, url string) (b
 
 	var elicitResponse mcp.ElicitResult
 
-	if err := session.Exchange(ctx, "elicitation/create", "", elicit, &elicitResponse); err != nil {
+	if err := session.Exchange(ctx, "elicitation/create", elicit, &elicitResponse); err != nil {
 		return false, fmt.Errorf("failed to elicit confirmation: %w", err)
 	}
 

--- a/pkg/mcp/auditlogs/auditlog.go
+++ b/pkg/mcp/auditlogs/auditlog.go
@@ -1,0 +1,41 @@
+package auditlogs
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// MCPAuditLog represents an audit log entry for MCP API calls
+type MCPAuditLog struct {
+	// Metadata is additional information about this server that a user can provide for audit log tracking purposes.
+	// For example Obot uses this to track catalog information.
+	Metadata         map[string]string  `json:"metadata,omitempty"`
+	CreatedAt        time.Time          `json:"createdAt"`
+	Subject          string             `json:"subject"`
+	ClientName       string             `json:"clientName"`
+	ClientVersion    string             `json:"clientVersion"`
+	ClientIP         string             `json:"clientIP"`
+	CallType         string             `json:"callType"`
+	CallIdentifier   string             `json:"callIdentifier,omitempty"`
+	RequestBody      json.RawMessage    `json:"requestBody,omitempty"`
+	ResponseBody     json.RawMessage    `json:"responseBody,omitempty"`
+	ResponseStatus   int                `json:"responseStatus"`
+	Error            string             `json:"error,omitempty"`
+	ProcessingTimeMs int64              `json:"processingTimeMs"`
+	SessionID        string             `json:"sessionID,omitempty"`
+	WebhookStatuses  []MCPWebhookStatus `json:"webhookStatuses,omitempty"`
+
+	// Additional metadata
+	RequestID       string          `json:"requestID,omitempty"`
+	UserAgent       string          `json:"userAgent,omitempty"`
+	RequestHeaders  json.RawMessage `json:"requestHeaders,omitempty"`
+	ResponseHeaders json.RawMessage `json:"responseHeaders,omitempty"`
+}
+
+type MCPWebhookStatus struct {
+	Type    string `json:"type,omitempty"`
+	Method  string `json:"method,omitempty"`
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+}

--- a/pkg/mcp/auditlogs/collector.go
+++ b/pkg/mcp/auditlogs/collector.go
@@ -1,0 +1,151 @@
+package auditlogs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/nanobot-ai/nanobot/pkg/log"
+)
+
+type Collector struct {
+	auditBuffer      []MCPAuditLog
+	auditLock        sync.Mutex
+	auditLogMetadata map[string]string
+	kickAuditPersist chan struct{}
+	done             chan struct{}
+	sendURL, token   string
+}
+
+func NewCollector(sendURL, token string, batchSize int, flushInterval time.Duration, auditLogMetadata map[string]string) *Collector {
+	c := &Collector{
+		sendURL:          sendURL,
+		token:            token,
+		done:             make(chan struct{}),
+		auditBuffer:      make([]MCPAuditLog, 0, 2*batchSize),
+		kickAuditPersist: make(chan struct{}),
+		auditLogMetadata: auditLogMetadata,
+	}
+
+	go c.runPersistenceLoop(flushInterval)
+
+	return c
+}
+
+// Close closes the collector and waits for all pending audit logs to be persisted.
+func (c *Collector) Close() {
+	if c == nil {
+		return
+	}
+
+	close(c.kickAuditPersist)
+	<-c.done
+}
+
+func (c *Collector) CollectMCPAuditEntry(entry MCPAuditLog) {
+	if c == nil || entry.CallType == "" {
+		// If the call type is empty, then this is a response to a request.
+		// The audit log will be handled elsewhere.
+		return
+	}
+
+	entry.Metadata = c.auditLogMetadata
+
+	c.auditLock.Lock()
+	defer c.auditLock.Unlock()
+
+	c.auditBuffer = append(c.auditBuffer, entry)
+	if len(c.auditBuffer) >= cap(c.auditBuffer)/2 {
+		select {
+		case c.kickAuditPersist <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (c *Collector) runPersistenceLoop(flushInterval time.Duration) {
+	timer := time.NewTimer(flushInterval)
+	defer timer.Stop()
+	defer close(c.done)
+
+	var closed bool
+	for {
+		select {
+		case _, closed = <-c.kickAuditPersist:
+			timer.Stop()
+		case <-timer.C:
+		}
+
+		if err := c.persistAuditLogs(); err != nil {
+			log.Errorf(context.Background(), "Failed to persist audit log: %v", err)
+		}
+
+		if closed {
+			return
+		}
+
+		timer.Reset(flushInterval)
+	}
+}
+
+func (c *Collector) persistAuditLogs() error {
+	c.auditLock.Lock()
+	if len(c.auditBuffer) == 0 {
+		c.auditLock.Unlock()
+		return nil
+	}
+
+	buf := c.auditBuffer
+	c.auditBuffer = make([]MCPAuditLog, 0, cap(c.auditBuffer))
+	c.auditLock.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := c.sendMCPAuditLogs(ctx, buf); err != nil {
+		c.auditLock.Lock()
+		c.auditBuffer = append(buf, c.auditBuffer...)
+		c.auditLock.Unlock()
+		return err
+	}
+
+	return nil
+}
+
+func (c *Collector) sendMCPAuditLogs(ctx context.Context, logs []MCPAuditLog) error {
+	h := http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	jsonBytes, err := json.Marshal(logs)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.sendURL, bytes.NewBuffer(jsonBytes))
+	if err != nil {
+		return err
+	}
+
+	if c.token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
+	}
+
+	resp, err := h.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status code sending audit logs %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	return nil
+}

--- a/pkg/mcp/context.go
+++ b/pkg/mcp/context.go
@@ -1,6 +1,10 @@
 package mcp
 
-import "context"
+import (
+	"context"
+
+	"github.com/nanobot-ai/nanobot/pkg/mcp/auditlogs"
+)
 
 var sessionKey = struct{}{}
 
@@ -28,7 +32,32 @@ func WithToken(ctx context.Context, token string) context.Context {
 	return context.WithValue(ctx, tokenKey{}, token)
 }
 
-func TokenFromContext(ctx context.Context) (string, bool) {
-	token, ok := ctx.Value(tokenKey{}).(string)
-	return token, ok
+func TokenFromContext(ctx context.Context) string {
+	token, _ := ctx.Value(tokenKey{}).(string)
+	return token
+}
+
+type auditLogKey struct{}
+
+func WithAuditLog(ctx context.Context, auditLog *auditlogs.MCPAuditLog) context.Context {
+	if auditLog == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, auditLogKey{}, auditLog)
+}
+
+func AuditLogFromContext(ctx context.Context) *auditlogs.MCPAuditLog {
+	auditLog, _ := ctx.Value(auditLogKey{}).(*auditlogs.MCPAuditLog)
+	return auditLog
+}
+
+type mcpServerConfigKey struct{}
+
+func WithMCPServerConfig(ctx context.Context, config Server) context.Context {
+	return context.WithValue(ctx, mcpServerConfigKey{}, config)
+}
+
+func MCPServerConfigFromContext(ctx context.Context) Server {
+	config, _ := ctx.Value(mcpServerConfigKey{}).(Server)
+	return config
 }

--- a/pkg/mcp/httpclient.go
+++ b/pkg/mcp/httpclient.go
@@ -171,8 +171,8 @@ func (s *HTTPClient) newRequest(ctx context.Context, method string, in any) (*ht
 
 	// Perform token exchange if configured and a token was parsed
 	// Check for a token on the context
-	token, ok := TokenFromContext(ctx)
-	if ok && token != "" {
+	token := TokenFromContext(ctx)
+	if token != "" {
 		// Exchange the token
 		exchangedToken, err := s.exchangeToken(ctx, token)
 		if err != nil {

--- a/pkg/mcp/message.go
+++ b/pkg/mcp/message.go
@@ -27,9 +27,18 @@ type Message struct {
 }
 
 func NewMessage(method string, params any) (*Message, error) {
+	return newMessage(method, params, nil)
+}
+
+func NewMessageWithID(method string, params any) (*Message, error) {
+	return newMessage(method, params, nextMessageID())
+}
+
+func newMessage(method string, params, id any) (*Message, error) {
 	msg := &Message{
 		JSONRPC: "2.0",
 		Method:  method,
+		ID:      id,
 	}
 	if params != nil {
 		data, err := json.Marshal(params)

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -90,7 +90,7 @@ type PrimitiveProperty struct {
 	MaxLength   *int         `json:"maxLength,omitempty"`
 	Minimum     *json.Number `json:"minimum,omitempty"`
 	Maximum     *json.Number `json:"maximum,omitempty"`
-	Default     *bool        `json:"default,omitempty"`
+	Default     any          `json:"default,omitempty"`
 	Enum        []string     `json:"enum,omitempty"`
 	EnumNames   []string     `json:"enumNames,omitempty"`
 	// Format must be one of "date-time", "email", "uri", "date"

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nanobot-ai/nanobot/pkg/complete"
 	"github.com/nanobot-ai/nanobot/pkg/llm"
 	"github.com/nanobot-ai/nanobot/pkg/mcp"
+	"github.com/nanobot-ai/nanobot/pkg/mcp/auditlogs"
 	"github.com/nanobot-ai/nanobot/pkg/sampling"
 	"github.com/nanobot-ai/nanobot/pkg/servers/agent"
 	"github.com/nanobot-ai/nanobot/pkg/servers/agentui"
@@ -40,6 +41,7 @@ type Options struct {
 	TokenExchangeEndpoint     string
 	TokenExchangeClientID     string
 	TokenExchangeClientSecret string
+	AuditLogCollector         *auditlogs.Collector
 }
 
 func (o Options) Merge(other Options) (result Options) {
@@ -53,6 +55,7 @@ func (o Options) Merge(other Options) (result Options) {
 	result.TokenExchangeEndpoint = complete.Last(o.TokenExchangeEndpoint, other.TokenExchangeEndpoint)
 	result.TokenExchangeClientID = complete.Last(o.TokenExchangeClientID, other.TokenExchangeClientID)
 	result.TokenExchangeClientSecret = complete.Last(o.TokenExchangeClientSecret, other.TokenExchangeClientSecret)
+	result.AuditLogCollector = complete.Last(o.AuditLogCollector, other.AuditLogCollector)
 	return
 }
 
@@ -77,6 +80,7 @@ func NewRuntime(cfg llm.Config, opts ...Options) (*Runtime, error) {
 		TokenExchangeEndpoint:     opt.TokenExchangeEndpoint,
 		TokenExchangeClientID:     opt.TokenExchangeClientID,
 		TokenExchangeClientSecret: opt.TokenExchangeClientSecret,
+		AuditLogCollector:         opt.AuditLogCollector,
 	})
 	agents := agents.New(completer, registry)
 	sampler := sampling.NewSampler(agents)

--- a/pkg/tools/flows.go
+++ b/pkg/tools/flows.go
@@ -343,7 +343,7 @@ func (s *Service) elicit(ctx flowContext, elicit types.Elicit) (*types.CallResul
 		}
 	}
 
-	if err := session.Exchange(ctx.ctx, "elicitation/create", "", &request, &response); err != nil {
+	if err := session.Exchange(ctx.ctx, "elicitation/create", &request, &response); err != nil {
 		return nil, fmt.Errorf("failed to create elicit request: %w", err)
 	}
 


### PR DESCRIPTION
If a URL is provided, then the audit logs will be sent to the specified URL. An optional token can be provided to authenticate the request.

A side effect of this change is that an MCP client will be initialized if the nanobot is exposing one MCP server.