### PR TITLE
enhance: gate BrowserView on active browser availability

### DIFF
--- a/packages/ui/src/lib/components/Thread.svelte
+++ b/packages/ui/src/lib/components/Thread.svelte
@@ -77,6 +77,15 @@ let selectedPrompt = $state<string | undefined>();
 let showBrowserViewer = $state(false);
 let browserViewerWidth = $state(50); // percentage
 let isResizing = $state(false);
+let browserAvailable = $state(false);
+
+function browserStatusUrl() {
+	if (typeof window === "undefined") {
+		return "/browser/status";
+	}
+
+	return new URL("/browser/status", window.location.origin).toString();
+}
 
 function startResize(e: MouseEvent) {
 	isResizing = true;
@@ -104,6 +113,33 @@ $effect(() => {
 		window.addEventListener("mouseup", stopResize);
 		return () => window.removeEventListener("mouseup", stopResize);
 	}
+});
+
+$effect(() => {
+	if (typeof window === "undefined") {
+		return;
+	}
+
+	const eventSource = new EventSource(browserStatusUrl());
+
+	const handleStatus = (event: Event) => {
+		try {
+			const data = JSON.parse((event as MessageEvent<string>).data) as { available?: boolean };
+			browserAvailable = !!data.available;
+			if (!browserAvailable) {
+				showBrowserViewer = false;
+			}
+		} catch {
+			// Ignore malformed status events and keep the last known state.
+		}
+	};
+
+	eventSource.addEventListener("status", handleStatus);
+
+	return () => {
+		eventSource.removeEventListener("status", handleStatus);
+		eventSource.close();
+	};
 });
 
 // Split elicitations: question type renders inline, others render as modal
