### PR TITLE
feat: add support for a default mini model configuration

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -51,6 +51,7 @@ type Nanobot struct {
 	EnvFile                 string            `usage:"Path to the environment file (default: ./nanobot.env)" default:"./nanobot.env"`
 	EmptyEnv                bool              `usage:"Do not load environment variables from the environment by default"`
 	DefaultModel            string            `usage:"Default model to use for completions" default:"gpt-4.1" env:"NANOBOT_DEFAULT_MODEL" name:"default-model"`
+	DefaultMiniModel        string            `usage:"Default model to use for things like thread summaries" default:"gpt-4.1" env:"NANOBOT_DEFAULT_MINI_MODEL" name:"default-mini-model"`
 	OpenAIAPIKey            string            `usage:"OpenAI API key" env:"OPENAI_API_KEY" name:"openai-api-key"`
 	OpenAIBaseURL           string            `usage:"OpenAI API URL" env:"OPENAI_BASE_URL" name:"openai-base-url"`
 	OpenAIHeaders           map[string]string `usage:"OpenAI API headers" env:"OPENAI_HEADERS" name:"openai-headers"`
@@ -152,7 +153,8 @@ func display(obj any, format string) bool {
 
 func (n *Nanobot) llmConfig() llm.Config {
 	return llm.Config{
-		DefaultModel: n.DefaultModel,
+		DefaultModel:     n.DefaultModel,
+		DefaultMiniModel: n.DefaultMiniModel,
 		Responses: responses.Config{
 			APIKey:            n.OpenAIAPIKey,
 			BaseURL:           n.OpenAIBaseURL,

--- a/pkg/config/agents/nanobot.md
+++ b/pkg/config/agents/nanobot.md
@@ -1,7 +1,6 @@
 ---
 name: Nanobot
 description: An AI agent for getting things done and automating work
-model: claude-opus-4-6
 temperature: 0.3
 permissions:
   '*': allow

--- a/pkg/config/static.go
+++ b/pkg/config/static.go
@@ -9,8 +9,9 @@ var UI = types.Config{
 	Agents: map[string]types.Agent{
 		"nanobot.summary": {
 			HookAgent: types.HookAgent{
-				Name: "nanobot.summary",
-				Chat: new(bool),
+				Name:  "nanobot.summary",
+				Model: "mini",
+				Chat:  new(bool),
 				Instructions: types.DynamicInstructions{
 					Instructions: `- you will generate a short title based on the first message a user begins a conversation with
 - ensure it is not more than 80 characters long

--- a/pkg/servers/system/config.go
+++ b/pkg/servers/system/config.go
@@ -69,8 +69,9 @@ func (s *Server) config(ctx context.Context, params types.AgentConfigHook) (type
 		params.MCPServers["nanobot.workflows"] = types.AgentConfigHookMCPServer{}
 		params.MCPServers["nanobot.workflow-tools"] = types.AgentConfigHookMCPServer{}
 
-		// Configure MCP search server if environment variables are set
 		session := mcp.SessionFromContext(ctx)
+
+		// Configure MCP search server if environment variables are set
 		if agent.Name != "nanobot.summary" && session != nil {
 			envMap := session.GetEnvMap()
 			if searchURL := envMap["MCP_SERVER_SEARCH_URL"]; searchURL != "" {


### PR DESCRIPTION
This change also makes the nanobot.summary agent use this default mini model.