### PR TITLE
chore: report 2025-06-18 as the MCP version

### DIFF
--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -387,7 +387,7 @@ func NewClient(ctx context.Context, serverName string, config Server, opts ...Cl
 	}
 	if opt.SessionState == nil {
 		_, err = c.Initialize(ctx, InitializeRequest{
-			ProtocolVersion: "2025-11-25",
+			ProtocolVersion: "2025-06-18",
 			Capabilities: ClientCapabilities{
 				Sampling:    sampling,
 				Roots:       roots,


### PR DESCRIPTION
Some clients refuse the newest version.

related to https://github.com/obot-platform/obot/issues/5680