### PR TITLE
Clone repo if env vars provided

### DIFF
--- a/pkg/cli/serve_test.go
+++ b/pkg/cli/serve_test.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCloneGitHubRepoIfConfigured_EmptyCloneURL(t *testing.T) {
+	// Save original env vars
+	originalCloneURL := os.Getenv("GITHUB_CLONE_URL")
+	originalRepo := os.Getenv("GITHUB_REPO")
+	defer func() {
+		os.Setenv("GITHUB_CLONE_URL", originalCloneURL)
+		os.Setenv("GITHUB_REPO", originalRepo)
+	}()
+
+	// Test with empty GITHUB_CLONE_URL
+	os.Setenv("GITHUB_CLONE_URL", "")
+	os.Setenv("GITHUB_REPO", "")
+
+	err := cloneGitHubRepoIfConfigured()
+	if err != nil {
+		t.Errorf("Expected no error with empty GITHUB_CLONE_URL, got: %v", err)
+	}
+}
+
+func TestCloneGitHubRepoIfConfigured_MissingGitHubRepo(t *testing.T) {
+	// Save original env vars
+	originalCloneURL := os.Getenv("GITHUB_CLONE_URL")
+	originalRepo := os.Getenv("GITHUB_REPO")
+	defer func() {
+		os.Setenv("GITHUB_CLONE_URL", originalCloneURL)
+		os.Setenv("GITHUB_REPO", originalRepo)
+	}()
+
+	// Test with GITHUB_CLONE_URL set but GITHUB_REPO empty
+	os.Setenv("GITHUB_CLONE_URL", "https://github.com/example/repo.git")
+	os.Setenv("GITHUB_REPO", "")
+
+	err := cloneGitHubRepoIfConfigured()
+	if err == nil {
+		t.Error("Expected error when GITHUB_CLONE_URL is set but GITHUB_REPO is not")
+	}
+	expectedMsg := "GITHUB_CLONE_URL is set but GITHUB_REPO is not"
+	if err.Error() != expectedMsg {
+		t.Errorf("Expected error message %q, got %q", expectedMsg, err.Error())
+	}
+}
+
+func TestCloneGitHubRepoIfConfigured_InvalidRepoFormat(t *testing.T) {
+	// Save original env vars
+	originalCloneURL := os.Getenv("GITHUB_CLONE_URL")
+	originalRepo := os.Getenv("GITHUB_REPO")
+	defer func() {
+		os.Setenv("GITHUB_CLONE_URL", originalCloneURL)
+		os.Setenv("GITHUB_REPO", originalRepo)
+	}()
+
+	testCases := []struct {
+		name     string
+		repoName string
+	}{
+		{
+			name:     "no slash",
+			repoName: "repo",
+		},
+		{
+			name:     "too many slashes",
+			repoName: "owner/repo/extra",
+		},
+		{
+			name:     "empty string",
+			repoName: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Setenv("GITHUB_CLONE_URL", "https://github.com/example/repo.git")
+			os.Setenv("GITHUB_REPO", tc.repoName)
+
+			err := cloneGitHubRepoIfConfigured()
+			if err == nil {
+				t.Errorf("Expected error for invalid repo format %q", tc.repoName)
+			}
+		})
+	}
+}
+
+func TestCloneGitHubRepoIfConfigured_DirectoryAlreadyExists(t *testing.T) {
+	// Save original env vars and working directory
+	originalCloneURL := os.Getenv("GITHUB_CLONE_URL")
+	originalRepo := os.Getenv("GITHUB_REPO")
+	originalWd, _ := os.Getwd()
+	defer func() {
+		os.Setenv("GITHUB_CLONE_URL", originalCloneURL)
+		os.Setenv("GITHUB_REPO", originalRepo)
+		os.Chdir(originalWd)
+	}()
+
+	// Create a temporary directory
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+
+	// Create a directory that matches the repo name
+	repoName := "test-repo"
+	repoDir := filepath.Join(tmpDir, repoName)
+	if err := os.Mkdir(repoDir, 0755); err != nil {
+		t.Fatalf("Failed to create test directory: %v", err)
+	}
+
+	// Set env vars
+	os.Setenv("GITHUB_CLONE_URL", "https://github.com/owner/test-repo.git")
+	os.Setenv("GITHUB_REPO", "owner/test-repo")
+
+	// Should not error and should not attempt to clone
+	err := cloneGitHubRepoIfConfigured()
+	if err != nil {
+		t.Errorf("Expected no error when directory already exists, got: %v", err)
+	}
+
+	// Verify we're now in the repo directory
+	// Use EvalSymlinks to resolve any symlinks (e.g., /var -> /private/var on macOS)
+	currentWd, _ := os.Getwd()
+	expectedPath, _ := filepath.EvalSymlinks(repoDir)
+	actualPath, _ := filepath.EvalSymlinks(currentWd)
+	if actualPath != expectedPath {
+		t.Errorf("Expected working directory to be %q, got %q", expectedPath, actualPath)
+	}
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -42,6 +42,7 @@ type Options struct {
 	TokenExchangeClientSecret string
 	AuditLogCollector         *auditlogs.Collector
 	ConfigDir                 string
+	Workdir                   string
 }
 
 func (o Options) Merge(other Options) (result Options) {
@@ -57,6 +58,7 @@ func (o Options) Merge(other Options) (result Options) {
 	result.TokenExchangeClientSecret = complete.Last(o.TokenExchangeClientSecret, other.TokenExchangeClientSecret)
 	result.AuditLogCollector = complete.Last(o.AuditLogCollector, other.AuditLogCollector)
 	result.ConfigDir = complete.Last(o.ConfigDir, other.ConfigDir)
+	result.Workdir = complete.Last(o.Workdir, other.Workdir)
 	return
 }
 
@@ -104,7 +106,7 @@ func NewRuntime(cfg llm.Config, opts ...Options) (*Runtime, error) {
 	})
 
 	registry.AddServer("nanobot.system", func(string) mcp.MessageHandler {
-		return system.NewServer(opt.ConfigDir)
+		return system.NewServer(opt.ConfigDir, opt.Workdir)
 	})
 
 	registry.AddServer("nanobot.workflows", func(string) mcp.MessageHandler {

--- a/pkg/servers/system/config_test.go
+++ b/pkg/servers/system/config_test.go
@@ -24,7 +24,7 @@ func createPermissions(t *testing.T, perms map[string]string) *types.AgentPermis
 }
 
 func TestConfigSkillsPermissionAppendsInstructions(t *testing.T) {
-	server := NewServer("")
+	server := NewServer("", "")
 	ctx := context.Background()
 
 	agent := &types.HookAgent{
@@ -70,7 +70,7 @@ func TestConfigSkillsPermissionAppendsInstructions(t *testing.T) {
 }
 
 func TestConfigSkillsPermissionIncludesSkillDetails(t *testing.T) {
-	server := NewServer("")
+	server := NewServer("", "")
 	ctx := context.Background()
 
 	agent := &types.HookAgent{
@@ -113,7 +113,7 @@ func TestConfigSkillsPermissionIncludesSkillDetails(t *testing.T) {
 }
 
 func TestConfigNoSkillsPermission(t *testing.T) {
-	server := NewServer("")
+	server := NewServer("", "")
 	ctx := context.Background()
 
 	originalInstructions := "You are a helpful assistant."
@@ -153,7 +153,7 @@ func TestConfigNoSkillsPermission(t *testing.T) {
 }
 
 func TestConfigSkillsPermissionDenied(t *testing.T) {
-	server := NewServer("")
+	server := NewServer("", "")
 	ctx := context.Background()
 
 	originalInstructions := "You are a helpful assistant."
@@ -192,7 +192,7 @@ func TestConfigSkillsPermissionDenied(t *testing.T) {
 
 func TestConfigWithUserSkills(t *testing.T) {
 	// Use test data directory with user skills
-	server := NewServer(testdataDir(t, "with-user-skills"))
+	server := NewServer(testdataDir(t, "with-user-skills"), "")
 	ctx := context.Background()
 
 	agent := &types.HookAgent{
@@ -231,7 +231,7 @@ func TestConfigWithUserSkills(t *testing.T) {
 }
 
 func TestConfigEmptyInstructions(t *testing.T) {
-	server := NewServer("")
+	server := NewServer("", "")
 	ctx := context.Background()
 
 	agent := &types.HookAgent{
@@ -265,7 +265,7 @@ func TestConfigEmptyInstructions(t *testing.T) {
 }
 
 func TestConfigNilAgent(t *testing.T) {
-	server := NewServer("")
+	server := NewServer("", "")
 	ctx := context.Background()
 
 	result, err := server.config(ctx, types.AgentConfigHook{
@@ -283,7 +283,7 @@ func TestConfigNilAgent(t *testing.T) {
 }
 
 func TestConfigAddsToolsForPermissions(t *testing.T) {
-	server := NewServer("")
+	server := NewServer("", "")
 	ctx := context.Background()
 
 	agent := &types.HookAgent{

--- a/pkg/servers/system/server_test.go
+++ b/pkg/servers/system/server_test.go
@@ -1,0 +1,44 @@
+package system
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetWorkdir_WithExplicitWorkdir(t *testing.T) {
+	expectedWorkdir := "/some/explicit/path"
+	server := NewServer("", expectedWorkdir)
+
+	workdir := server.getWorkdir()
+	if workdir != expectedWorkdir {
+		t.Errorf("Expected workdir %q, got %q", expectedWorkdir, workdir)
+	}
+}
+
+func TestGetWorkdir_WithEmptyWorkdir(t *testing.T) {
+	server := NewServer("", "")
+
+	workdir := server.getWorkdir()
+
+	// Should return current working directory
+	expectedWorkdir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current working directory: %v", err)
+	}
+
+	if workdir != expectedWorkdir {
+		t.Errorf("Expected workdir to be current directory %q, got %q", expectedWorkdir, workdir)
+	}
+}
+
+func TestGetWorkdir_FallbackToDot(t *testing.T) {
+	// This test verifies the fallback behavior, though it's hard to trigger
+	// the os.Getwd() error in normal circumstances
+	server := NewServer("", "")
+
+	// Even if we can't force an error, the workdir should be valid
+	workdir := server.getWorkdir()
+	if workdir == "" {
+		t.Error("Expected workdir to not be empty")
+	}
+}

--- a/pkg/servers/system/skills_test.go
+++ b/pkg/servers/system/skills_test.go
@@ -19,7 +19,7 @@ func testdataDir(t *testing.T, subdir string) string {
 }
 
 func TestListSkills(t *testing.T) {
-	server := NewServer("")
+	server := NewServer("", "")
 	ctx := context.Background()
 
 	result, err := server.listSkills(ctx, struct{}{})
@@ -60,7 +60,7 @@ func TestListSkills(t *testing.T) {
 }
 
 func TestListSkillsWithUserSkills(t *testing.T) {
-	server := NewServer(testdataDir(t, "with-user-skills"))
+	server := NewServer(testdataDir(t, "with-user-skills"), "")
 	ctx := context.Background()
 
 	result, err := server.listSkills(ctx, struct{}{})
@@ -97,7 +97,7 @@ func TestListSkillsWithUserSkills(t *testing.T) {
 }
 
 func TestListSkillsUserOverridesBuiltin(t *testing.T) {
-	server := NewServer(testdataDir(t, "with-override"))
+	server := NewServer(testdataDir(t, "with-override"), "")
 	ctx := context.Background()
 
 	result, err := server.listSkills(ctx, struct{}{})
@@ -134,7 +134,7 @@ func TestListSkillsUserOverridesBuiltin(t *testing.T) {
 
 func TestListSkillsMissingDirectory(t *testing.T) {
 	// Use a non-existent directory - should not error
-	server := NewServer("/non/existent/directory")
+	server := NewServer("/non/existent/directory", "")
 	ctx := context.Background()
 
 	result, err := server.listSkills(ctx, struct{}{})
@@ -153,7 +153,7 @@ func TestListSkillsMissingDirectory(t *testing.T) {
 
 func TestListSkillsEmptyDirectory(t *testing.T) {
 	// Use a directory with an empty skills subdirectory
-	server := NewServer(testdataDir(t, "empty-skills"))
+	server := NewServer(testdataDir(t, "empty-skills"), "")
 	ctx := context.Background()
 
 	result, err := server.listSkills(ctx, struct{}{})
@@ -171,7 +171,7 @@ func TestListSkillsEmptyDirectory(t *testing.T) {
 }
 
 func TestGetSkill(t *testing.T) {
-	server := NewServer("")
+	server := NewServer("", "")
 	ctx := context.Background()
 
 	tests := []struct {
@@ -244,7 +244,7 @@ func TestGetSkill(t *testing.T) {
 }
 
 func TestGetSkillUserSkill(t *testing.T) {
-	server := NewServer(testdataDir(t, "with-user-skills"))
+	server := NewServer(testdataDir(t, "with-user-skills"), "")
 	ctx := context.Background()
 
 	content, err := server.getSkill(ctx, GetSkillParams{Name: "my-custom-skill"})
@@ -260,7 +260,7 @@ func TestGetSkillUserSkill(t *testing.T) {
 }
 
 func TestGetSkillUserOverridesBuiltin(t *testing.T) {
-	server := NewServer(testdataDir(t, "with-override"))
+	server := NewServer(testdataDir(t, "with-override"), "")
 	ctx := context.Background()
 
 	content, err := server.getSkill(ctx, GetSkillParams{Name: "learn"})
@@ -280,7 +280,7 @@ func TestGetSkillUserOverridesBuiltin(t *testing.T) {
 
 func TestGetSkillFallsBackToBuiltin(t *testing.T) {
 	// Use the with-user-skills directory which doesn't have a learn.md file
-	server := NewServer(testdataDir(t, "with-user-skills"))
+	server := NewServer(testdataDir(t, "with-user-skills"), "")
 	ctx := context.Background()
 
 	content, err := server.getSkill(ctx, GetSkillParams{Name: "learn"})


### PR DESCRIPTION
And make the repo the current working dir. Also, fix working directory
for system tools after git clone by capturing it after repository cloning
and passes it through runtime options to system server, ensuring
bash/glob/grep tools operate in the correct directory.

Signed-off-by: Craig Jellick <craig@obot.ai>
