### PR TITLE
Chore: Log if we dont have the MCP API key

### DIFF
--- a/pkg/servers/system/mcp_servers.go
+++ b/pkg/servers/system/mcp_servers.go
@@ -114,6 +114,8 @@ func (s *Server) addMCPServer(ctx context.Context, params AddMCPServerParams) (m
 		headers = map[string]string{
 			"Authorization": "Bearer " + apiKey,
 		}
+	} else {
+		log.Infof(ctx, "MCP_API_KEY environment variable is not set, auth will fallback to OAuth")
 	}
 
 	// Create the new server config


### PR DESCRIPTION
This is essentially a bit of debuggin to pin down why calls to the
mcp-connect URLs are going through OAuth (and then failing). When we see
a failure, I'll want to check the logs for this log statement.

Signed-off-by: Craig Jellick <craig@obot.ai>
