### PR TITLE
fix(config): publish workflow tools server in UI static config

### DIFF
--- a/pkg/config/static.go
+++ b/pkg/config/static.go
@@ -23,7 +23,7 @@ var UI = types.Config{
 		},
 	},
 	Publish: types.Publish{
-		MCPServers: []string{"nanobot.meta", "nanobot.workflows", "nanobot.workflow-tools"},
+		MCPServers: []string{"nanobot.meta", "nanobot.workflows", "nanobot.workflow-tools/deleteWorkflow"},
 		Resources:  []string{"nanobot.system"},
 	},
 	MCPServers: map[string]mcp.Server{


### PR DESCRIPTION
Expose `nanobot.workflow-tools` in the UI static publish config so its tools
are included in published MCP tool discovery.

This adds the server to:
- `publish.mcpServers`
- `mcpServers`


