### PR TITLE
Cache exchanged MCP auth tokens in HTTP client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	golang.org/x/image v0.36.0
 	golang.org/x/net v0.49.0
 	golang.org/x/oauth2 v0.30.0
+	golang.org/x/sync v0.19.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.6.0
 	gorm.io/driver/postgres v1.6.0
@@ -65,7 +66,6 @@ require (
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6 // indirect
 	golang.org/x/mod v0.32.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/time v0.9.0 // indirect

--- a/pkg/mcp/httpclient.go
+++ b/pkg/mcp/httpclient.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,6 +20,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/nanobot-ai/nanobot/pkg/complete"
 	"github.com/nanobot-ai/nanobot/pkg/log"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -34,6 +36,75 @@ func isJWT(token string) bool {
 	parser := jwt.NewParser()
 	_, _, err := parser.ParseUnverified(token, jwt.MapClaims{})
 	return err == nil
+}
+
+type cachedTokenExchange struct {
+	mu      sync.Mutex
+	entries map[string]cachedTokenExchangeEntry
+	group   singleflight.Group
+}
+
+type cachedTokenExchangeEntry struct {
+	accessToken string
+	expiresAt   time.Time
+}
+
+var globalTokenExchangeCache = &cachedTokenExchange{
+	entries: map[string]cachedTokenExchangeEntry{},
+}
+
+func (c *cachedTokenExchange) get(key string, now time.Time) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[key]
+	if !ok {
+		return "", false
+	}
+	if !entry.expiresAt.IsZero() && !now.Before(entry.expiresAt) {
+		delete(c.entries, key)
+		return "", false
+	}
+	return entry.accessToken, true
+}
+
+func (c *cachedTokenExchange) set(key, accessToken string, expiresAt time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = cachedTokenExchangeEntry{
+		accessToken: accessToken,
+		expiresAt:   expiresAt,
+	}
+}
+
+func tokenExchangeCacheKey(endpoint, resource, subjectTokenType, subjectToken, clientID, clientSecret string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		endpoint,
+		resource,
+		subjectTokenType,
+		subjectToken,
+		clientID,
+		clientSecret,
+	}, "\x00")))
+	return fmt.Sprintf("%x", sum[:])
+}
+
+func tokenExchangeExpiresAt(now time.Time, expiresIn int) (time.Time, bool) {
+	if expiresIn <= 0 {
+		return time.Time{}, false
+	}
+
+	ttl := time.Duration(expiresIn) * time.Second
+	if ttl <= time.Minute {
+		return time.Time{}, false
+	}
+
+	expiresAt := now.Add(ttl - time.Minute)
+	if !expiresAt.After(now) {
+		return time.Time{}, false
+	}
+
+	return expiresAt, true
 }
 
 type HTTPClient struct {
@@ -862,67 +933,87 @@ func (s *HTTPClient) exchangeToken(ctx context.Context, subjectToken string) (st
 		return "", nil
 	}
 
-	// Build the token exchange request according to RFC 8693
-	data := url.Values{}
-	data.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
-	data.Set("subject_token", subjectToken)
-
-	// Detect token type based on format
 	subjectTokenType := tokenTypeAPIKey
 	if isJWT(subjectToken) {
 		subjectTokenType = tokenTypeJWT
 	}
-	slog.Info("mcp client token exchange requested",
-		"server", s.serverName,
-		"token_type", subjectTokenType,
-		"endpoint", s.tokenExchangeEndpoint)
-	data.Set("subject_token_type", subjectTokenType)
-	data.Set("requested_token_type", "urn:ietf:params:oauth:token-type:access_token")
-	data.Set("resource", s.baseURL)
 
-	// Create the HTTP request
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.tokenExchangeEndpoint, strings.NewReader(data.Encode()))
+	cacheKey := tokenExchangeCacheKey(
+		s.tokenExchangeEndpoint,
+		s.baseURL,
+		subjectTokenType,
+		subjectToken,
+		s.tokenExchangeClientID,
+		s.tokenExchangeClientSecret,
+	)
+	if accessToken, ok := globalTokenExchangeCache.get(cacheKey, time.Now()); ok {
+		return accessToken, nil
+	}
+
+	result, err, _ := globalTokenExchangeCache.group.Do(cacheKey, func() (any, error) {
+		if accessToken, ok := globalTokenExchangeCache.get(cacheKey, time.Now()); ok {
+			return accessToken, nil
+		}
+
+		data := url.Values{}
+		data.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+		data.Set("subject_token", subjectToken)
+		data.Set("subject_token_type", subjectTokenType)
+		data.Set("requested_token_type", "urn:ietf:params:oauth:token-type:access_token")
+		data.Set("resource", s.baseURL)
+
+		slog.Info("mcp client token exchange requested",
+			"server", s.serverName,
+			"token_type", subjectTokenType,
+			"endpoint", s.tokenExchangeEndpoint)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.tokenExchangeEndpoint, strings.NewReader(data.Encode()))
+		if err != nil {
+			return "", fmt.Errorf("failed to create token exchange request: %w", err)
+		}
+
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		if s.tokenExchangeClientID != "" || s.tokenExchangeClientSecret != "" {
+			req.SetBasicAuth(s.tokenExchangeClientID, s.tokenExchangeClientSecret)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("failed to call token exchange endpoint: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			slog.Debug("token exchange endpoint returned non-200 status", "endpoint", s.tokenExchangeEndpoint, "status_code", resp.StatusCode)
+			return "", nil
+		}
+
+		var tokenResp struct {
+			AccessToken     string `json:"access_token"`
+			IssuedTokenType string `json:"issued_token_type"`
+			TokenType       string `json:"token_type"`
+			ExpiresIn       int    `json:"expires_in"`
+			Scope           string `json:"scope"`
+			RefreshToken    string `json:"refresh_token"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+			return "", fmt.Errorf("failed to parse token exchange response: %w", err)
+		}
+
+		if tokenResp.AccessToken == "" {
+			return "", fmt.Errorf("token exchange response missing access_token")
+		}
+
+		if expiresAt, ok := tokenExchangeExpiresAt(time.Now(), tokenResp.ExpiresIn); ok {
+			globalTokenExchangeCache.set(cacheKey, tokenResp.AccessToken, expiresAt)
+		}
+
+		return tokenResp.AccessToken, nil
+	})
 	if err != nil {
-		return "", fmt.Errorf("failed to create token exchange request: %w", err)
+		return "", err
 	}
 
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	// Add HTTP Basic authentication if client credentials are configured
-	if s.tokenExchangeClientID != "" || s.tokenExchangeClientSecret != "" {
-		req.SetBasicAuth(s.tokenExchangeClientID, s.tokenExchangeClientSecret)
-	}
-
-	// Make the request
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to call token exchange endpoint: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// If the response status code is not OK, then continue without a token.
-	// Maybe OAuth will work.
-	if resp.StatusCode != http.StatusOK {
-		slog.Debug("token exchange endpoint returned non-200 status", "endpoint", s.tokenExchangeEndpoint, "status_code", resp.StatusCode)
-		return "", nil
-	}
-
-	// Parse successful response
-	var tokenResp struct {
-		AccessToken     string `json:"access_token"`
-		IssuedTokenType string `json:"issued_token_type"`
-		TokenType       string `json:"token_type"`
-		ExpiresIn       int    `json:"expires_in"`
-		Scope           string `json:"scope"`
-		RefreshToken    string `json:"refresh_token"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-		return "", fmt.Errorf("failed to parse token exchange response: %w", err)
-	}
-
-	if tokenResp.AccessToken == "" {
-		return "", fmt.Errorf("token exchange response missing access_token")
-	}
-
-	return tokenResp.AccessToken, nil
+	accessToken, _ := result.(string)
+	return accessToken, nil
 }


### PR DESCRIPTION
### Holding off for now
I'm going to wait until donnie is around to take this out of draft and consider moving it forward. Why the token exchange path does get called a ton, it is not particularly expensive, so it isn't a fire to get this in and I want to see how Donnie feels about it.

---
Add a process-wide cache for RFC 8693 token exchange results in the MCP
HTTP client so short-lived and concurrent MCP clients do not repeatedly
hit the auth server for the same exchanged token.

The cache key includes:
- token exchange endpoint
- resource/base URL
- subject token type
- subject token value
- client credential identity

Behavior changes:
- reuse exchanged access tokens until shortly before expiry
- coalesce concurrent identical exchanges with singleflight
- keep existing behavior when token exchange is not configured or the
exchange endpoint returns a non-200 response

This targets the cold-start path where Nanobot creates transient MCP
clients behind shim proxies and was previously re-exchanging the same
token on initialize, notifications/initialized, tools/list, and
tools/call.

Signed-off-by: Craig Jellick <craig@obot.ai>