### PR TITLE
Fix: Make gpt-5.x models work properly

### DIFF
--- a/pkg/llm/responses/translate.go
+++ b/pkg/llm/responses/translate.go
@@ -116,11 +116,11 @@ func toRequest(completion *types.CompletionRequest) (req Request, _ error) {
 		req.Truncation = &completion.Truncation
 	}
 
-	if completion.Temperature != nil {
+	if completion.Temperature != nil && !reasoningPrefix.MatchString(req.Model) {
 		req.Temperature = completion.Temperature
 	}
 
-	if completion.TopP != nil {
+	if completion.TopP != nil && !reasoningPrefix.MatchString(req.Model) {
 		req.TopP = completion.TopP
 	}
 

--- a/pkg/llm/responses/types.go
+++ b/pkg/llm/responses/types.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	reasoningPrefix = regexp.MustCompile("^o[0-9]")
+	reasoningPrefix = regexp.MustCompile("^(o[0-9]|gpt-5)")
 )
 
 type Request struct {


### PR DESCRIPTION
We need to turn on reasoning for the gpt-5.x models, else they very
dumb.

Also, the gpt-5.x models do not support support temperature and topP.
Starting with 5.3, the LLM completely rejects requests with it set. So,
disable it for all OpenAI reasoning models makes the most sense.

Signed-off-by: Craig Jellick <craig@obot.ai>
