### PR TITLE
fix(anthropic): drop empty translated message content

### DIFF
--- a/pkg/llm/anthropic/translate.go
+++ b/pkg/llm/anthropic/translate.go
@@ -109,8 +109,12 @@ func toRequest(req *types.CompletionRequest) (Request, error) {
 	for _, msg := range req.Input {
 		for _, input := range msg.Items {
 			if input.Content != nil {
+				content := contentToContent([]mcp.Content{*input.Content})
+				if len(content) == 0 {
+					continue
+				}
 				result.Messages = append(result.Messages, Message{
-					Content: contentToContent([]mcp.Content{*input.Content}),
+					Content: content,
 					Role:    msg.Role,
 				})
 			}

--- a/pkg/llm/anthropic/translate_test.go
+++ b/pkg/llm/anthropic/translate_test.go
@@ -1,0 +1,75 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nanobot-ai/nanobot/pkg/mcp"
+	"github.com/nanobot-ai/nanobot/pkg/types"
+)
+
+func TestToRequestDropsResourceLinkContent(t *testing.T) {
+	req := types.CompletionRequest{
+		Model: "claude-opus-4-6",
+		Input: []types.Message{
+			{
+				Role: "user",
+				Items: []types.CompletionItem{
+					{
+						Content: &mcp.Content{
+							Type: "text",
+							Text: "what's in this file",
+						},
+					},
+					{
+						Content: &mcp.Content{
+							Type:     "resource_link",
+							Name:     "screenshot.png",
+							URI:      "file:///screenshot.png",
+							MIMEType: "image/png",
+						},
+					},
+				},
+			},
+			{
+				Role: "user",
+				Items: []types.CompletionItem{
+					{
+						Content: &mcp.Content{
+							Type: "text",
+							Text: "The user has attached the following file \"screenshot.png\".",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	anthropicReq, err := toRequest(&req)
+	if err != nil {
+		t.Fatalf("toRequest failed: %v", err)
+	}
+
+	if len(anthropicReq.Messages) != 2 {
+		t.Fatalf("expected 2 messages after dropping resource link, got %d", len(anthropicReq.Messages))
+	}
+
+	for i, msg := range anthropicReq.Messages {
+		if msg.Content == nil {
+			t.Fatalf("message %d has nil content", i)
+		}
+		if len(msg.Content) == 0 {
+			t.Fatalf("message %d has empty content", i)
+		}
+	}
+
+	data, err := json.Marshal(anthropicReq)
+	if err != nil {
+		t.Fatalf("failed to marshal request: %v", err)
+	}
+
+	if strings.Contains(string(data), `"content":null`) {
+		t.Fatalf("request still contains null content: %s", data)
+	}
+}


### PR DESCRIPTION
resource_link chat items can translate to zero Anthropic content blocks.
We were still appending those messages, which serialized as `"content": null`
in the Anthropic payload.

Anthropic requires `messages[n].content` to be a valid list, so this caused:
`invalid_request_error: messages.<n>.content: Input should be a valid list`.

Only append translated content messages when the converted content slice is
non-empty, so unsupported/empty items (like resource_link placeholders) are
dropped instead of producing malformed requests.

Add a regression test that verifies resource_link items are dropped and the
serialized request does not contain `"content":null`.
