### PR TITLE
feat: add tool output truncation to prevent context overflow

### DIFF
--- a/pkg/agents/toolcall.go
+++ b/pkg/agents/toolcall.go
@@ -114,6 +114,7 @@ func (a *Agents) invoke(ctx context.Context, target types.TargetMapping[types.Ta
 			IsError: true,
 		}
 	}
+
 	return &types.Message{
 		Role: "user",
 		Items: []types.CompletionItem{

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -715,6 +715,31 @@ func (s *Service) Call(ctx context.Context, server, tool string, args any, opts 
 		}
 	}
 
+	// Apply truncation to prevent context overflow. Registered after the progress
+	// defer so it runs BEFORE it (LIFO), ensuring the progress notification also
+	// sees the truncated content.
+	defer func() {
+		if ret == nil || err != nil {
+			return
+		}
+		callID := ""
+		if opt.ToolCallInvocation != nil {
+			callID = opt.ToolCallInvocation.ToolCall.CallID
+		}
+		truncResult, truncErr := TruncateToolOutput(ctx, target, callID, ret, DefaultMaxBytes)
+		if truncErr != nil {
+			ret.Content = []mcp.Content{
+				{
+					Type: "text",
+					Text: fmt.Sprintf("Error: tool output too large and truncation failed: %v", truncErr),
+				},
+			}
+			ret.IsError = true
+		} else if truncResult.Truncated {
+			ret.Content = truncResult.Content
+		}
+	}()
+
 	if _, ok := config.Agents[server]; ok && tool != types.AgentTool+server {
 		return s.sampleCall(ctx, server, args, SampleCallOptions{
 			ProgressToken: opt.ProgressToken,

--- a/pkg/tools/truncate.go
+++ b/pkg/tools/truncate.go
@@ -1,0 +1,159 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/nanobot-ai/nanobot/pkg/mcp"
+	"github.com/nanobot-ai/nanobot/pkg/types"
+)
+
+const (
+	DefaultMaxBytes = 50 * 1024 // 50KB
+)
+
+// TruncationResult contains the truncated content and metadata
+type TruncationResult struct {
+	Content   []mcp.Content
+	Truncated bool
+	FilePath  string
+}
+
+// ContentByteSize returns the byte size of a content item's payload.
+func ContentByteSize(c mcp.Content) int {
+	switch c.Type {
+	case "text":
+		return len(c.Text)
+	case "resource":
+		if c.Resource != nil {
+			return len(c.Resource.Text) + len(c.Resource.Blob)
+		}
+		return 0
+	default:
+		// image, audio, and other types use the Data field
+		return len(c.Data)
+	}
+}
+
+// TruncateToolOutput checks if a tool output needs truncation and truncates it if necessary.
+// It saves the full original content as JSON to disk and returns truncated content.
+func TruncateToolOutput(ctx context.Context, toolName, callID string, response *types.CallResult, maxBytes int) (TruncationResult, error) {
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxBytes
+	}
+
+	// Calculate total size across all content items
+	totalBytes := 0
+	for _, c := range response.Content {
+		totalBytes += ContentByteSize(c)
+	}
+
+	// No truncation needed
+	if totalBytes <= maxBytes {
+		return TruncationResult{}, nil
+	}
+
+	// Save full original content to disk as JSON
+	sessionID, _ := types.GetSessionAndAccountID(ctx)
+	if sessionID == "" {
+		sessionID = "default"
+	}
+
+	timestamp := time.Now().Format("20060102-150405")
+	safeSessionID := SanitizeFileName(sessionID)
+	safeToolName := SanitizeFileName(toolName)
+	safeCallID := SanitizeFileName(callID)
+	outputDir := filepath.Join(".nanobot", safeSessionID, "truncated-tool-outputs")
+
+	if err := os.MkdirAll(outputDir, 0700); err != nil {
+		return TruncationResult{}, fmt.Errorf("failed to create tool output directory: %w", err)
+	}
+
+	filePath := filepath.Join(outputDir, fmt.Sprintf("%s-%s-%s.json", timestamp, safeToolName, safeCallID))
+
+	fullJSON, err := json.Marshal(response.Content)
+	if err != nil {
+		return TruncationResult{}, fmt.Errorf("failed to marshal full content: %w", err)
+	}
+	if err := os.WriteFile(filePath, fullJSON, 0600); err != nil {
+		return TruncationResult{}, fmt.Errorf("failed to write full output to file: %w", err)
+	}
+
+	// Walk content items in original order with a remaining byte budget
+	remaining := maxBytes
+	result := []mcp.Content{
+		{
+			Type: "text",
+			Text: fmt.Sprintf("Tool output truncated because it is too large. Full output saved to: %s\n\n", filePath),
+		},
+	}
+
+	for _, c := range response.Content {
+		size := ContentByteSize(c)
+
+		if c.Type != "text" {
+			// Non-text: keep if it fits entirely, otherwise drop
+			if size <= remaining {
+				result = append(result, c)
+				remaining -= size
+			}
+			continue
+		}
+
+		// Text item: keep if it fits entirely
+		if size <= remaining {
+			result = append(result, c)
+			remaining -= size
+			continue
+		}
+
+		// Partial text truncation: truncate on a clean UTF-8 boundary
+		truncated := truncateUTF8(c.Text, remaining)
+		result = append(result, mcp.Content{Type: "text", Text: truncated})
+		// Stop processing further items after text truncation
+		break
+	}
+
+	return TruncationResult{
+		Content:   result,
+		Truncated: true,
+		FilePath:  filePath,
+	}, nil
+}
+
+// truncateUTF8 truncates s to at most maxBytes while preserving valid UTF-8.
+func truncateUTF8(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	// Walk backwards from maxBytes to find a valid UTF-8 boundary
+	for maxBytes > 0 && !utf8.RuneStart(s[maxBytes]) {
+		maxBytes--
+	}
+	return s[:maxBytes]
+}
+
+// SanitizeFileName removes characters that aren't safe for filenames
+func SanitizeFileName(name string) string {
+	// Replace unsafe characters with underscores
+	replacer := strings.NewReplacer(
+		"/", "_",
+		"\\", "_",
+		":", "_",
+		"*", "_",
+		"?", "_",
+		"\"", "_",
+		"<", "_",
+		">", "_",
+		"|", "_",
+		".", "_",
+		" ", "-",
+	)
+	return replacer.Replace(name)
+}

--- a/pkg/tools/truncate_test.go
+++ b/pkg/tools/truncate_test.go
@@ -1,0 +1,340 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/nanobot-ai/nanobot/pkg/mcp"
+	"github.com/nanobot-ai/nanobot/pkg/types"
+)
+
+// setupTruncateTestDir creates a temp directory and changes to it, returning a cleanup function.
+func setupTruncateTestDir(t *testing.T) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "truncate-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory %q: %v", tmpDir, err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(origDir); err != nil {
+			t.Fatalf("failed to restore working directory to %q: %v", origDir, err)
+		}
+		os.RemoveAll(tmpDir)
+	})
+}
+
+func TestTruncateToolOutput(t *testing.T) {
+	ctx := context.Background()
+	setupTruncateTestDir(t)
+
+	tests := []struct {
+		name        string
+		toolName    string
+		content     []mcp.Content
+		maxBytes    int
+		shouldTrunc bool
+	}{
+		{
+			name:     "no truncation needed - small content",
+			toolName: "test-tool",
+			content: []mcp.Content{
+				{Type: "text", Text: "line 1\nline 2\nline 3"},
+			},
+			maxBytes:    1000,
+			shouldTrunc: false,
+		},
+		{
+			name:     "truncate by bytes",
+			toolName: "test-tool",
+			content: []mcp.Content{
+				{Type: "text", Text: strings.Repeat("a", 100000)},
+			},
+			maxBytes:    50000,
+			shouldTrunc: true,
+		},
+		{
+			name:     "mixed text and non-text exceeds budget",
+			toolName: "test-tool",
+			content: []mcp.Content{
+				{Type: "text", Text: strings.Repeat("a", 100000)},
+				{Type: "image", Data: "base64data"},
+			},
+			maxBytes:    50000,
+			shouldTrunc: true,
+		},
+		{
+			name:     "non-text content contributes to byte budget",
+			toolName: "test-tool",
+			content: []mcp.Content{
+				{Type: "image", Data: strings.Repeat("x", 40000)},
+				{Type: "text", Text: strings.Repeat("a", 20000)},
+			},
+			maxBytes:    50000,
+			shouldTrunc: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := &types.CallResult{
+				Content: tt.content,
+			}
+
+			result, err := TruncateToolOutput(ctx, tt.toolName, "call-123", response, tt.maxBytes)
+			if err != nil {
+				t.Fatalf("TruncateToolOutput failed: %v", err)
+			}
+
+			if tt.shouldTrunc {
+				if !result.Truncated {
+					t.Error("expected truncated=true")
+				}
+
+				// Verify JSON file was created
+				if result.FilePath == "" {
+					t.Error("expected file path to be set when truncated")
+				}
+				if _, err := os.Stat(result.FilePath); os.IsNotExist(err) {
+					t.Errorf("truncation file not created at %s", result.FilePath)
+				}
+
+				// Verify the JSON file contains the full original content
+				fileData, err := os.ReadFile(result.FilePath)
+				if err != nil {
+					t.Fatalf("failed to read truncation file: %v", err)
+				}
+				var savedContent []mcp.Content
+				if err := json.Unmarshal(fileData, &savedContent); err != nil {
+					t.Fatalf("failed to unmarshal saved content: %v", err)
+				}
+				if len(savedContent) != len(tt.content) {
+					t.Errorf("saved content has %d items, expected %d", len(savedContent), len(tt.content))
+				}
+
+				// Verify a truncation notice is in the content
+				foundNotice := false
+				for _, content := range result.Content {
+					if content.Type == "text" && strings.Contains(content.Text, "Tool output truncated") {
+						foundNotice = true
+					}
+				}
+				if !foundNotice {
+					t.Error("truncation notice not found in content")
+				}
+			} else {
+				if result.Truncated {
+					t.Error("expected truncated=false for no truncation")
+				}
+			}
+		})
+	}
+}
+
+func TestTruncateLargeNonTextDropped(t *testing.T) {
+	ctx := context.Background()
+	setupTruncateTestDir(t)
+
+	response := &types.CallResult{
+		Content: []mcp.Content{
+			{Type: "image", Data: strings.Repeat("x", 60000)},
+			{Type: "text", Text: "small text"},
+		},
+	}
+
+	result, err := TruncateToolOutput(ctx, "drop-tool", "call-drop", response, 50000)
+	if err != nil {
+		t.Fatalf("TruncateToolOutput failed: %v", err)
+	}
+
+	if !result.Truncated {
+		t.Fatal("expected truncation")
+	}
+
+	foundNotice := false
+	for _, c := range result.Content {
+		if strings.Contains(c.Text, "Tool output truncated") {
+			foundNotice = true
+		}
+	}
+	if !foundNotice {
+		t.Fatal("expected truncation notice")
+	}
+
+	// Verify JSON file has the full original content including the image
+	fileData, err := os.ReadFile(result.FilePath)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	var savedContent []mcp.Content
+	if err := json.Unmarshal(fileData, &savedContent); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(savedContent) != 2 {
+		t.Fatalf("expected 2 saved items, got %d", len(savedContent))
+	}
+	if savedContent[0].Type != "image" {
+		t.Errorf("expected saved first item to be image, got %s", savedContent[0].Type)
+	}
+}
+
+func TestTruncateCallIDInFilename(t *testing.T) {
+	ctx := context.Background()
+	setupTruncateTestDir(t)
+
+	response := &types.CallResult{
+		Content: []mcp.Content{
+			{Type: "text", Text: strings.Repeat("x", 100000)},
+		},
+	}
+
+	result, err := TruncateToolOutput(ctx, "my-tool", "call_abc123", response, 50000)
+	if err != nil {
+		t.Fatalf("TruncateToolOutput failed: %v", err)
+	}
+
+	if !result.Truncated {
+		t.Fatal("expected truncation")
+	}
+	if !strings.Contains(result.FilePath, "call_abc123") {
+		t.Errorf("expected callID in file path, got %s", result.FilePath)
+	}
+	if !strings.HasSuffix(result.FilePath, ".json") {
+		t.Errorf("expected .json extension, got %s", result.FilePath)
+	}
+}
+
+func TestTruncateEmbeddedResource(t *testing.T) {
+	ctx := context.Background()
+	setupTruncateTestDir(t)
+
+	response := &types.CallResult{
+		Content: []mcp.Content{
+			{
+				Type: "resource",
+				Resource: &mcp.EmbeddedResource{
+					URI:      "file:///large.txt",
+					MIMEType: "text/plain",
+					Text:     strings.Repeat("r", 60000),
+				},
+			},
+			{Type: "text", Text: "small text"},
+		},
+	}
+
+	result, err := TruncateToolOutput(ctx, "resource-tool", "call-res", response, 50000)
+	if err != nil {
+		t.Fatalf("TruncateToolOutput failed: %v", err)
+	}
+
+	if !result.Truncated {
+		t.Fatal("expected truncation")
+	}
+
+	foundNotice := false
+	for _, c := range result.Content {
+		if strings.Contains(c.Text, "Tool output truncated") {
+			foundNotice = true
+		}
+	}
+	if !foundNotice {
+		t.Fatal("expected truncation notice")
+	}
+}
+
+func TestContentByteSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  mcp.Content
+		expected int
+	}{
+		{
+			name:     "text content",
+			content:  mcp.Content{Type: "text", Text: "hello"},
+			expected: 5,
+		},
+		{
+			name:     "image content",
+			content:  mcp.Content{Type: "image", Data: "base64data"},
+			expected: 10,
+		},
+		{
+			name:     "audio content",
+			content:  mcp.Content{Type: "audio", Data: "audiodata"},
+			expected: 9,
+		},
+		{
+			name: "resource with text",
+			content: mcp.Content{
+				Type:     "resource",
+				Resource: &mcp.EmbeddedResource{Text: "resource text"},
+			},
+			expected: 13,
+		},
+		{
+			name: "resource with blob",
+			content: mcp.Content{
+				Type:     "resource",
+				Resource: &mcp.EmbeddedResource{Blob: "blobdata"},
+			},
+			expected: 8,
+		},
+		{
+			name:     "resource with nil resource",
+			content:  mcp.Content{Type: "resource"},
+			expected: 0,
+		},
+		{
+			name:     "resource_link",
+			content:  mcp.Content{Type: "resource_link", URI: "file:///test"},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			size := ContentByteSize(tt.content)
+			if size != tt.expected {
+				t.Errorf("expected %d, got %d", tt.expected, size)
+			}
+		})
+	}
+}
+
+func TestSanitizeFileName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"simple", "simple"},
+		{"with spaces", "with-spaces"},
+		{"with/slash", "with_slash"},
+		{"with:colon", "with_colon"},
+		{"with*asterisk", "with_asterisk"},
+		{"with?question", "with_question"},
+		{"with\"quote", "with_quote"},
+		{"with<greater>", "with_greater_"},
+		{"with|pipe", "with_pipe"},
+		{"with.dot", "with_dot"},
+		{"..", "__"},
+		{"../../../etc", "_________etc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := SanitizeFileName(tt.input)
+			if result != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds automatic truncation of tool call responses that exceed a default
size limit (50KB). When a response is truncated the full original
content is saved to .nanobot/<sessionID>/tool-outputs/ as a JSON file
keyed by call ID, and the agent receives a notice with the file path so
it can explore the content with file tools.

Key design decisions:
- Truncation is bytes-only; non-text content items (images, embedded
  resources) are counted toward the budget and dropped if they don't fit
- Truncation runs in tools/service.go Call() so both the LLM and the UI
  see the truncated output
- Session IDs and filenames are sanitized to prevent path traversal
- On truncation failure the response is replaced with an error message

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
