### PR TITLE
fix: pull initialize request from session state if it exists

### DIFF
--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -318,7 +318,10 @@ func NewSession(ctx context.Context, serverName string, config Server, opts ...C
 			}
 			headers["Mcp-Session-Id"] = opt.SessionState.ID
 		}
-		wire = newHTTPClient(serverName, config, opt.HTTPClientOptions, headers, !opt.ignoreEvents)
+		wire, err = newHTTPClient(serverName, config, opt.HTTPClientOptions, opt.SessionState, headers, !opt.ignoreEvents)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		wire, err = newStdioClient(ctx, opt.Roots, opt.Env, serverName, config, opt.Runner)
 		if err != nil {


### PR DESCRIPTION
This will ensure that creating a client will properly detect if it should use an existing session or create a new one.