### PR TITLE
Add Python to container PATH via uv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,8 @@ RUN apk update && apk add --no-cache \
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 RUN uv python install 3.13 && \
     mkdir -p /usr/local/bin && \
-    ln -s $(uv python find) /usr/local/bin/python3 && \
-    ln -s /usr/local/bin/python3 /usr/local/bin/python
+    ln -sf "$(uv python find)" /usr/local/bin/python3 && \
+    ln -sf /usr/local/bin/python3 /usr/local/bin/python
 
 # Install mcp-cli
 ARG TARGETARCH


### PR DESCRIPTION
Install Python 3.13 via uv to a shared location (/opt/python) and
symlink to /usr/local/bin so it's accessible to the non-root user.

I'm doing this because despite the fact that the python skill tells the model to use `uv` to run and execute python, the model will still sometimes try to call python direclty. This gets a python onto the path so that that doesnt fail.



Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
