### PR TITLE
fix: use absolute path for truncated tool output and simplify directory structure

### DIFF
--- a/pkg/agents/truncate.go
+++ b/pkg/agents/truncate.go
@@ -18,6 +18,8 @@ const maxToolResultSize = 50 * 1024 // 50 KiB
 
 var sanitizeRe = regexp.MustCompile(`[^a-zA-Z0-9_\-.]`)
 
+const sessionsDir = "sessions"
+
 // hasSkipTruncation returns true if any content item has the skip-truncation meta key set.
 func hasSkipTruncation(content []mcp.Content) bool {
 	for _, c := range content {
@@ -61,11 +63,13 @@ func truncateToolResult(ctx context.Context, toolName, callID string, msg *types
 		}
 	}
 
-	// Build file path
+	// Build absolute file path (store under the session's working directory)
 	sessionID, _ := types.GetSessionAndAccountID(ctx)
-	filePath := filepath.Join(".nanobot", sanitizePathComponent(sessionID),
-		"truncated-outputs",
-		sanitizePathComponent(toolName)+"-"+sanitizePathComponent(callID)+ext)
+	fileName := sanitizePathComponent(toolName) + "-" + sanitizePathComponent(callID) + ext
+	filePath := filepath.Join(sessionsDir, sessionID, "truncated-outputs", fileName)
+	if cwd, err := os.Getwd(); err == nil {
+		filePath = filepath.Join(cwd, filePath)
+	}
 
 	writeErr := writeFullResult(content, filePath)
 	truncated := buildTruncatedContent(content, maxToolResultSize, filePath)

--- a/pkg/agents/truncate_test.go
+++ b/pkg/agents/truncate_test.go
@@ -523,8 +523,8 @@ func TestTruncateToolResult_LargeTextContent(t *testing.T) {
 		t.Error("truncated result should not be marked as error")
 	}
 
-	// File should exist with full content
-	filePath := filepath.Join(".nanobot", "default", "truncated-outputs", "my-tool-call1.txt")
+	// File should exist with full content in the session working directory
+	filePath := filepath.Join("sessions", "default", "truncated-outputs", "my-tool-call1.txt")
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Fatalf("failed to read output file: %v", err)
@@ -552,8 +552,8 @@ func TestTruncateToolResult_MixedContentUsesJSON(t *testing.T) {
 		t.Fatal("expected truncated message, got original")
 	}
 
-	// Should use .json extension
-	filePath := filepath.Join(".nanobot", "default", "truncated-outputs", "img-tool-call2.json")
+	// Should use .json extension in the session working directory
+	filePath := filepath.Join("sessions", "default", "truncated-outputs", "img-tool-call2.json")
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Fatalf("failed to read output file: %v", err)
@@ -685,8 +685,8 @@ func TestTruncateToolResult_SpecialCharsInNames(t *testing.T) {
 		t.Fatal("expected truncated message")
 	}
 
-	// File should exist with sanitized name
-	filePath := filepath.Join(".nanobot", "default", "truncated-outputs", "tool_name_special-call_5___.txt")
+	// File should exist with sanitized name in the session working directory
+	filePath := filepath.Join("sessions", "default", "truncated-outputs", "tool_name_special-call_5___.txt")
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		t.Errorf("expected file at %s", filePath)
 	}


### PR DESCRIPTION
Before this change, truncated tool outputs were being stored at
/home/nanobot/.nanbot/<session>/truncated-outputs and in the tool output
we were saying they were at a relative path of ./.nanobot/<session>/...

This confused the LLM because it would look for them nested under the
sessions dir, so it would for example look at:
/home/nanobot/sessions/<session id>/.nanobot/<session
id>/truncated-outputs.

This moves these files to be just /home/nanobot/sessions/<session
id>/truncated-outputs and puts the absolute path in the message to the
LLM.