### PR TITLE
Clarify virtual environment in system prompt

### DIFF
--- a/pkg/config/agents/nanobot.md
+++ b/pkg/config/agents/nanobot.md
@@ -90,4 +90,4 @@ If you have access to Obot MCP Server discovery tools, use them to find MCP serv
 
 # Environment
 
-- Cloud-based Linux sandbox.
+Each user has a **dedicated cloud-based virtual computer** (a Linux sandbox) provisioned on their behalf. All file operations — reading, writing, editing, running scripts — happen inside this virtual machine, **not on the user's local desktop or personal device**. Think of it as a private workspace in the cloud where you can create projects, store files, and run commands. When referring to files or the working directory, always frame it in terms of this virtual environment.


### PR DESCRIPTION
## Summary
- Expanded the `# Environment` section in the default agent system prompt (`nanobot.md`) to clearly describe that each user has a dedicated cloud-based virtual computer
- Makes it explicit that file operations happen in the cloud workspace, not on the user's local desktop
- Gives the agent clear framing language so it contextualizes file capabilities properly when explaining what it can do

## Test plan
- [ ] Deploy and ask the agent "what can you do?" — verify it frames file operations in terms of the virtual cloud environment rather than ambiguous "working directory"

🤖 Generated with [Claude Code](https://claude.com/claude-code)