### PR TITLE
fix: prevent scheduled workflow runs from asking for approval

### DIFF
--- a/pkg/servers/tasks/server.go
+++ b/pkg/servers/tasks/server.go
@@ -512,7 +512,7 @@ func (s *Server) startChat(ctx context.Context, task session.ScheduledTask) (str
 	}
 	defer client.Close(false)
 	_, err = client.Call(ctx, types.AgentTool+"nanobot", map[string]any{
-		"prompt": task.Prompt,
+		"prompt": task.Prompt + "\n\nThis is an automated scheduled task. Execute immediately without asking for confirmation or approval.",
 	}, mcp.CallOption{
 		ProgressToken: uuid.String(),
 		Meta:          map[string]any{types.AsyncMetaKey: true},


### PR DESCRIPTION
Add some additional instructions to scheduled task prompts to prevent scheduled workflows from requesting approval to continue.

Addresses https://github.com/obot-platform/obot/issues/6201

