### PR TITLE
fix: write session workflow associations to dedicated table

### DIFF
--- a/pkg/servers/meta/tools.go
+++ b/pkg/servers/meta/tools.go
@@ -36,7 +36,12 @@ func (s *Server) updateChat(ctx context.Context, data struct {
 		chatSession.Description = data.Title
 	}
 
-	chat := chatFromSession(chatSession, accountID)
+	workflowURIs, err := manager.DB.ListWorkflowURIs(ctx, chatSession.SessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	chat := chatFromSession(chatSession, accountID, workflowURIs[chatSession.SessionID])
 	return &chat, nil
 }
 
@@ -75,9 +80,19 @@ func (s *Server) listChats(ctx context.Context, _ struct{}) (*types.ChatList, er
 		return nil, err
 	}
 
+	sessionIDs := make([]string, 0, len(sessions))
+	for _, session := range sessions {
+		sessionIDs = append(sessionIDs, session.SessionID)
+	}
+
+	workflowURIs, err := manager.DB.ListWorkflowURIs(ctx, sessionIDs...)
+	if err != nil {
+		return nil, err
+	}
+
 	chats := make([]types.Chat, 0, len(sessions))
 	for _, s := range sessions {
-		chats = append(chats, chatFromSession(&s, accountID))
+		chats = append(chats, chatFromSession(&s, accountID, workflowURIs[s.SessionID]))
 	}
 
 	return &types.ChatList{
@@ -85,12 +100,12 @@ func (s *Server) listChats(ctx context.Context, _ struct{}) (*types.ChatList, er
 	}, nil
 }
 
-func chatFromSession(s *session.Session, currentAccountID string) types.Chat {
+func chatFromSession(s *session.Session, currentAccountID string, workflowURIs []string) types.Chat {
 	return types.Chat{
 		ID:           s.SessionID,
 		Title:        s.Description,
 		Created:      s.CreatedAt,
 		ReadOnly:     s.AccountID != currentAccountID,
-		WorkflowURIs: s.WorkflowURIs,
+		WorkflowURIs: workflowURIs,
 	}
 }

--- a/pkg/servers/workflows/tools_server.go
+++ b/pkg/servers/workflows/tools_server.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/nanobot-ai/nanobot/pkg/mcp"
-	"github.com/nanobot-ai/nanobot/pkg/types"
+	"github.com/nanobot-ai/nanobot/pkg/session"
 	"github.com/nanobot-ai/nanobot/pkg/version"
 )
 
@@ -58,41 +58,41 @@ func (s *ToolsServer) initialize(ctx context.Context, _ mcp.Message, params mcp.
 
 func (s *ToolsServer) recordWorkflowRun(ctx context.Context, data struct {
 	URI string `json:"uri"`
-}) (*map[string]string, error) {
-	mcpSession := mcp.SessionFromContext(ctx).Root()
-
-	var uris []string
-	mcpSession.Get(types.WorkflowURIsSessionKey, &uris)
-
-	// Deduplicate: only append if URI is not already recorded.
-	var found bool
-	for _, u := range uris {
-		if u == data.URI {
-			found = true
-			break
-		}
-	}
-	if !found {
-		uris = append(uris, data.URI)
+}) (string, error) {
+	if _, err := parseWorkflowURI(data.URI); err != nil {
+		return "", fmt.Errorf("failed to parse workflow URI: %w", err)
 	}
 
-	mcpSession.Set(types.WorkflowURIsSessionKey, uris)
+	workflowSession := mcp.SessionFromContext(ctx).Root()
+	if workflowSession == nil {
+		return "", mcp.ErrRPCInvalidRequest.WithMessage("session not found")
+	}
 
-	return &map[string]string{"uri": data.URI}, nil
+	var manager session.Manager
+	if !workflowSession.Get(session.ManagerSessionKey, &manager) {
+		return "", mcp.ErrRPCInvalidRequest.WithMessage("session manager not found")
+	}
+
+	sessionID := workflowSession.ID()
+	if err := manager.DB.AddWorkflowRun(ctx, sessionID, data.URI); err != nil {
+		return "", fmt.Errorf("failed to add workflow run: %w", err)
+	}
+
+	return fmt.Sprintf("%s run recorded for session %s", data.URI, sessionID), nil
 }
 
 func (s *ToolsServer) deleteWorkflow(_ context.Context, data struct {
 	URI string `json:"uri"`
-}) (*struct{}, error) {
+}) (string, error) {
 	workflowName, err := parseWorkflowURI(data.URI)
 	if err != nil {
-		return nil, err
+		return "", fmt.Errorf("failed to parse workflow URI: %w", err)
 	}
 
-	workflowPath := filepath.Join(".", workflowsDir, workflowName+".md")
+	workflowPath := filepath.Join(workflowsDir, workflowName+".md")
 	if err := os.Remove(workflowPath); err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("failed to delete workflow: %w", err)
+		return "", fmt.Errorf("failed to delete workflow: %w", err)
 	}
 
-	return &struct{}{}, nil
+	return fmt.Sprintf("%s deleted", data.URI), nil
 }

