### PR TITLE
fix: add required field to PrimitiveSchema for elicitations

### DIFF
--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -92,6 +92,7 @@ type PrimitiveSchema struct {
 	// Type must be "object" only
 	Type       string                       `json:"type"`
 	Properties map[string]PrimitiveProperty `json:"properties"`
+	Required   []string                     `json:"required,omitempty"`
 }
 
 type PrimitiveProperty struct {


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/5890

When the obot-mcp-server sends an elicitation, Nanobot ends up unmarshaling it into this struct, which was dropping the `required` field. This fixes that, so that it gets persisted through the whole elicitation flow and shows up properly in the Obot UI.