### PR TITLE
fix: address some minor performance hiccups

### DIFF
--- a/pkg/agents/run.go
+++ b/pkg/agents/run.go
@@ -440,7 +440,7 @@ func (a *Agents) Complete(ctx context.Context, req types.CompletionRequest, opts
 			return nil, err
 		}
 
-		ctx := types.WithConfig(ctx, config)
+		ctx = types.WithConfig(ctx, config)
 
 		if err := a.run(ctx, config, currentRun, previousRun, opts); err != nil {
 			return nil, err

--- a/pkg/cmd/builder.go
+++ b/pkg/cmd/builder.go
@@ -51,7 +51,7 @@ func fields(obj any) []fieldInfo {
 		if fieldType.Anonymous {
 			if fieldType.Type.Kind() == reflect.Struct {
 				result = append(result, fields(objValue.Field(i).Addr().Interface())...)
-			} else if fieldType.Type.Kind() == reflect.Ptr && fieldType.Type.Elem().Kind() == reflect.Struct {
+			} else if fieldType.Type.Kind() == reflect.Pointer && fieldType.Type.Elem().Kind() == reflect.Struct {
 				result = append(result, fields(objValue.Field(i).Interface())...)
 			}
 		} else if !fieldType.Anonymous {

--- a/pkg/mcp/httpserver.go
+++ b/pkg/mcp/httpserver.go
@@ -190,6 +190,7 @@ func (h *HTTPServer) streamEvents(rw http.ResponseWriter, req *http.Request, aud
 		return
 	}
 	slog.Debug("mcp server opening event stream", "session_id", id, "path", req.URL.Path)
+	defer slog.Debug("mcp server closed event stream", "session_id", id, "path", req.URL.Path)
 
 	session, ok, err := h.sessions.Acquire(req.Context(), h.MessageHandler, id)
 	if err != nil {

--- a/pkg/mcp/serversession.go
+++ b/pkg/mcp/serversession.go
@@ -230,6 +230,7 @@ func (s *serverWire) subscribe(ctx context.Context) (<-chan Message, <-chan stru
 	s.subscriberLock.Unlock()
 	context.AfterFunc(ctx, func() {
 		s.removeSubscriber(ch)
+		close(ch)
 	})
 	return ch, s.ctx.Done()
 }

--- a/pkg/mcp/session.go
+++ b/pkg/mcp/session.go
@@ -370,7 +370,7 @@ func (s *Session) copyInto(out, in any) bool {
 		return true
 	}
 
-	if dstVal.Type().Kind() == reflect.Ptr && srcVal.Type().AssignableTo(dstVal.Type().Elem()) {
+	if dstVal.Type().Kind() == reflect.Pointer && srcVal.Type().AssignableTo(dstVal.Type().Elem()) {
 		dstVal.Elem().Set(srcVal)
 		return true
 	}
@@ -815,8 +815,13 @@ func newSession(ctx context.Context, wire Wire, handler MessageHandler, session 
 		s.InitializeRequest = session.InitializeRequest
 		s.InitializeResult = session.InitializeResult
 	}
-	withSession := WithSession(ctx, s)
-	s.ctx, s.cancel = context.WithCancelCause(withSession)
+	if s.Parent != nil {
+		go func() {
+			s.Parent.Wait()
+			s.Close(false)
+		}()
+	}
+	s.ctx, s.cancel = context.WithCancelCause(WithSession(ctx, s))
 
 	if err := wire.Start(s.ctx, s.onWire); err != nil {
 		return nil, err

--- a/pkg/servers/agent/agent.go
+++ b/pkg/servers/agent/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"slices"
 
 	"github.com/nanobot-ai/nanobot/pkg/agents"
@@ -26,6 +27,7 @@ type Server struct {
 
 type Caller interface {
 	Call(ctx context.Context, server, tool string, args any, opts ...tools.CallOptions) (ret *types.CallResult, err error)
+	BuildToolMappings(ctx context.Context, toolList []string, opts ...types.BuildToolMappingsOptions) (types.ToolMappings, error)
 	GetClient(ctx context.Context, name string) (*mcp.Client, error)
 	GetPrompt(ctx context.Context, target, prompt string, args map[string]string) (*mcp.GetPromptResult, error)
 }
@@ -55,9 +57,6 @@ func (s *Server) withConfig(ctx context.Context) (context.Context, error) {
 
 func (s *Server) OnMessage(ctx context.Context, msg mcp.Message) {
 	switch msg.Method {
-	case "initialize":
-		mcp.Invoke(ctx, msg, s.initialize)
-		return
 	case "notifications/initialized":
 		// nothing to do
 		return
@@ -88,6 +87,9 @@ func (s *Server) OnMessage(ctx context.Context, msg mcp.Message) {
 	}
 
 	switch msg.Method {
+	case "initialize":
+		mcp.Invoke(ctx, msg, s.initialize)
+		return
 	case "resources/list":
 		mcp.Invoke(ctx, msg, s.resourcesList)
 	case "resources/templates/list":
@@ -335,7 +337,24 @@ func (s *Server) resourcesList(ctx context.Context, _ mcp.Message, _ mcp.ListRes
 	return result, nil
 }
 
-func (s *Server) initialize(_ context.Context, _ mcp.Message, params mcp.InitializeRequest) (*mcp.InitializeResult, error) {
+func (s *Server) initialize(ctx context.Context, _ mcp.Message, params mcp.InitializeRequest) (*mcp.InitializeResult, error) {
+	config := types.ConfigFromContext(ctx)
+	agent := config.Agents[s.agentName]
+	servers := slices.Concat(agent.Agents, agent.MCPServers, agent.Prompts, agent.Resources, agent.Tools)
+	go func(servers []string) {
+		// Build the tool mappings on initialization in an effort to speed up the first chat message.
+		// Do so in a goroutine to avoid blocking the initialize response.
+		if _, err := s.runtime.BuildToolMappings(types.WithConfig(
+			mcp.WithSession(
+				context.Background(),
+				mcp.SessionFromContext(ctx),
+			),
+			config,
+		), servers); err != nil {
+			slog.Warn("failed to build tool mappings on initialize", "error", err)
+		}
+	}(servers)
+
 	return &mcp.InitializeResult{
 		ProtocolVersion: params.ProtocolVersion,
 		Capabilities: mcp.ServerCapabilities{

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -188,6 +188,11 @@ func (m *Manager) Acquire(ctx context.Context, server mcp.MessageHandler, id str
 			return nil, false, nil
 		}
 
+		if live.cancel != nil {
+			live.cancel()
+			live.cancel = nil
+		}
+
 		live.count++
 		m.liveSessions[id] = live
 		m.liveSessionsLock.Unlock()
@@ -208,6 +213,10 @@ func (m *Manager) Acquire(ctx context.Context, server mcp.MessageHandler, id str
 	live, ok = m.liveSessions[id]
 	if ok {
 		serverSession.Close(false)
+		if live.cancel != nil {
+			live.cancel()
+			live.cancel = nil
+		}
 		live.count++
 		m.liveSessions[id] = live
 		m.liveSessionsLock.Unlock()

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -239,16 +239,6 @@ func (c *clientFactory) get(envHash string) (*mcp.Client, error) {
 	return c.client, nil
 }
 
-func (c *clientFactory) Close(deleteSession bool) {
-	c.clientLock.Lock()
-	defer c.clientLock.Unlock()
-	if c.client != nil {
-		c.client.Close(deleteSession)
-		c.client = nil
-	}
-	c.envHash = ""
-}
-
 func (c *clientFactory) Serialize() (any, error) {
 	if c.client == nil || c.client.Session.ID() == "" {
 		return nil, nil


### PR DESCRIPTION
This change does a couple of things:
1. It builds the tool mapping on agent initialization in an effort of speeding up the first chat message.
2. Ensures event streams are closed.