### PR TITLE
fix(files): normalize uploaded filenames and percent-encode file URIs

### DIFF
--- a/pkg/fileuri/fileuri.go
+++ b/pkg/fileuri/fileuri.go
@@ -1,0 +1,59 @@
+package fileuri
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+const scheme = "file:///"
+
+// Encode converts a relative file path to a properly percent-encoded file:/// URI.
+// Each path segment is individually encoded to preserve "/" separators.
+func Encode(relPath string) string {
+	segments := strings.Split(filepath.ToSlash(relPath), "/")
+	for i, seg := range segments {
+		segments[i] = url.PathEscape(seg)
+	}
+	return scheme + strings.Join(segments, "/")
+}
+
+// Decode extracts and percent-decodes the relative path from a file:/// URI.
+// Returns an error if the URI doesn't have the file:/// prefix or decoding fails.
+func Decode(uri string) (string, error) {
+	raw, ok := strings.CutPrefix(uri, scheme)
+	if !ok {
+		return "", fmt.Errorf("invalid file URI, expected file:///path: %s", uri)
+	}
+	if raw == "" {
+		return "", fmt.Errorf("file path is required in URI: %s", uri)
+	}
+	decoded, err := url.PathUnescape(raw)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode file URI %s: %w", uri, err)
+	}
+	return decoded, nil
+}
+
+// SafeFilename replaces Unicode space characters (e.g. U+202F NARROW NO-BREAK SPACE
+// commonly found in macOS screenshot filenames) with regular ASCII space.
+func SafeFilename(s string) string {
+	var (
+		b       strings.Builder
+		changed bool
+	)
+	for _, r := range s {
+		if r != ' ' && unicode.IsSpace(r) {
+			b.WriteRune(' ')
+			changed = true
+			continue
+		}
+		b.WriteRune(r)
+	}
+	if !changed {
+		return s
+	}
+	return b.String()
+}

