### PR TITLE
fix: add special truncation logic for built-in read tool

### DIFF
--- a/pkg/servers/system/read.go
+++ b/pkg/servers/system/read.go
@@ -21,6 +21,11 @@ const (
 	maxLineLength    = 2000
 	maxPDFPages      = 10
 	maxImageBytes    = 10_000_000 // 10MB
+	// maxReadTextBytes caps the size of a readText result. Beyond this, we return
+	// a notice instructing the model to use bash to read relevant portions instead
+	// of letting the generic tool-result truncator persist the output to disk.
+	// Should be kept in sync with maxToolResultSize in pkg/agents/truncate.go.
+	maxReadTextBytes = 50 * 1024 // 50 KiB
 )
 
 func readText(p ReadParams) (*mcp.CallToolResult, error) {
@@ -88,9 +93,61 @@ func readText(p ReadParams) (*mcp.CallToolResult, error) {
 		}
 	}
 
+	// Determine whether the loop stopped because of the line limit while file
+	// content still remains. We only trip the bash hint for this case when the
+	// caller relied on the default limit (no explicit offset or limit) — when
+	// the caller is paginating intentionally, hitting the limit is expected.
+	hitDefaultLineLimit := linesRead >= limit && p.Limit == nil && p.Offset == nil
+	moreFileContent := false
+	if hitDefaultLineLimit {
+		if _, err := reader.Peek(1); err == nil {
+			moreFileContent = true
+		}
+	}
+
+	if result.Len() > maxReadTextBytes || moreFileContent {
+		return tooLargeReadResult(p, result.Len(), linesRead), nil
+	}
+
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{{Type: "text", Text: result.String()}},
 	}, nil
+}
+
+// tooLargeReadResult returns a CallToolResult that tells the model the read
+// output couldn't return the full file — either because the built output
+// exceeded maxReadTextBytes or because the line limit was hit with more file
+// content remaining — and that it should call read again with offset and
+// limit to fetch specific line ranges. The content is marked with
+// SkipTruncationMetaKey so the generic truncator does not persist it to disk.
+func tooLargeReadResult(p ReadParams, builtBytes, linesReturned int) *mcp.CallToolResult {
+	var fileSize int64 = -1
+	if info, err := os.Stat(p.FilePath); err == nil {
+		fileSize = info.Size()
+	}
+
+	var sizeDesc string
+	if fileSize >= 0 {
+		sizeDesc = fmt.Sprintf("file size %d bytes; ", fileSize)
+	}
+
+	notice := fmt.Sprintf(
+		"File %s is too large to return in full through the read tool "+
+			"(%sreturned %d lines / %d bytes, with more content remaining). "+
+			"Call read again with the `offset` and `limit` parameters to fetch a "+
+			"specific line range (offset is the number of lines to skip from the "+
+			"start of the file, so the first returned line is line offset+1; limit "+
+			"is the maximum number of lines to return).",
+		p.FilePath, sizeDesc, linesReturned, builtBytes,
+	)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{{
+			Type: "text",
+			Text: notice,
+			Meta: map[string]any{types.SkipTruncationMetaKey: true},
+		}},
+	}
 }
 
 func readImage(p ReadParams, mimeType string) (*mcp.CallToolResult, error) {

--- a/pkg/servers/system/read_test.go
+++ b/pkg/servers/system/read_test.go
@@ -66,6 +66,88 @@ func TestRead(t *testing.T) {
 		}
 	})
 
