### PR TITLE
enhance: send tool call errors back to the LLM for retry

### DIFF
--- a/pkg/agents/run.go
+++ b/pkg/agents/run.go
@@ -452,9 +452,8 @@ func (a *Agents) Complete(ctx context.Context, req types.CompletionRequest, opts
 			session.Set(previousExecutionKey, currentRun)
 		}
 
-		if err := a.toolCalls(ctx, currentRun, opts); err != nil {
-			return nil, err
-		}
+		// This doesn't return an error because any issues we run into should be returned to the LLM for further processing.
+		a.toolCalls(ctx, currentRun, opts)
 
 		if currentRun.Done {
 			if isChat {

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -697,7 +697,6 @@ func (s *Service) Call(ctx context.Context, server, tool string, args any, opts 
 						},
 					}
 				}
-				// Use the session's context in case the original context was cancelled, as we want to ensure the progress update is sent.
 				_ = session.SendPayload(ctx, "notifications/progress", mcp.NotificationProgressRequest{
 					ProgressToken: opt.ProgressToken,
 					Meta: map[string]any{


### PR DESCRIPTION
This only happens in the agent loop.