### PR TITLE
fix: ensure structuredContent is a JSON object

### DIFF
--- a/pkg/mcp/servertools.go
+++ b/pkg/mcp/servertools.go
@@ -198,9 +198,14 @@ func callResult(object any, err error) (*CallToolResult, error) {
 		return nil, fmt.Errorf("failed to marshal thread data: %w", err)
 	}
 
+	var structuredContent map[string]any
+	if len(dataBytes) > 0 && dataBytes[0] == '{' {
+		_ = json.Unmarshal(dataBytes, &structuredContent)
+	}
+
 	return &CallToolResult{
 		IsError:           false,
-		StructuredContent: object,
+		StructuredContent: structuredContent,
 		Content: []Content{
 			{
 				Type: "text",

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -333,9 +333,9 @@ func (t ToolAnnotations) IsDestructive() bool {
 }
 
 type CallToolResult struct {
-	IsError           bool      `json:"isError"`
-	Content           []Content `json:"content,omitzero"`
-	StructuredContent any       `json:"structuredContent,omitempty"`
+	IsError           bool           `json:"isError"`
+	Content           []Content      `json:"content,omitzero"`
+	StructuredContent map[string]any `json:"structuredContent,omitempty"`
 }
 
 type CallToolRequest struct {

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -638,7 +638,7 @@ func (s *Service) Call(ctx context.Context, server, tool string, args any, opts 
 			return
 		}
 		if ret.StructuredContent == nil && len(ret.Content) == 1 && ret.Content[0].Text != "" {
-			var obj any
+			var obj map[string]any
 			if err := json.Unmarshal([]byte(ret.Content[0].Text), &obj); err == nil {
 				ret.StructuredContent = obj
 			}

--- a/pkg/types/completer.go
+++ b/pkg/types/completer.go
@@ -296,12 +296,12 @@ type ToolCall struct {
 }
 
 type CallResult struct {
-	Content           []mcp.Content `json:"content,omitempty"`
-	IsError           bool          `json:"isError,omitempty"`
-	Agent             string        `json:"agent,omitempty"`
-	Model             string        `json:"model,omitempty"`
-	StopReason        string        `json:"stopReason,omitempty"`
-	StructuredContent any           `json:"structuredContent,omitempty"`
+	Content           []mcp.Content  `json:"content,omitempty"`
+	IsError           bool           `json:"isError,omitempty"`
+	Agent             string         `json:"agent,omitempty"`
+	Model             string         `json:"model,omitempty"`
+	StopReason        string         `json:"stopReason,omitempty"`
+	StructuredContent map[string]any `json:"structuredContent,omitempty"`
 }
 
 type AsyncCallResult struct {


### PR DESCRIPTION
The spec requires that structuredOutput is an object and not an array.