### PR TITLE
Chore: Remove agent audit log special case

### DIFF
--- a/pkg/mcp/auditlogs/collector.go
+++ b/pkg/mcp/auditlogs/collector.go
@@ -6,12 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
-
-	"log/slog"
 )
 
 type Collector struct {
@@ -52,11 +50,6 @@ func (c *Collector) CollectMCPAuditEntry(entry MCPAuditLog) {
 	if c == nil || entry.CallType == "" {
 		// If the call type is empty, then this is a response to a request.
 		// The audit log will be handled elsewhere.
-		return
-	}
-
-	if entry.ClientName == "nanobot-ui" && strings.HasPrefix(entry.CallIdentifier, "chat://") && entry.CallType == "resources/read" {
-		// These are spammy audit logs that we do not need to send, as they never contain useful information.
 		return
 	}
 


### PR DESCRIPTION
We're dropping agents from audit logging to the mcp audit logs all
together, so we don't need this carve out.

Signed-off-by: Craig Jellick <craig@obot.ai>
