### PR TITLE
Fix SSE shutdown logging in MCP HTTP client

### DIFF
--- a/pkg/mcp/httpclient.go
+++ b/pkg/mcp/httpclient.go
@@ -396,7 +396,7 @@ func (s *HTTPClient) ensureSSE(ctx context.Context, msg *Message, lastEventID st
 			}
 			if !ok {
 				if err := messages.err(); err != nil {
-					if errors.Is(err, context.Canceled) {
+					if errors.Is(err, context.Canceled) || s.ctx.Err() != nil {
 						slog.Debug("context canceled reading SSE message", "error", err)
 					} else {
 						slog.Error("failed to read SSE message", "error", err)


### PR DESCRIPTION
Treat SSE read failures as expected during client shutdown when the
client context is already done, and avoid logging them as errors.

Signed-off-by: Craig Jellick <craig@obot.ai>