+	t.Run("text too large returns offset/limit hint", func(t *testing.T) {
+		// Build a file whose readText output will exceed maxReadTextBytes.
+		// Each line is ~100 chars; ~600 lines puts us comfortably over 50 KiB.
+		var sb strings.Builder
+		for i := 0; i < 600; i++ {
+			sb.WriteString(strings.Repeat("y", 100))
+			sb.WriteString("\n")
+		}
+		path := write("big.txt", sb.String())
+
+		result, err := s.read(t.Context(), ReadParams{FilePath: path})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(result.Content) != 1 {
+			t.Fatalf("expected single content item, got %d", len(result.Content))
+		}
+		text := result.Content[0].Text
+		if !strings.Contains(text, "too large") || !strings.Contains(text, "offset") || !strings.Contains(text, "limit") {
+			t.Errorf("expected offset/limit hint notice, got %q", text)
+		}
+		if !strings.Contains(text, path) {
+			t.Errorf("expected notice to mention file path, got %q", text)
+		}
+		// Must not include any of the actual file content.
+		if strings.Contains(text, strings.Repeat("y", 100)) {
+			t.Errorf("notice should not contain file contents, got %q", text)
+		}
+		// Must be marked skip-truncation so the agents truncator leaves it alone.
+		skipMeta, _ := result.Content[0].Meta[types.SkipTruncationMetaKey].(bool)
+		if !skipMeta {
+			t.Error("expected skip-truncation meta on oversized read notice")
+		}
+	})
+
+	t.Run("text many short lines triggers offset/limit hint", func(t *testing.T) {
+		// File with more than defaultReadLimit lines, each short enough that the
+		// built result stays well under maxReadTextBytes. Without the line-limit
+		// check, the caller would silently get only the first 2000 lines.
+		var sb strings.Builder
+		for i := 0; i < defaultReadLimit+500; i++ {
+			sb.WriteString("x\n")
+		}
+		path := write("many.txt", sb.String())
+
+		result, err := s.read(t.Context(), ReadParams{FilePath: path})
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := result.Content[0].Text
+		if !strings.Contains(text, "too large") || !strings.Contains(text, "offset") || !strings.Contains(text, "limit") {
+			t.Errorf("expected offset/limit hint notice, got %q", text)
+		}
+		skipMeta, _ := result.Content[0].Meta[types.SkipTruncationMetaKey].(bool)
+		if !skipMeta {
+			t.Error("expected skip-truncation meta on oversized read notice")
+		}
+	})
+
+	t.Run("text explicit pagination returns content", func(t *testing.T) {
+		// Same oversized file, but caller explicitly paginates: the hint
+		// must NOT fire — caller asked for a slice and should get it.
+		var sb strings.Builder
+		for i := 0; i < defaultReadLimit+500; i++ {
+			sb.WriteString("x\n")
+		}
+		path := write("paginated.txt", sb.String())
+		offset, limit := 0, 100
+		result, err := s.read(t.Context(), ReadParams{FilePath: path, Offset: &offset, Limit: &limit})
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := result.Content[0].Text
+		if strings.Contains(text, "too large") {
+			t.Errorf("explicit pagination should not trigger hint, got %q", text)
+		}
+		// Should have exactly 100 line-numbered rows.
+		if got := strings.Count(text, "\tx\n"); got != 100 {
+			t.Errorf("expected 100 lines, got %d", got)
+		}
+	})
+
 	t.Run("text rejects pages", func(t *testing.T) {
 		path := write("t.txt", "x\n")
 		p := "1-5"

--- a/pkg/servers/system/server.go
+++ b/pkg/servers/system/server.go
@@ -517,10 +517,11 @@ func (s *Server) bash(ctx context.Context, params BashParams) (string, error) {
 type ReadParams struct {
 	// FilePath is the absolute path to the file to read.
 	FilePath string `json:"file_path"`
-	// Offset is the line number to start reading from (default beginning of file).
-	// Only applicable to text files.
+	// Offset is the number of lines to skip from the start of the file
+	// (default 0, meaning read from the beginning). The first returned line is
+	// line offset+1. Only applicable to text files.
 	Offset *int `json:"offset,omitempty"`
-	// Limit is the number of lines to read (default 2000).
+	// Limit is the maximum number of lines to return (default 2000).
 	// Only applicable to text files.
 	Limit *int `json:"limit,omitempty"`
 	// Pages is the page range for PDF files (e.g., "1-5", "3", "10-20").


### PR DESCRIPTION
With this change, if the output of the `read` tool surpasses 50 KiB or 2000 lines of text, we return a special message instructing the LLM to use the `offset` and `limit` parameters to read portions of the file at a time.

for https://github.com/obot-platform/obot/issues/5946