--- a/pkg/fileuri/fileuri_test.go
+++ b/pkg/fileuri/fileuri_test.go
@@ -1,0 +1,103 @@
+package fileuri
+
+import (
+	"testing"
+)
+
+func TestEncode(t *testing.T) {
+	tests := []struct {
+		name    string
+		relPath string
+		want    string
+	}{
+		{"simple", "test.txt", "file:///test.txt"},
+		{"subdirectory", "subdir/file.txt", "file:///subdir/file.txt"},
+		{"space in name", "Screenshot 2024.png", "file:///Screenshot%202024.png"},
+		{"multiple segments with spaces", "my dir/my file.txt", "file:///my%20dir/my%20file.txt"},
+		{"hash in name", "notes#1.txt", "file:///notes%231.txt"},
+		{"percent in name", "100%.txt", "file:///100%25.txt"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Encode(tt.relPath)
+			if got != tt.want {
+				t.Errorf("Encode(%q) = %q, want %q", tt.relPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecode(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		want    string
+		wantErr bool
+	}{
+		{"simple", "file:///test.txt", "test.txt", false},
+		{"encoded space", "file:///Screenshot%202024.png", "Screenshot 2024.png", false},
+		{"unencoded space (legacy)", "file:///Screenshot 2024.png", "Screenshot 2024.png", false},
+		{"subdirectory encoded", "file:///my%20dir/my%20file.txt", "my dir/my file.txt", false},
+		{"hash encoded", "file:///notes%231.txt", "notes#1.txt", false},
+		{"missing prefix", "https:///test.txt", "", true},
+		{"empty path", "file:///", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Decode(tt.uri)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Decode(%q) error = %v, wantErr %v", tt.uri, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Decode(%q) = %q, want %q", tt.uri, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	paths := []string{
+		"test.txt",
+		"subdir/file.txt",
+		"Screenshot 2024-07-03 at 11.24.24 AM.png",
+		"my dir/my file.txt",
+		"notes#1.txt",
+		"100%.txt",
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			uri := Encode(path)
+			decoded, err := Decode(uri)
+			if err != nil {
+				t.Fatalf("Decode(Encode(%q)) error: %v", path, err)
+			}
+			if decoded != path {
+				t.Errorf("round-trip failed: Encode(%q) = %q, Decode = %q", path, uri, decoded)
+			}
+		})
+	}
+}
+
+func TestSafeFilename(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"no change", "normal file.txt", "normal file.txt"},
+		{"narrow no-break space", "Screenshot\u202fAM.png", "Screenshot AM.png"},
+		{"no-break space", "no\u00a0break.txt", "no break.txt"},
+		{"multiple unicode spaces", "a\u202fb\u00a0c.txt", "a b c.txt"},
+		{"tabs preserved as space", "a\tb.txt", "a b.txt"},
+		{"newline to space", "a\nb.txt", "a b.txt"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SafeFilename(tt.input)
+			if got != tt.want {
+				t.Errorf("SafeFilename(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/servers/meta/resources.go
+++ b/pkg/servers/meta/resources.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nanobot-ai/nanobot/pkg/fileuri"
 	"github.com/nanobot-ai/nanobot/pkg/fswatch"
 	"github.com/nanobot-ai/nanobot/pkg/log"
 	"github.com/nanobot-ai/nanobot/pkg/mcp"
@@ -319,7 +320,7 @@ func (s *Server) listFileResourcesAllSessions(ctx context.Context) ([]mcp.Resour
 			}
 
 			// URI format: file:///sessions/{sessionID}/{path}
-			uri := fmt.Sprintf("file:///%s/%s/%s", sessionsDir, sess.SessionID, relPath)
+			uri := fileuri.Encode(filepath.Join(sessionsDir, sess.SessionID, relPath))
 			name := fmt.Sprintf("%s/%s", sess.SessionID, relPath)
 
 			resources = append(resources, mcp.Resource{
@@ -343,8 +344,7 @@ func (s *Server) listFileResourcesAllSessions(ctx context.Context) ([]mcp.Resour
 }
 
 // verifyFileResourceAccess verifies that the file URI belongs to a session owned by the current account.
-func (s *Server) verifyFileResourceAccess(ctx context.Context, uri string) error {
-	relPath := strings.TrimPrefix(uri, "file:///")
+func (s *Server) verifyFileResourceAccess(ctx context.Context, relPath string) error {
 
 	// Expected format: sessions/{sessionID}/...
 	if !strings.HasPrefix(relPath, sessionsDir+"/") {
@@ -374,11 +374,14 @@ func (s *Server) verifyFileResourceAccess(ctx context.Context, uri string) error
 
 // readFileResource reads a cross-session file resource.
 func (s *Server) readFileResource(ctx context.Context, uri string) (*mcp.ReadResourceResult, error) {
-	if err := s.verifyFileResourceAccess(ctx, uri); err != nil {
-		return nil, err
+	relPath, err := fileuri.Decode(uri)
+	if err != nil {
+		return nil, mcp.ErrRPCInvalidParams.WithMessage("%v", err)
 	}
 
-	relPath := strings.TrimPrefix(uri, "file:///")
+	if err := s.verifyFileResourceAccess(ctx, relPath); err != nil {
+		return nil, err
+	}
 
 	// Prevent directory traversal: reject absolute paths and any ".." segments.
 	if filepath.IsAbs(relPath) {
@@ -511,7 +514,7 @@ func (s *Server) handleWorkflowEvents(events []fswatch.Event) {
 func (s *Server) handleSessionFileEvents(events []fswatch.Event) {
 	for _, event := range events {
 		// event.Path is relative to the sessions directory, e.g. "{sessionID}/file.txt"
-		uri := fmt.Sprintf("file:///%s/%s", sessionsDir, event.Path)
+		uri := fileuri.Encode(filepath.Join(sessionsDir, event.Path))
 
 		switch event.Type {
 		case fswatch.EventDelete:

--- a/pkg/servers/system/files.go
+++ b/pkg/servers/system/files.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/nanobot-ai/nanobot/pkg/fileuri"
 	"github.com/nanobot-ai/nanobot/pkg/fswatch"
 	"github.com/nanobot-ai/nanobot/pkg/log"
 	"github.com/nanobot-ai/nanobot/pkg/mcp"
@@ -91,7 +92,7 @@ func fileFilter(relPath string, info os.FileInfo) bool {
 // handleFileEvents processes filesystem events from the watcher.
 func (s *Server) handleFileEvents(events []fswatch.Event) {
 	for _, event := range events {
-		uri := "file:///" + event.Path
+		uri := fileuri.Encode(event.Path)
 
 		switch event.Type {
 		case fswatch.EventDelete:
@@ -174,7 +175,7 @@ func (s *Server) listFileResources(ctx context.Context) ([]mcp.Resource, error) 
 		}
 
 		resources = append(resources, mcp.Resource{
-			URI:      "file:///" + relPath,
+			URI:      fileuri.Encode(relPath),
 			Name:     filepath.Base(relPath),
 			MimeType: mimeType,
 			Size:     info.Size(),
@@ -195,14 +196,9 @@ func (s *Server) listFileResources(ctx context.Context) ([]mcp.Resource, error) 
 
 // readFileResource reads a file resource by URI, resolved against the session directory.
 func (s *Server) readFileResource(ctx context.Context, uri string) (*mcp.ReadResourceResult, error) {
-	// Parse file:/// URI
-	if !strings.HasPrefix(uri, "file:///") {
-		return nil, mcp.ErrRPCInvalidParams.WithMessage("invalid file URI, expected file:///path")
-	}
-
-	relPath := strings.TrimPrefix(uri, "file:///")
-	if relPath == "" {
-		return nil, mcp.ErrRPCInvalidParams.WithMessage("file path is required")
+	relPath, err := fileuri.Decode(uri)
+	if err != nil {
+		return nil, mcp.ErrRPCInvalidParams.WithMessage("%v", err)
 	}
 
 	// Prevent directory traversal attacks
@@ -262,14 +258,9 @@ func (s *Server) readFileResource(ctx context.Context, uri string) (*mcp.ReadRes
 
 // subscribeFileResource subscribes to a file resource.
 func (s *Server) subscribeFileResource(ctx context.Context, uri string) error {
-	// Parse file:/// URI
-	if !strings.HasPrefix(uri, "file:///") {
-		return mcp.ErrRPCInvalidParams.WithMessage("invalid file URI, expected file:///path")
-	}
-
-	relPath := strings.TrimPrefix(uri, "file:///")
-	if relPath == "" {
-		return mcp.ErrRPCInvalidParams.WithMessage("file path is required")
+	relPath, err := fileuri.Decode(uri)
+	if err != nil {
+		return mcp.ErrRPCInvalidParams.WithMessage("%v", err)
 	}
 
 	// Prevent directory traversal
@@ -346,6 +337,9 @@ func (s *Server) uploadFile(ctx context.Context, params UploadFileParams) (*mcp.
 		return nil, mcp.ErrRPCInvalidParams.WithMessage("invalid file path: cannot access files outside session directory")
 	}
 
+	// Sanitize: replace Unicode space characters with regular ASCII space
+	relPath = fileuri.SafeFilename(relPath)
+
 	// Resolve against session directory
 	sessionID, _ := types.GetSessionAndAccountID(ctx)
 	if sessionID == "" {
@@ -386,7 +380,7 @@ func (s *Server) uploadFile(ctx context.Context, params UploadFileParams) (*mcp.
 	}
 
 	return &mcp.Resource{
-		URI:      "file:///" + relPath,
+		URI:      fileuri.Encode(relPath),
 		Name:     relPath,
 		MimeType: mimeType,
 		Size:     info.Size(),
@@ -402,11 +396,9 @@ type DeleteFileParams struct {
 }
 
 func (s *Server) deleteFile(ctx context.Context, params DeleteFileParams) (string, error) {
-	relPath, ok := strings.CutPrefix(params.URI, "file:///")
-	if !ok {
-		return "", mcp.ErrRPCInvalidParams.WithMessage("invalid file URI, expected file:///path")
-	} else if relPath == "" {
-		return "", mcp.ErrRPCInvalidParams.WithMessage("file path is required")
+	relPath, err := fileuri.Decode(params.URI)
+	if err != nil {
+		return "", mcp.ErrRPCInvalidParams.WithMessage("%v", err)
 	}
 
 	// Prevent directory traversal attacks

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nanobot-ai/nanobot/pkg/complete"
 	"github.com/nanobot-ai/nanobot/pkg/envvar"
 	"github.com/nanobot-ai/nanobot/pkg/expr"
+	"github.com/nanobot-ai/nanobot/pkg/fileuri"
 	"github.com/nanobot-ai/nanobot/pkg/mcp"
 	"github.com/nanobot-ai/nanobot/pkg/mcp/auditlogs"
 	"github.com/nanobot-ai/nanobot/pkg/sampling"
@@ -959,25 +960,7 @@ func hasOnlySampleKeys(args map[string]any) bool {
 }
 
 func fileAttachmentPath(uri string) (string, error) {
-	if !strings.HasPrefix(uri, "file:///") {
-		return "", fmt.Errorf("invalid attachment URL: %s, only data URI and file:/// URIs are supported", uri)
-	}
-
-	rawPath := strings.TrimPrefix(uri, "file:///")
-	if rawPath == "" {
-		return "", fmt.Errorf("invalid attachment URL: %s, missing file path", uri)
-	}
-
-	path, err := url.PathUnescape(rawPath)
-	if err != nil {
-		return "", fmt.Errorf("invalid attachment URL: %s, failed to decode path: %w", uri, err)
-	}
-
-	if path == "" {
-		return "", fmt.Errorf("invalid attachment URL: %s, missing file path", uri)
-	}
-
-	return path, nil
+	return fileuri.Decode(uri)
 }
 
 func attachmentPreview(attachment types.Attachment, decodedPath string) mcp.Content {
@@ -1069,7 +1052,7 @@ func (s *Service) convertToSampleRequest(config types.Config, agent string, args
 
 	for _, attachment := range sampleArgs.Attachments {
 		if strings.HasPrefix(attachment.URL, "file:///") {
-			path, err := fileAttachmentPath(attachment.URL)
+			path, err := fileuri.Decode(attachment.URL)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
The primary bug was upload filename normalization: macOS-originated filenames could contain
Unicode whitespace (notably U+202F narrow no-break space), which produced visually similar but
non-canonical paths and caused downstream file lookup/resource operations to fail.
This change normalizes uploaded filenames to ASCII spaces before writing files, so persisted paths
are stable and predictable.

While fixing this, we also corrected file resource URI generation: several paths were emitting raw
`file:///` URIs with unescaped characters (including spaces), which is invalid URI formatting.
URIs are now percent-encoded on output and decoded consistently on input across list/read/subscribe/
delete and attachment path handling, removing producer/consumer mismatch.

Addresses https://github.com/obot-platform/obot/issues/#5944

