### PR TITLE
 enhance: add meta to file resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	golang.org/x/net v0.49.0
 	golang.org/x/oauth2 v0.30.0
+	golang.org/x/sys v0.40.0
 	golang.org/x/term v0.39.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.6.0
@@ -65,7 +66,6 @@ require (
 	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6 // indirect
 	golang.org/x/mod v0.31.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
 	golang.org/x/tools v0.40.0 // indirect

--- a/pkg/servers/system/files_darwin.go
+++ b/pkg/servers/system/files_darwin.go
@@ -1,0 +1,17 @@
+package system
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func init() {
+	fileCreatedAt = func(_ string, info os.FileInfo) time.Time {
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok || stat == nil {
+			return time.Time{}
+		}
+		return time.Unix(stat.Birthtimespec.Sec, stat.Birthtimespec.Nsec)
+	}
+}

--- a/pkg/servers/system/files_linux.go
+++ b/pkg/servers/system/files_linux.go
@@ -1,0 +1,57 @@
+package system
+
+import (
+	"os"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func init() {
+	var (
+		mu          sync.RWMutex
+		skipDevices = make(map[uint64]struct{})
+	)
+
+	fileCreatedAt = func(relPath string, info os.FileInfo) time.Time {
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok || stat == nil {
+			return time.Time{}
+		}
+
+		mu.RLock()
+		_, skip := skipDevices[stat.Dev]
+		mu.RUnlock()
+		if skip {
+			// We've determined the device this file belongs to doesn't support birth time.
+			// Bail out early to avoid an extra syscall.
+			return time.Time{}
+		}
+
+		// Make a statx syscall with STATX_BTIME to request the birth time.
+		var statx unix.Statx_t
+		if err := unix.Statx(
+			unix.AT_FDCWD,
+			relPath,
+			unix.AT_STATX_SYNC_AS_STAT,
+			unix.STATX_BTIME,
+			&statx,
+		); err != nil {
+			return time.Time{}
+		}
+
+		// Determine if the device actually supports birth time from the statx response.
+		sec, nsec := statx.Btime.Sec, int64(statx.Btime.Nsec)
+		if statx.Mask&unix.STATX_BTIME == 0 || (sec == 0 && nsec == 0) {
+			// Assume the device doesn't support birth time and skip future statx calls for all other files on the device.
+			mu.Lock()
+			skipDevices[stat.Dev] = struct{}{}
+			mu.Unlock()
+			return time.Time{}
+		}
+
+		return time.Unix(sec, nsec)
+	}
+}

--- a/pkg/servers/system/files_test.go
+++ b/pkg/servers/system/files_test.go
@@ -107,9 +107,12 @@ func TestListFileResources(t *testing.T) {
 	}
 
 	for _, f := range expectedFiles {
-		if _, ok := found[f]; !ok {
+		r, ok := found[f]
+		if !ok {
 			t.Errorf("expected file %s not found in resources", f)
+			continue
 		}
+		assertFileTimestampMeta(t, f, r.Meta)
 	}
 
 	// Check that excluded directory files are NOT present
@@ -258,6 +261,8 @@ func TestReadFileResource(t *testing.T) {
 			if content.URI != tt.uri {
 				t.Errorf("expected URI %q, got %q", tt.uri, content.URI)
 			}
+
+			assertFileTimestampMeta(t, tt.uri, content.Meta)
 		})
 	}
 }
@@ -522,3 +527,33 @@ func (m *mockFileInfo) Mode() os.FileMode  { return 0644 }
 func (m *mockFileInfo) ModTime() time.Time { return time.Time{} }
 func (m *mockFileInfo) IsDir() bool        { return m.isDir }
 func (m *mockFileInfo) Sys() interface{}   { return nil }
+
+func assertFileTimestampMeta(t *testing.T, resourceID string, meta map[string]any) {
+	t.Helper()
+
+	if meta == nil {
+		t.Fatalf("resource %s expected _meta to be set", resourceID)
+	}
+
+	modifiedAtRaw, ok := meta["modifiedAt"]
+	if !ok {
+		t.Fatalf("resource %s expected _meta.modifiedAt", resourceID)
+	}
+	modifiedAt, ok := modifiedAtRaw.(string)
+	if !ok {
+		t.Fatalf("resource %s expected _meta.modifiedAt to be string, got %T", resourceID, modifiedAtRaw)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, modifiedAt); err != nil {
+		t.Fatalf("resource %s expected _meta.modifiedAt in RFC3339 format, got %q", resourceID, modifiedAt)
+	}
+
+	if createdAtRaw, ok := meta["createdAt"]; ok {
+		createdAt, ok := createdAtRaw.(string)
+		if !ok {
+			t.Fatalf("resource %s expected _meta.createdAt to be string, got %T", resourceID, createdAtRaw)
+		}
+		if _, err := time.Parse(time.RFC3339Nano, createdAt); err != nil {
+			t.Fatalf("resource %s expected _meta.createdAt in RFC3339 format, got %q", resourceID, createdAt)
+		}
+	}
+}

--- a/pkg/servers/system/files_windows.go
+++ b/pkg/servers/system/files_windows.go
@@ -1,0 +1,18 @@
+package system
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func init() {
+	fileCreatedAt = func(_ string, info os.FileInfo) time.Time {
+		data, ok := info.Sys().(*syscall.Win32FileAttributeData)
+		if !ok || data == nil {
+			return time.Time{}
+		}
+
+		return time.Unix(0, data.CreationTime.Nanoseconds()).UTC()
+	}
+}


### PR DESCRIPTION
Add createdAt and modifiedAt _meta fields to file resource list/read. Additionally, populate the first-class size field (bytes) on resource list responses.

createdAt metadata is only populated for linux, darwin, and windows builds. On linux, the field is omitted for a file if birthtime (BTIME) isn't available or supported (Note: My testing indicates that the field will be omitted on our setup in our main and chat environments).