### PR TITLE
cache token

### DIFF
--- a/pkg/mcp/httpclient.go
+++ b/pkg/mcp/httpclient.go
@@ -467,7 +467,7 @@ func (s *HTTPClient) ensureSSE(ctx context.Context, msg *Message, lastEventID st
 			}
 			if !ok {
 				if err := messages.err(); err != nil {
-					if errors.Is(err, context.Canceled) {
+					if errors.Is(err, context.Canceled) || s.ctx.Err() != nil {
 						slog.Debug("context canceled reading SSE message", "error", err)
 					} else {
 						slog.Error("failed to read SSE message", "error", err)


### PR DESCRIPTION
- **Cache exchanged MCP auth tokens in HTTP client**
- **Chore: fix noisy log**
