### PR TITLE
fix: ensure UI threads always get a description

### DIFF
--- a/pkg/servers/agent/chat_call.go
+++ b/pkg/servers/agent/chat_call.go
@@ -187,12 +187,7 @@ func appendProgress(ctx context.Context, session *mcp.Session, progressMessage *
 }
 
 func (c chatCall) Invoke(ctx context.Context, msg mcp.Message, payload mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	description := c.s.describeSession(ctx, payload.Arguments)
-	if description != nil {
-		defer func() {
-			<-description
-		}()
-	}
+	c.s.describeSession(ctx, payload.Arguments)
 
 	if attachments, _ := payload.Arguments["attachments"].([]any); len(attachments) > 0 {
 		var err error

--- a/pkg/servers/agent/chat_call_ui.go
+++ b/pkg/servers/agent/chat_call_ui.go
@@ -85,8 +85,7 @@ attachmentsLoop:
 	return newAttachments, nil
 }
 
-func (s *Server) describeSession(ctx context.Context, args any) <-chan struct{} {
-	result := make(chan struct{})
+func (s *Server) describeSession(ctx context.Context, args any) {
 	var description string
 
 	session := mcp.SessionFromContext(ctx)
@@ -94,8 +93,7 @@ func (s *Server) describeSession(ctx context.Context, args any) <-chan struct{} 
 	session.Get(types.DescriptionSessionKey, &description)
 	if description == "" && s.agentName != "nanobot.summary" {
 		go func() {
-			defer close(result)
-			ret, err := s.runtime.Call(ctx, "nanobot.summary", "nanobot.summary", args)
+			ret, err := s.runtime.Call(session.Context(), "nanobot.summary", "nanobot.summary", args)
 			if err != nil {
 				return
 			}
@@ -107,9 +105,5 @@ func (s *Server) describeSession(ctx context.Context, args any) <-chan struct{} 
 				}
 			}
 		}()
-	} else {
-		close(result)
 	}
-
-	return result
 }


### PR DESCRIPTION
There is a race condition between when the LLM call completes and when the description is returned. This change removes this race condition by disconnecting the description retrieval from the LLM call.