--- a/pkg/servers/workflows/tools_server_test.go
+++ b/pkg/servers/workflows/tools_server_test.go
@@ -2,40 +2,64 @@ package workflows
 
 import (
 	"context"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/nanobot-ai/nanobot/pkg/mcp"
-	"github.com/nanobot-ai/nanobot/pkg/types"
+	"github.com/nanobot-ai/nanobot/pkg/session"
 )
 
 func TestRecordWorkflowRun_DeduplicatesURI(t *testing.T) {
 	s := NewToolsServer()
-	ctx := context.Background()
-	session := mcp.NewEmptySession(ctx)
-	ctx = mcp.WithSession(ctx, session)
+	ctx := t.Context()
+	manager, err := session.NewManager("sqlite::memory:")
+	if err != nil {
+		t.Fatalf("failed to create session manager: %v", err)
+	}
 
-	uri := "workflow:///test-workflow"
-	if _, err := s.recordWorkflowRun(ctx, struct {
+	if err := manager.DB.Create(ctx, &session.Session{
+		SessionID: "test-session",
+		AccountID: "test-account",
+		Type:      "thread",
+	}); err != nil {
+		t.Fatalf("failed to create test session record: %v", err)
+	}
+
+	serverSession, err := mcp.NewExistingServerSession(ctx, mcp.SessionState{ID: "test-session"}, mcp.MessageHandlerFunc(func(context.Context, mcp.Message) {}))
+	if err != nil {
+		t.Fatalf("failed to create test server session: %v", err)
+	}
+	defer serverSession.Close(false)
+
+	serverSession.GetSession().Set(session.ManagerSessionKey, manager)
+	ctx = mcp.WithSession(ctx, serverSession.GetSession())
+
+	data := struct {
 		URI string `json:"uri"`
-	}{URI: uri}); err != nil {
+	}{
+		URI: "workflow:///test-workflow",
+	}
+	if _, err := s.recordWorkflowRun(ctx, data); err != nil {
 		t.Fatalf("first recordWorkflowRun() failed: %v", err)
 	}
 
-	if _, err := s.recordWorkflowRun(ctx, struct {
-		URI string `json:"uri"`
-	}{URI: uri}); err != nil {
+	if _, err := s.recordWorkflowRun(ctx, data); err != nil {
 		t.Fatalf("second recordWorkflowRun() failed: %v", err)
 	}
 
-	var uris []string
-	session.Root().Get(types.WorkflowURIsSessionKey, &uris)
-	if len(uris) != 1 {
-		t.Fatalf("expected one recorded URI, got %d: %v", len(uris), uris)
+	workflowURIs, err := manager.DB.ListWorkflowURIs(ctx, "test-session")
+	if err != nil {
+		t.Fatalf("failed to load stored workflow URIs: %v", err)
 	}
-	if uris[0] != uri {
-		t.Errorf("recorded URI = %q, want %q", uris[0], uri)
+
+	expected := map[string][]string{
+		"test-session": {data.URI},
+	}
+	if !maps.EqualFunc(workflowURIs, expected, slices.Equal) {
+		t.Fatalf("workflowURIs = %#v, want %#v", workflowURIs, expected)
 	}
 }
 
@@ -55,7 +79,7 @@ func TestDeleteWorkflow_RemovesFile(t *testing.T) {
 	}
 
 	s := NewToolsServer()
-	if _, err := s.deleteWorkflow(context.Background(), struct {
+	if _, err := s.deleteWorkflow(t.Context(), struct {
 		URI string `json:"uri"`
 	}{URI: "workflow:///to-delete"}); err != nil {
 		t.Fatalf("deleteWorkflow() failed: %v", err)

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -65,7 +65,6 @@ func (m *Manager) newRecord(id, accountID string) *Session {
 func (m *Manager) loadAttributesFromRecord(stored *Session, session *mcp.ServerSession) {
 	session.GetSession().Set(types.DescriptionSessionKey, stored.Description)
 	session.GetSession().Set(types.AccountIDSessionKey, stored.AccountID)
-	session.GetSession().Set(types.WorkflowURIsSessionKey, stored.WorkflowURIs)
 }
 
 func (m *Manager) saveAttributesToRecord(stored *Session, session *mcp.ServerSession) error {
@@ -75,7 +74,6 @@ func (m *Manager) saveAttributesToRecord(stored *Session, session *mcp.ServerSes
 
 	session.GetSession().Get(types.DescriptionSessionKey, &stored.Description)
 	session.GetSession().Get(types.ConfigSessionKey, &config)
-	session.GetSession().Get(types.WorkflowURIsSessionKey, &stored.WorkflowURIs)
 
 	stored.Config = ConfigWrapper(config)
 	return nil

--- a/pkg/session/migrations.go
+++ b/pkg/session/migrations.go
@@ -1,0 +1,71 @@
+package session
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// migrateSessionWorkflowURIs migrates the workflow_uris column of the sessions table into rows in the workflow_runs table.
+// After a successful migration, the workflow_uris column is dropped from the sessions table.
+func migrateSessionWorkflowURIs(tx *gorm.DB) error {
+	if !tx.Migrator().HasColumn(&Session{}, "workflow_uris") {
+		return nil
+	}
+
+	rows, err := tx.
+		Table("sessions").
+		Select("session_id", "workflow_uris").
+		Where("workflow_uris IS NOT NULL").
+		Rows()
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var runs []WorkflowRun
+	for rows.Next() {
+		var (
+			sessionID string
+			raw       any
+		)
+
+		if err := rows.Scan(&sessionID, &raw); err != nil {
+			return err
+		}
+		if sessionID == "" {
+			continue
+		}
+
+		var uris []string
+		if err := scan(raw, &uris); err != nil {
+			return fmt.Errorf("failed to decode workflow_uris for session %s: %w", sessionID, err)
+		}
+
+		for _, uri := range uris {
+			if uri == "" {
+				continue
+			}
+			run := WorkflowRun{
+				SessionID:   sessionID,
+				WorkflowURI: uri,
+			}
+			runs = append(runs, run)
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	if len(runs) > 0 {
+		if err := tx.
+			Clauses(clause.OnConflict{DoNothing: true}).
+			CreateInBatches(runs, 500).Error; err != nil {
+			return err
+		}
+	}
+
+	return tx.Migrator().DropColumn(&Session{}, "workflow_uris")
+}

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nanobot-ai/nanobot/pkg/uuid"
 	"golang.org/x/oauth2"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 const (
@@ -26,14 +27,27 @@ func NewStore(db *gorm.DB) *Store {
 	return &Store{db: db}
 }
 
-func NewStoreFromDSN(dsn string) (*Store, error) {
+func NewStoreFromDSN(dsn string) (store *Store, err error) {
 	db, err := gormdsn.NewDBFromDSN(dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create database connection: %w", err)
 	}
 
-	if err := db.AutoMigrate(&Session{}, &Token{}); err != nil {
+	tx := db.Begin()
+	defer func() {
+		if err != nil {
+			tx.Rollback()
+		} else {
+			tx.Commit()
+		}
+	}()
+
+	if err := tx.AutoMigrate(&Session{}, &Token{}, &WorkflowRun{}); err != nil {
 		return nil, fmt.Errorf("failed to migrate schema: %w", err)
+	}
+
+	if err := migrateSessionWorkflowURIs(tx); err != nil {
+		return nil, fmt.Errorf("failed to migrate session workflow URIs: %w", err)
 	}
 
 	return &Store{db: db}, nil
@@ -100,6 +114,46 @@ func (s *Store) FindByAccount(ctx context.Context, sessionType, accountID string
 		return nil, err
 	}
 	return sessions, nil
+}
+
+// ListWorkflowURIs returns the URIs of the workflows that have been run in each of the given sessions.
+func (s *Store) ListWorkflowURIs(ctx context.Context, sessionIDs ...string) (map[string][]string, error) {
+	if len(sessionIDs) == 0 {
+		return nil, nil
+	}
+
+	var runs []WorkflowRun
+	err := s.db.WithContext(ctx).
+		Where("session_id IN ?", sessionIDs).
+		Order("session_id ASC, workflow_uri ASC").
+		Find(&runs).Error
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string][]string, len(sessionIDs))
+	for _, run := range runs {
+		result[run.SessionID] = append(result[run.SessionID], run.WorkflowURI)
+	}
+
+	return result, nil
+}
+
+// AddWorkflowRun records a workflow run for a session and ignores duplicates.
+func (s *Store) AddWorkflowRun(ctx context.Context, sessionID, workflowURI string) error {
+	if sessionID == "" {
+		return fmt.Errorf("session ID cannot be empty")
+	}
+	if workflowURI == "" {
+		return fmt.Errorf("workflow URI cannot be empty")
+	}
+
+	run := WorkflowRun{
+		SessionID:   sessionID,
+		WorkflowURI: workflowURI,
+	}
+
+	return s.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(&run).Error
 }
 
 func (s *Store) List(ctx context.Context) ([]Session, error) {

--- a/pkg/session/types.go
+++ b/pkg/session/types.go
@@ -55,14 +55,19 @@ func scan(value any, obj any) error {
 
 type Session struct {
 	gorm.Model
-	Type         string        `json:"type,omitempty"`
-	SessionID    string        `json:"sessionId" gorm:"uniqueIndex;not null"`
-	Description  string        `json:"description,omitempty"`
-	AccountID    string        `json:"accountId,omitempty"`
-	State        State         `json:"state" gorm:"type:json"`
-	Config       ConfigWrapper `json:"config,omitempty" gorm:"type:json"`
-	Cwd          string        `json:"cwd,omitempty"`
-	WorkflowURIs []string      `json:"workflowURIs,omitempty" gorm:"column:workflow_uris;serializer:json"`
+	Type        string        `json:"type,omitempty"`
+	SessionID   string        `json:"sessionId" gorm:"uniqueIndex;not null"`
+	Description string        `json:"description,omitempty"`
+	AccountID   string        `json:"accountId,omitempty"`
+	State       State         `json:"state" gorm:"type:json"`
+	Config      ConfigWrapper `json:"config,omitempty" gorm:"type:json"`
+	Cwd         string        `json:"cwd,omitempty"`
+}
+
+// WorkflowRun records that a workflow was executed within a session.
+type WorkflowRun struct {
+	SessionID   string `json:"sessionId" gorm:"primaryKey;not null"`
+	WorkflowURI string `json:"workflowURI" gorm:"primaryKey;not null"`
 }
 
 type Token struct {

--- a/pkg/types/chat.go
+++ b/pkg/types/chat.go
@@ -80,8 +80,6 @@ type ChatList struct {
 	Chats []Chat `json:"chats"`
 }
 
-const WorkflowURIsSessionKey = "workflowURIs"
-
 type Chat struct {
 	ID           string    `json:"id"`
 	Title        string    `json:"title"`


### PR DESCRIPTION
Workflow runs are tracked indirectly by mutating `workflowURIs` in session attributes and relying on later session persistence to write `workflow_uris`. This path is non-atomic, and concurrent requests can cause workflow associations to be clobbered or lost.

To fix this, write runs directly to a new table (`workflow_runs`) on `recordWorkflowRun`, then resolve them from that table on `list-chats`.

- add startup migration to move existing `sessions.workflow_uris` JSON data into `workflow_runs`, then drop the legacy column
- update chat list/update paths to build `workflowURIs` from `workflow_runs`
- remove obsolete `workflowURIs` session-attribute wiring (`WorkflowURIsSessionKey` and manager sync logic)
- add store helpers for inserting runs idempotently and listing runs by session
- update workflow tests to validate DB-backed deduplication behavior

This change also modifies the return values of `recordWorkflowRun` and `deleteWorkflow` to strings.

Addresses https://github.com/obot-platform/obot/issues/5860

