### PR TITLE
fix: clone audit log metadata to avoid getting overwritten

### DIFF
--- a/pkg/mcp/auditlogs/collector.go
+++ b/pkg/mcp/auditlogs/collector.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"sync"
 	"time"
@@ -54,7 +55,10 @@ func (c *Collector) CollectMCPAuditEntry(entry MCPAuditLog) {
 		return
 	}
 
-	entry.Metadata = c.auditLogMetadata
+	// Copy the metadata to avoid sharing the same map across entries
+	if len(c.auditLogMetadata) > 0 {
+		entry.Metadata = maps.Clone(c.auditLogMetadata)
+	}
 
 	c.auditLock.Lock()
 	defer c.auditLock.Unlock()


### PR DESCRIPTION
Gonna be fully honest: I don't remember why I did this, but it's what I've been using locally, and I assume it fixed something.