### PR TITLE
chore: addMCPServer: return tool names without descriptions

### DIFF
--- a/pkg/servers/system/mcp_servers.go
+++ b/pkg/servers/system/mcp_servers.go
@@ -146,12 +146,9 @@ func (s *Server) addMCPServer(ctx context.Context, params AddMCPServerParams) (m
 		log.Debugf(ctx, "failed to list tools for MCP server %q: %v", params.Name, err)
 		result["message"] = fmt.Sprintf("Successfully added MCP server '%s'. The server's tools will be available in the next agent turn.", params.Name)
 	} else {
-		toolList := make([]map[string]string, 0, len(tools))
+		toolList := make([]string, 0, len(tools))
 		for _, t := range tools {
-			toolList = append(toolList, map[string]string{
-				"name":        t.Name,
-				"description": t.Description,
-			})
+			toolList = append(toolList, t.Name)
 		}
 		result["tools"] = toolList
 		result["message"] = fmt.Sprintf("Successfully added MCP server '%s' with %d tool(s). The tools will be available in the next agent turn.", params.Name, len(tools))

--- a/pkg/servers/system/server.go
+++ b/pkg/servers/system/server.go
@@ -264,7 +264,7 @@ Parameters:
 - url (required): The URL of the MCP server to add
 - name (required): A unique name for the server (used to reference it later)
 
-When available, the response includes a "tools" field listing the server's available tools with their names and descriptions. This field is only present if the server's tools can be listed successfully.
+When available, the response includes a "tools" field listing the server's available tool names. This field is only present if the server's tools can be listed successfully.
 The server is session-scoped and will not persist after the session ends.`, s.addMCPServer),
 		mcp.NewServerTool("removeMCPServer", `Removes a dynamically added MCP server from the current session.
 


### PR DESCRIPTION
Requested by Craig. The tool descriptions can be long, so we are changing this to return only the tool names.