### PR TITLE
Fix: More reliably load workflow skill

### DIFF
--- a/pkg/servers/system/skills/workflows.md
+++ b/pkg/servers/system/skills/workflows.md
@@ -1,6 +1,6 @@
 ---
 name: workflows
-description: Design and execute workflows - structured multi-step processes with inputs, conditions, and error handling.
+description: Load this skill for ANY request that mentions workflows, including listing, creating, running, editing, or discussing them.
 ---
 
 # Workflows


### PR DESCRIPTION
This mitigates an issue where the agent isn't loading the workflow skill
before doing things like listing workflows. This should help guide it to
load the skill first so that it knows where workflows are and what types
of files they are.

Signed-off-by: Craig Jellick <craig@obot.ai>
