### PR TITLE
fix(ui): send elicitation capability on initialize

### DIFF
--- a/packages/ui/src/lib/mcpclient.ts
+++ b/packages/ui/src/lib/mcpclient.ts
@@ -161,7 +161,9 @@ export class SimpleClient {
 					method: "initialize",
 					params: {
 						protocolVersion: "2024-11-05",
-						capabilities: {},
+						capabilities: {
+							elicitation: {},
+						},
 						clientInfo: {
 							name: "nanobot-ui",
 							version: "0.0.1",

--- a/pkg/session/ui.go
+++ b/pkg/session/ui.go
@@ -104,9 +104,11 @@ func UISession(next http.Handler, sessionStore *Manager, apiHandler http.Handler
 				if strings.Contains(req.URL.Path, "immutable") {
 					serveGzipAndCached(req, rw, uiFS)
 				} else {
+					setNoCacheHeaders(rw)
 					http.FileServer(http.FS(uiFS)).ServeHTTP(rw, req)
 				}
 			} else {
+				setNoCacheHeaders(rw)
 				http.ServeFileFS(rw, req, uiFS, "fallback.html")
 			}
 		} else {
@@ -118,6 +120,12 @@ func UISession(next http.Handler, sessionStore *Manager, apiHandler http.Handler
 
 func isSecureRequest(req *http.Request) bool {
 	return req.TLS != nil || req.Header.Get("X-Forwarded-Proto") == "https"
+}
+
+func setNoCacheHeaders(rw http.ResponseWriter) {
+	rw.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0")
+	rw.Header().Set("Pragma", "no-cache")
+	rw.Header().Set("Expires", "0")
 }
 
 func serveGzipAndCached(req *http.Request, rw http.ResponseWriter, fs fs.FS) {


### PR DESCRIPTION
## Summary
- Add the elicitation client capability to SimpleClient initialize  requests so new UI sessions advertise elicitation ssupport
- Disable caching for the HTML shell and other non-immutable UI assets so rebuilt embedded bundles are picked up after refresh. Needed to do this because my browser was really holding on to old versions of the ui locally.