### PR TITLE
enhance: use human-friendly step names in workflows

### DIFF
--- a/pkg/config/agents/WORKFLOW_SCHEMA.md
+++ b/pkg/config/agents/WORKFLOW_SCHEMA.md
@@ -15,18 +15,18 @@ Review code changes for quality issues.
 
 ## Steps
 
-### 1. find_changes
+### 1. Find Changes
 Find all modified code files in {{input.target}}.
 
-### 2. review_code
+### 2. Review Code
 Review these files for quality issues:
-{{find_changes}}
+{{Find Changes}}
 
 Focus on: error handling, edge cases, and readability.
 
 ## Output
 
-{{review_code}}
+{{Review Code}}
 ```
 
 ## Example: With Conditions
@@ -38,25 +38,25 @@ Analyze an issue and apply a fix only if it's safe to do so.
 
 ## Steps
 
-### 1. analyze_issue
+### 1. Analyze Issue
 Analyze the reported issue and determine severity.
 
-### 2. check_safety
+### 2. Check Safety
 Based on this analysis, determine if an automated fix is safe:
-{{analyze_issue}}
+{{Analyze Issue}}
 
 End your response with SAFE or UNSAFE.
 
-### 3. apply_fix
-Apply the fix for: {{analyze_issue}}
+### 3. Apply Fix
+Apply the fix for: {{Analyze Issue}}
 
-**Condition:** {{check_safety}} contains SAFE
+**Condition:** {{Check Safety}} contains SAFE
 
-### 4. create_manual_report
+### 4. Create Manual Report
 Create a report explaining why manual intervention is needed:
-{{analyze_issue}}
+{{Analyze Issue}}
 
-**Condition:** {{check_safety}} contains UNSAFE
+**Condition:** {{Check Safety}} contains UNSAFE
 ```
 
 ## Example: With Error Handling
@@ -72,41 +72,41 @@ Deploy changes with automatic rollback on failure.
 
 ## Steps
 
-### 1. run_tests
+### 1. Run Tests
 Run the full test suite. Report any failures.
 
-### 2. deploy
+### 2. Deploy
 Deploy to {{input.environment}}.
 
-**On error:** rollback
+**On error:** Rollback
 
-### 3. verify
+### 3. Verify
 Verify the deployment is healthy.
 
-**On error:** rollback
+**On error:** Rollback
 
-### 4. rollback
+### 4. Rollback
 Roll back to the previous version and report what went wrong.
 
 ## Output
 
 Deployment to {{input.environment}} complete.
-{{verify}}
+{{Verify}}
 ```
 
 ## Key Concepts
 
-**Variables:** Use `{{input.name}}` for inputs and `{{step_id}}` for outputs from previous steps.
+**Variables:** Use `{{input.name}}` for inputs and `{{Step Name}}` for outputs from previous steps.
 
 **Conditions:** Add `**Condition:**` to make a step run only when the condition is true. Common patterns:
-- `{{step_id}} contains X` - check if output contains text
-- `{{step_id}} not empty` - check if output exists
+- `{{Step Name}} contains X` - check if output contains text
+- `{{Step Name}} not empty` - check if output exists
 - `{{input.flag}} equals yes` - check exact value
 
 **Error handling:** Add `**On error:**` to control what happens when a step fails:
 - `stop` (default) - halt the workflow
 - `continue` - log the error and move to the next step
-- `step_id` - jump to a specific step (useful for cleanup/rollback)
+- `Step Name` - jump to a specific step (useful for cleanup/rollback)
 
 **Output:** The `## Output` section defines the final result. If omitted, the last step's output is used.
 

--- a/pkg/config/agents/executor.md
+++ b/pkg/config/agents/executor.md
@@ -33,7 +33,7 @@ Check what inputs the workflow needs. Ask the user for any required inputs that 
 For each step:
 
 - **Check conditions** - If the step has a `**Condition:**`, evaluate it. Skip the step if false.
-- **Interpolate variables** - Replace `{{input.name}}` with input values and `{{step_id}}` with outputs from previous steps.
+- **Interpolate variables** - Replace `{{input.name}}` with input values and `{{Step Name}}` with outputs from previous steps.
 - **Execute the task** - Do what the step describes.
 - **Store the output** - Save the result so later steps can reference it.
 - **Handle errors** - If the step fails, follow its `**On error:**` directive (stop, continue, or jump to another step).
@@ -65,7 +65,7 @@ Offer to suggest improvements if things didn't go smoothly.
 
 Keep the user informed as you go:
 - "Starting workflow: <name>"
-- "Executing step: <id>"  
-- "Step <id> complete"
-- "Skipping step <id> (condition not met)"
+- "Executing step: <name>"
+- "Step <name> complete"
+- "Skipping step <name> (condition not met)"
 - "Workflow complete"

--- a/pkg/config/agents/planner.md
+++ b/pkg/config/agents/planner.md
@@ -41,7 +41,7 @@ After getting answers:
 
 ## Writing Good Workflows
 
-**Use descriptive step IDs** - `fetch_issues` not `step1`. These are used to reference outputs in later steps.
+**Use descriptive step names** - `Fetch Issues` not `step1` or `fetch_issues`. Use human-friendly title case names. These are used to reference outputs in later steps as `{{Fetch Issues}}`.
 
 **Be specific in task descriptions** - Give enough detail that the executor knows exactly what to do and what format to return.
 


### PR DESCRIPTION
Update workflow schema and agent instructions to use Title Case step
names (e.g., "Bake Donuts") instead of snake_case identifiers (e.g.,
"bake_donuts"). Since workflows are executed by LLMs, human-readable
names improve clarity without sacrificing functionality.

Signed-off-by: Craig Jellick <craig@obot.ai>
