### PR TITLE
fix: return modified time on resources listed by the meta server

### DIFF
--- a/pkg/servers/meta/resources.go
+++ b/pkg/servers/meta/resources.go
@@ -327,6 +327,9 @@ func (s *Server) listFileResourcesAllSessions(ctx context.Context) ([]mcp.Resour
 				Name:     name,
 				MimeType: mimeType,
 				Size:     info.Size(),
+				Annotations: &mcp.Annotations{
+					LastModified: info.ModTime(),
+				},
 			})
 
 			return nil


### PR DESCRIPTION
Populate the Annotations.LastModified field when listing file resources in the meta server. This field drives the `Last Modified` column in the downstream Obot UI when browsing files.