@@ -213,17 +249,19 @@ async function handleDrop(e: DragEvent) {
 
 	<!-- Chat area -->
 	<div class="relative flex flex-col" style="width: {showBrowserViewer ? `${100 - browserViewerWidth}%` : '100%'}">
-		<!-- Header with browser viewer toggle -->
-		<div class="flex items-center justify-end border-b border-base-300 bg-base-100 px-4 py-2">
-			<button
-				class="btn btn-ghost btn-sm"
-				onclick={() => (showBrowserViewer = !showBrowserViewer)}
-				title="Toggle browser view"
-			>
-				<Monitor size={16} />
-				Browser
-			</button>
-		</div>
+		{#if browserAvailable}
+			<!-- Header with browser viewer toggle -->
+			<div class="flex items-center justify-end border-b border-base-300 bg-base-100 px-4 py-2">
+				<button
+					class="btn btn-ghost btn-sm"
+					onclick={() => (showBrowserViewer = !showBrowserViewer)}
+					title="Toggle browser view"
+				>
+					<Monitor size={16} />
+					Browser
+				</button>
+			</div>
+		{/if}
 
 		<!-- Messages area - full height scrollable with bottom padding for floating input -->
 		<div class="w-full flex-1 overflow-y-auto" bind:this={messagesContainer} onscroll={handleScroll}>

--- a/pkg/session/browser.go
+++ b/pkg/session/browser.go
@@ -3,6 +3,7 @@ package session
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -11,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 const (
@@ -25,6 +27,11 @@ const (
 type browserResizeRequest struct {
 	Width  int `json:"width"`
 	Height int `json:"height"`
+}
+
+type browserStatusResponse struct {
+	Available   bool `json:"available"`
+	WindowCount int  `json:"windowCount"`
 }
 
 type browserProxyHandler struct {
@@ -69,10 +76,73 @@ func (h *browserProxyHandler) ServeHTTP(rw http.ResponseWriter, req *http.Reques
 	case "/healthz":
 		rw.WriteHeader(http.StatusOK)
 		_, _ = rw.Write([]byte("ok"))
+	case "/status":
+		h.handleStatusStream(rw, req)
 	case "/resize":
 		h.handleResize(rw, req)
 	default:
 		h.proxy.ServeHTTP(rw, req)
+	}
+}
+
+func (h *browserProxyHandler) handleStatusStream(rw http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		rw.Header().Set("Allow", http.MethodGet)
+		http.Error(rw, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	flusher, ok := rw.(http.Flusher)
+	if !ok {
+		http.Error(rw, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "text/event-stream")
+	rw.Header().Set("Cache-Control", "no-cache")
+	rw.Header().Set("Connection", "keep-alive")
+	rw.Header().Set("X-Accel-Buffering", "no")
+
+	writeStatus := func(status browserStatusResponse) error {
+		payload, err := json.Marshal(status)
+		if err != nil {
+			return err
+		}
+
+		if _, err := fmt.Fprintf(rw, "event: status\ndata: %s\n\n", payload); err != nil {
+			return err
+		}
+		flusher.Flush()
+		return nil
+	}
+
+	lastStatus := h.currentStatus()
+	if err := writeStatus(lastStatus); err != nil {
+		return
+	}
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-req.Context().Done():
+			return
+		case <-ticker.C:
+			status := h.currentStatus()
+			if status == lastStatus {
+				if _, err := rw.Write([]byte(": keepalive\n\n")); err != nil {
+					return
+				}
+				flusher.Flush()
+				continue
+			}
+
+			if err := writeStatus(status); err != nil {
+				return
+			}
+			lastStatus = status
+		}
 	}
 }
 
@@ -146,6 +216,14 @@ func (h *browserProxyHandler) resize(width, height int) error {
 	return nil
 }
 
+func (h *browserProxyHandler) currentStatus() browserStatusResponse {
+	windowCount, _ := h.browserWindowCount()
+	return browserStatusResponse{
+		Available:   windowCount > 0,
+		WindowCount: windowCount,
+	}
+}
+
 func (h *browserProxyHandler) maximizeWindows() error {
 	listCmd := exec.Command("wmctrl", "-l")
 	listOutput, err := listCmd.Output()
@@ -169,6 +247,31 @@ func (h *browserProxyHandler) maximizeWindows() error {
 	}
 
 	return nil
+}
+
+func (h *browserProxyHandler) browserWindowCount() (int, error) {
+	output, err := exec.Command("wmctrl", "-lx").CombinedOutput()
+	if err != nil {
+		return 0, err
+	}
+
+	return countBrowserWindows(string(output)), nil
+}
+
+func countBrowserWindows(output string) int {
+	count := 0
+	for _, line := range strings.Split(output, "\n") {
+		lower := strings.ToLower(line)
+		if lower == "" {
+			continue
+		}
+
+		if strings.Contains(lower, "chromium") || strings.Contains(lower, "chrome") {
+			count++
+		}
+	}
+
+	return count
 }
 
 func parseResolution(value string) (int, int, error) {

--- a/pkg/session/browser_test.go
+++ b/pkg/session/browser_test.go
@@ -61,3 +61,17 @@ func TestBrowserNormalizeSize(t *testing.T) {
 		t.Fatalf("normalizeSize should round to 8px increments, got %dx%d", width, height)
 	}
 }
+
+func TestCountBrowserWindows(t *testing.T) {
+	t.Parallel()
+
+	output := `
+0x01200003  0 host google-chrome.Google-chrome  Google - Google Chrome for Testing
+0x01400004  0 host Navigator.firefox  Docs
+0x01600005  0 host chromium.Chromium  Slack - Chromium
+`
+
+	if got := countBrowserWindows(output); got != 2 {
+		t.Fatalf("countBrowserWindows() = %d, want 2", got)
+	}
+}

--- a/scripts/agent-entrypoint.sh
+++ b/scripts/agent-entrypoint.sh
@@ -38,6 +38,7 @@ session.screen0.tab.placement: TopLeft
 session.screen0.fullMaximization: true
 session.screen0.maxDisableMove: true
 session.screen0.maxDisableResize: true
+session.screen0.toolbar.height: 0
 EOF
 
 	cat > "${fluxbox_dir}/apps" <<'EOF'
@@ -68,7 +69,7 @@ start_browser_stack() {
 	configure_fluxbox
 
 	echo "Starting window manager (fluxbox)..."
-	fluxbox -rc "${HOME}/.nanobot/fluxbox/init" &
+	fluxbox -no-toolbar -rc "${HOME}/.nanobot/fluxbox/init" &
 
 	echo "Starting x11vnc on port ${VNC_PORT}..."
 	x11vnc -display ":${DISPLAY_NUM}" \


### PR DESCRIPTION
Add a lightweight browser availability stream to the session backend so BrowserView is only exposed when a Chrome or Chromium window exists on the X display.

The UI now listens to that stream to hide the Browser toggle until a real browser window is present, and closes the viewer again if the browser disappears. The agent entrypoint also starts Fluxbox without its toolbar so the BrowserView surface does not show the workspace footer.

