### PR TITLE
chore: modify for workflow sharing improvements

### DIFF
--- a/pkg/servers/artifacts/publish.go
+++ b/pkg/servers/artifacts/publish.go
@@ -88,7 +88,7 @@ func (s *Server) publishArtifact(ctx context.Context, params publishArtifactPara
 
 	msg := fmt.Sprintf("Published %s v%d", apiResp.Name, apiResp.LatestVersion)
 	if apiResp.LatestVersion == 1 {
-		msg += ". This artifact is currently private. The user can change visibility to public in the Obot UI."
+		msg += ". This artifact is currently only visible to its owner. The user can add sharing subjects in the Obot UI."
 	}
 
 	return &publishResult{

--- a/pkg/servers/artifacts/publish.go
+++ b/pkg/servers/artifacts/publish.go
@@ -88,7 +88,7 @@ func (s *Server) publishArtifact(ctx context.Context, params publishArtifactPara
 
 	msg := fmt.Sprintf("Published %s v%d", apiResp.Name, apiResp.LatestVersion)
 	if apiResp.LatestVersion == 1 {
-		msg += ". This artifact is currently only visible to its owner. The user can add sharing subjects in the Obot UI."
+		msg += ". This artifact is currently only visible to its owner. Use setArtifactSubjects to share it with users, groups, or all Obot users."
 	}
 
 	return &publishResult{

--- a/pkg/servers/artifacts/search.go
+++ b/pkg/servers/artifacts/search.go
@@ -28,7 +28,10 @@ type searchResultItem struct {
 	ArtifactType  string `json:"artifactType"`
 	AuthorEmail   string `json:"authorEmail,omitempty"`
 	LatestVersion int    `json:"latestVersion"`
-	Visibility    string `json:"visibility"`
+	Subjects      []struct {
+		Type string `json:"type"`
+		ID   string `json:"id"`
+	} `json:"subjects,omitempty"`
 }
 
 func (s *Server) searchArtifacts(ctx context.Context, params searchArtifactsParams) (*searchResult, error) {

--- a/pkg/servers/artifacts/search.go
+++ b/pkg/servers/artifacts/search.go
@@ -28,10 +28,6 @@ type searchResultItem struct {
 	ArtifactType  string `json:"artifactType"`
 	AuthorEmail   string `json:"authorEmail,omitempty"`
 	LatestVersion int    `json:"latestVersion"`
-	Subjects      []struct {
-		Type string `json:"type"`
-		ID   string `json:"id"`
-	} `json:"subjects,omitempty"`
 }
 
 func (s *Server) searchArtifacts(ctx context.Context, params searchArtifactsParams) (*searchResult, error) {

--- a/pkg/servers/artifacts/server.go
+++ b/pkg/servers/artifacts/server.go
@@ -21,6 +21,17 @@ func NewServer() *Server {
 			"Publish a local workflow as a shareable artifact to the Obot registry. "+
 				"Reads the workflow directory, validates the SKILL.md, creates a ZIP, and uploads it.",
 			s.publishArtifact),
+		mcp.NewServerTool("listSubjects",
+			"List Obot users or groups that can be used as workflow-sharing subjects. "+
+				"Set `type` to 'user' or 'group'. "+
+				"Use the optional `query` to filter results by ID or name-like fields; leave it blank to list everything.",
+			s.listSubjects),
+		mcp.NewServerTool("setArtifactSubjects",
+			"Replace the sharing subjects for a published workflow artifact in the Obot registry. "+
+				"Use an empty subject list to make it owner-only again. "+
+				"Supported subject types are 'user', 'group', and 'selector' with id '*'. "+
+				"Use the artifact ID returned by publishArtifact or searchArtifacts.",
+			s.setArtifactSubjects),
 		mcp.NewServerTool("searchArtifacts",
 			"Search the Obot registry for published artifacts (workflows) by keyword query. "+
 				"This searches the REMOTE registry only — it does NOT find locally installed workflows. "+

--- a/pkg/servers/artifacts/server.go
+++ b/pkg/servers/artifacts/server.go
@@ -27,7 +27,8 @@ func NewServer() *Server {
 				"Use the optional `query` to filter results by ID or name-like fields; leave it blank to list everything.",
 			s.listSubjects),
 		mcp.NewServerTool("setArtifactSubjects",
-			"Replace the sharing subjects for a published workflow artifact in the Obot registry. "+
+			"Replace the sharing subjects for a published workflow version in the Obot registry. "+
+				"If version is omitted, the latest version is updated. "+
 				"Use an empty subject list to make it owner-only again. "+
 				"Supported subject types are 'user', 'group', and 'selector' with id '*'. "+
 				"Use the artifact ID returned by publishArtifact or searchArtifacts.",

--- a/pkg/servers/artifacts/sharing.go
+++ b/pkg/servers/artifacts/sharing.go
@@ -1,0 +1,143 @@
+package artifacts
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type setArtifactSubjectsParams struct {
+	ID       string            `json:"id"`
+	Subjects []artifactSubject `json:"subjects,omitempty"`
+}
+
+type artifactSubject struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+type setArtifactSubjectsResult struct {
+	ID       string            `json:"id"`
+	Name     string            `json:"name"`
+	Subjects []artifactSubject `json:"subjects,omitempty"`
+	Message  string            `json:"message"`
+}
+
+func (s *Server) setArtifactSubjects(ctx context.Context, params setArtifactSubjectsParams) (*setArtifactSubjectsResult, error) {
+	if strings.TrimSpace(params.ID) == "" {
+		return nil, fmt.Errorf("id is required")
+	}
+
+	subjects, err := normalizeArtifactSubjects(params.Subjects)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := getObotConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"subjects": subjects,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, cfg.baseURL+"/api/published-artifacts/"+params.ID, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if cfg.authHeader != "" {
+		req.Header.Set("Authorization", cfg.authHeader)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update artifact subjects: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("update artifact subjects failed (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var apiResp struct {
+		ID       string            `json:"id"`
+		Name     string            `json:"name"`
+		Subjects []artifactSubject `json:"subjects,omitempty"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &setArtifactSubjectsResult{
+		ID:       apiResp.ID,
+		Name:     apiResp.Name,
+		Subjects: apiResp.Subjects,
+		Message:  artifactSubjectsMessage(apiResp.Name, apiResp.Subjects),
+	}, nil
+}
+
+func normalizeArtifactSubjects(subjects []artifactSubject) ([]artifactSubject, error) {
+	if len(subjects) == 0 {
+		return nil, nil
+	}
+
+	result := make([]artifactSubject, 0, len(subjects))
+	seen := make(map[artifactSubject]struct{}, len(subjects))
+
+	for _, subject := range subjects {
+		normalized := artifactSubject{
+			Type: strings.ToLower(strings.TrimSpace(subject.Type)),
+			ID:   strings.TrimSpace(subject.ID),
+		}
+
+		switch normalized.Type {
+		case "user", "group":
+			if normalized.ID == "" {
+				return nil, fmt.Errorf("%s subject id is required", normalized.Type)
+			}
+		case "selector":
+			if normalized.ID != "*" {
+				return nil, fmt.Errorf("selector subject id must be '*'")
+			}
+		default:
+			return nil, fmt.Errorf("invalid subject type: %q", subject.Type)
+		}
+
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		result = append(result, normalized)
+	}
+
+	if len(result) > 1 {
+		for _, subject := range result {
+			if subject.Type == "selector" && subject.ID == "*" {
+				return nil, fmt.Errorf("selector '*' must be the only subject")
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func artifactSubjectsMessage(name string, subjects []artifactSubject) string {
+	switch {
+	case len(subjects) == 0:
+		return fmt.Sprintf("Updated sharing for %s. It is now owner-only.", name)
+	case len(subjects) == 1 && subjects[0].Type == "selector" && subjects[0].ID == "*":
+		return fmt.Sprintf("Updated sharing for %s. It is now shared with all Obot users.", name)
+	default:
+		return fmt.Sprintf("Updated sharing for %s with %d subject(s).", name, len(subjects))
+	}
+}

--- a/pkg/servers/artifacts/sharing.go
+++ b/pkg/servers/artifacts/sharing.go
@@ -67,7 +67,7 @@ func (s *Server) setArtifactSubjects(ctx context.Context, params setArtifactSubj
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("update artifact subjects failed (status %d): %s", resp.StatusCode, string(body))
 	}
 

--- a/pkg/servers/artifacts/sharing.go
+++ b/pkg/servers/artifacts/sharing.go
@@ -12,6 +12,7 @@ import (
 
 type setArtifactSubjectsParams struct {
 	ID       string            `json:"id"`
+	Version  *int              `json:"version,omitempty"`
 	Subjects []artifactSubject `json:"subjects,omitempty"`
 }
 
@@ -43,6 +44,7 @@ func (s *Server) setArtifactSubjects(ctx context.Context, params setArtifactSubj
 	}
 
 	body, err := json.Marshal(map[string]any{
+		"version":  params.Version,
 		"subjects": subjects,
 	})
 	if err != nil {
@@ -82,7 +84,7 @@ func (s *Server) setArtifactSubjects(ctx context.Context, params setArtifactSubj
 		ID:       apiResp.ID,
 		Name:     apiResp.Name,
 		Subjects: apiResp.Subjects,
-		Message:  artifactSubjectsMessage(apiResp.Name, apiResp.Subjects),
+		Message:  artifactSubjectsMessage(apiResp.Name, params.Version, apiResp.Subjects),
 	}, nil
 }
 
@@ -131,13 +133,17 @@ func normalizeArtifactSubjects(subjects []artifactSubject) ([]artifactSubject, e
 	return result, nil
 }
 
-func artifactSubjectsMessage(name string, subjects []artifactSubject) string {
+func artifactSubjectsMessage(name string, version *int, subjects []artifactSubject) string {
+	target := name
+	if version != nil {
+		target = fmt.Sprintf("%s v%d", name, *version)
+	}
 	switch {
 	case len(subjects) == 0:
-		return fmt.Sprintf("Updated sharing for %s. It is now owner-only.", name)
+		return fmt.Sprintf("Updated sharing for %s. It is now owner-only.", target)
 	case len(subjects) == 1 && subjects[0].Type == "selector" && subjects[0].ID == "*":
-		return fmt.Sprintf("Updated sharing for %s. It is now shared with all Obot users.", name)
+		return fmt.Sprintf("Updated sharing for %s. It is now shared with all Obot users.", target)
 	default:
-		return fmt.Sprintf("Updated sharing for %s with %d subject(s).", name, len(subjects))
+		return fmt.Sprintf("Updated sharing for %s with %d subject(s).", target, len(subjects))
 	}
 }

--- a/pkg/servers/artifacts/sharing_test.go
+++ b/pkg/servers/artifacts/sharing_test.go
@@ -1,0 +1,126 @@
+package artifacts
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nanobot-ai/nanobot/pkg/mcp"
+)
+
+func artifactTestContext(baseURL string, env map[string]string) context.Context {
+	session := &mcp.Session{}
+	session.SetEnv(map[string]string{
+		"OBOT_URL": baseURL,
+	})
+	session.AddEnv(env)
+	return mcp.WithSession(context.Background(), session)
+}
+
+func TestNormalizeArtifactSubjects(t *testing.T) {
+	subjects, err := normalizeArtifactSubjects([]artifactSubject{
+		{Type: " USER ", ID: " alice "},
+		{Type: "user", ID: "alice"},
+		{Type: "group", ID: "eng"},
+	})
+	if err != nil {
+		t.Fatalf("normalizeArtifactSubjects() error = %v", err)
+	}
+
+	if len(subjects) != 2 {
+		t.Fatalf("expected 2 normalized subjects, got %d", len(subjects))
+	}
+	if subjects[0] != (artifactSubject{Type: "user", ID: "alice"}) {
+		t.Fatalf("unexpected first subject: %+v", subjects[0])
+	}
+	if subjects[1] != (artifactSubject{Type: "group", ID: "eng"}) {
+		t.Fatalf("unexpected second subject: %+v", subjects[1])
+	}
+}
+
+func TestNormalizeArtifactSubjectsRejectsMixedSelector(t *testing.T) {
+	_, err := normalizeArtifactSubjects([]artifactSubject{
+		{Type: "selector", ID: "*"},
+		{Type: "user", ID: "alice"},
+	})
+	if err == nil {
+		t.Fatal("expected error for mixed selector subjects, got nil")
+	}
+}
+
+func TestSetArtifactSubjects(t *testing.T) {
+	var (
+		gotAuthHeader string
+		gotBody       map[string]any
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/api/published-artifacts/pa1" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+
+		gotAuthHeader = r.Header.Get("Authorization")
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed reading body: %v", err)
+		}
+		if err := json.Unmarshal(data, &gotBody); err != nil {
+			t.Fatalf("failed decoding body: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"pa1","name":"code-review","subjects":[{"type":"group","id":"eng"},{"type":"user","id":"alice"}]}`)
+	}))
+	defer ts.Close()
+
+	s := NewServer()
+	result, err := s.setArtifactSubjects(artifactTestContext(ts.URL, map[string]string{
+		"MCP_API_KEY": "secret-token",
+	}), setArtifactSubjectsParams{
+		ID: "pa1",
+		Subjects: []artifactSubject{
+			{Type: "group", ID: "eng"},
+			{Type: "user", ID: "alice"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("setArtifactSubjects() error = %v", err)
+	}
+
+	if gotAuthHeader != "Bearer secret-token" {
+		t.Fatalf("unexpected auth header: %q", gotAuthHeader)
+	}
+	if result.Message != "Updated sharing for code-review with 2 subject(s)." {
+		t.Fatalf("unexpected message: %q", result.Message)
+	}
+
+	rawSubjects, ok := gotBody["subjects"].([]any)
+	if !ok || len(rawSubjects) != 2 {
+		t.Fatalf("unexpected request subjects payload: %#v", gotBody["subjects"])
+	}
+}
+
+func TestSetArtifactSubjectsOwnerOnlyMessage(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"pa1","name":"code-review","subjects":[]}`)
+	}))
+	defer ts.Close()
+
+	s := NewServer()
+	result, err := s.setArtifactSubjects(artifactTestContext(ts.URL, nil), setArtifactSubjectsParams{ID: "pa1"})
+	if err != nil {
+		t.Fatalf("setArtifactSubjects() error = %v", err)
+	}
+
+	if !strings.Contains(result.Message, "owner-only") {
+		t.Fatalf("expected owner-only message, got %q", result.Message)
+	}
+}

--- a/pkg/servers/artifacts/sharing_test.go
+++ b/pkg/servers/artifacts/sharing_test.go
@@ -84,7 +84,8 @@ func TestSetArtifactSubjects(t *testing.T) {
 	result, err := s.setArtifactSubjects(artifactTestContext(ts.URL, map[string]string{
 		"MCP_API_KEY": "secret-token",
 	}), setArtifactSubjectsParams{
-		ID: "pa1",
+		ID:      "pa1",
+		Version: func() *int { v := 2; return &v }(),
 		Subjects: []artifactSubject{
 			{Type: "group", ID: "eng"},
 			{Type: "user", ID: "alice"},
@@ -97,10 +98,13 @@ func TestSetArtifactSubjects(t *testing.T) {
 	if gotAuthHeader != "Bearer secret-token" {
 		t.Fatalf("unexpected auth header: %q", gotAuthHeader)
 	}
-	if result.Message != "Updated sharing for code-review with 2 subject(s)." {
+	if result.Message != "Updated sharing for code-review v2 with 2 subject(s)." {
 		t.Fatalf("unexpected message: %q", result.Message)
 	}
 
+	if gotBody["version"].(float64) != 2 {
+		t.Fatalf("unexpected version payload: %#v", gotBody["version"])
+	}
 	rawSubjects, ok := gotBody["subjects"].([]any)
 	if !ok || len(rawSubjects) != 2 {
 		t.Fatalf("unexpected request subjects payload: %#v", gotBody["subjects"])

--- a/pkg/servers/artifacts/subjects.go
+++ b/pkg/servers/artifacts/subjects.go
@@ -131,7 +131,7 @@ func listGroupSubjects(ctx context.Context, cfg obotConfig, query string) ([]lis
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("list groups failed (status %d): %s", resp.StatusCode, string(body))
 	}
 

--- a/pkg/servers/artifacts/subjects.go
+++ b/pkg/servers/artifacts/subjects.go
@@ -1,0 +1,182 @@
+package artifacts
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type listSubjectsParams struct {
+	Type  string `json:"type"`
+	Query string `json:"query,omitempty"`
+}
+
+type listSubjectsResult struct {
+	Type  string            `json:"type"`
+	Items []listSubjectItem `json:"items"`
+}
+
+type listSubjectItem struct {
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	Name        string `json:"name,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+	Username    string `json:"username,omitempty"`
+	Email       string `json:"email,omitempty"`
+}
+
+func (s *Server) listSubjects(ctx context.Context, params listSubjectsParams) (*listSubjectsResult, error) {
+	cfg, err := getObotConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	subjectType := strings.ToLower(strings.TrimSpace(params.Type))
+	query := strings.TrimSpace(params.Query)
+
+	switch subjectType {
+	case "user":
+		items, err := listUserSubjects(ctx, cfg, query)
+		if err != nil {
+			return nil, err
+		}
+		return &listSubjectsResult{Type: subjectType, Items: items}, nil
+	case "group":
+		items, err := listGroupSubjects(ctx, cfg, query)
+		if err != nil {
+			return nil, err
+		}
+		return &listSubjectsResult{Type: subjectType, Items: items}, nil
+	default:
+		return nil, fmt.Errorf("type must be 'user' or 'group'")
+	}
+}
+
+func listUserSubjects(ctx context.Context, cfg obotConfig, query string) ([]listSubjectItem, error) {
+	u, err := url.Parse(cfg.baseURL + "/api/users")
+	if err != nil {
+		return nil, fmt.Errorf("failed to build users URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	if cfg.authHeader != "" {
+		req.Header.Set("Authorization", cfg.authHeader)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list users: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("list users failed (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var apiResp struct {
+		Items []struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"displayName,omitempty"`
+			Username    string `json:"username,omitempty"`
+			Email       string `json:"email,omitempty"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return nil, fmt.Errorf("failed to parse users response: %w", err)
+	}
+
+	items := make([]listSubjectItem, 0, len(apiResp.Items))
+	for _, item := range apiResp.Items {
+		subject := listSubjectItem{
+			ID:          item.ID,
+			Type:        "user",
+			DisplayName: item.DisplayName,
+			Username:    item.Username,
+			Email:       item.Email,
+		}
+		if subjectMatchesQuery(subject, query) {
+			items = append(items, subject)
+		}
+	}
+
+	return items, nil
+}
+
+func listGroupSubjects(ctx context.Context, cfg obotConfig, query string) ([]listSubjectItem, error) {
+	u, err := url.Parse(cfg.baseURL + "/api/groups")
+	if err != nil {
+		return nil, fmt.Errorf("failed to build groups URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	if cfg.authHeader != "" {
+		req.Header.Set("Authorization", cfg.authHeader)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list groups: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("list groups failed (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var apiResp []struct {
+		ID   string `json:"id"`
+		Name string `json:"name,omitempty"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return nil, fmt.Errorf("failed to parse groups response: %w", err)
+	}
+
+	items := make([]listSubjectItem, 0, len(apiResp))
+	for _, item := range apiResp {
+		subject := listSubjectItem{
+			ID:   item.ID,
+			Type: "group",
+			Name: item.Name,
+		}
+		if subjectMatchesQuery(subject, query) {
+			items = append(items, subject)
+		}
+	}
+
+	return items, nil
+}
+
+func subjectMatchesQuery(item listSubjectItem, query string) bool {
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		return true
+	}
+
+	fields := []string{
+		item.ID,
+		item.Name,
+		item.DisplayName,
+		item.Username,
+		item.Email,
+	}
+
+	for _, field := range fields {
+		if strings.Contains(strings.ToLower(field), query) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/servers/artifacts/subjects_test.go
+++ b/pkg/servers/artifacts/subjects_test.go
@@ -1,0 +1,70 @@
+package artifacts
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListSubjectsUsers(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/users" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"items":[{"id":"1","displayName":"Alice Smith","username":"alice","email":"alice@example.com"},{"id":"2","displayName":"Bob Jones","username":"bob","email":"bob@example.com"}]}`)
+	}))
+	defer ts.Close()
+
+	s := NewServer()
+	result, err := s.listSubjects(artifactTestContext(ts.URL, nil), listSubjectsParams{
+		Type:  "user",
+		Query: "alice",
+	})
+	if err != nil {
+		t.Fatalf("listSubjects() error = %v", err)
+	}
+
+	if len(result.Items) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result.Items))
+	}
+	if result.Items[0].ID != "1" {
+		t.Fatalf("unexpected user id: %q", result.Items[0].ID)
+	}
+}
+
+func TestListSubjectsGroups(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/groups" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[{"id":"okta:eng","name":"Engineering"},{"id":"okta:sales","name":"Sales"}]`)
+	}))
+	defer ts.Close()
+
+	s := NewServer()
+	result, err := s.listSubjects(artifactTestContext(ts.URL, nil), listSubjectsParams{
+		Type:  "group",
+		Query: "eng",
+	})
+	if err != nil {
+		t.Fatalf("listSubjects() error = %v", err)
+	}
+
+	if len(result.Items) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result.Items))
+	}
+	if result.Items[0].ID != "okta:eng" {
+		t.Fatalf("unexpected group id: %q", result.Items[0].ID)
+	}
+}
+
+func TestListSubjectsRejectsInvalidType(t *testing.T) {
+	s := NewServer()
+	_, err := s.listSubjects(artifactTestContext("https://example.com", nil), listSubjectsParams{Type: "team"})
+	if err == nil {
+		t.Fatal("expected error for invalid type, got nil")
+	}
+}

--- a/pkg/servers/system/skills/workflows.md
+++ b/pkg/servers/system/skills/workflows.md
@@ -283,7 +283,14 @@ To publish a workflow, use the `publishArtifact` tool:
 2. Call `publishArtifact` with the workflow directory name. For example: `publishArtifact({ "workflowName": "code-review" })`.
 3. The tool bundles all files in the directory and uploads to Obot. The `SKILL.md` frontmatter is the source of truth for artifact metadata.
 4. The first publish creates version 1. Subsequent publishes of the same workflow create new versions (v2, v3, etc.).
-5. The tool response may mention owner-only sharing for newly published workflows — relay that information to the user. Do NOT assume or state the workflow's sharing subjects unless the tool response explicitly mentions them.
+5. Newly published workflows start owner-only unless the subjects are updated.
+6. To change who the workflow is shared with, use `setArtifactSubjects({ "id": "<artifact-id>", "subjects": [...] })`.
+7. Supported subjects are:
+   - `{ "type": "user", "id": "<user-id>" }`
+   - `{ "type": "group", "id": "<group-id>" }`
+   - `{ "type": "selector", "id": "*" }` for all Obot users
+8. An empty `subjects` list makes the workflow owner-only again.
+9. To find valid user or group IDs before setting subjects, use `listSubjects({ "type": "user" | "group", "query": "..." })`. Leave `query` blank to list everything visible.
 
 ### Searching the Registry
 

--- a/pkg/servers/system/skills/workflows.md
+++ b/pkg/servers/system/skills/workflows.md
@@ -283,7 +283,7 @@ To publish a workflow, use the `publishArtifact` tool:
 2. Call `publishArtifact` with the workflow directory name. For example: `publishArtifact({ "workflowName": "code-review" })`.
 3. The tool bundles all files in the directory and uploads to Obot. The `SKILL.md` frontmatter is the source of truth for artifact metadata.
 4. The first publish creates version 1. Subsequent publishes of the same workflow create new versions (v2, v3, etc.).
-5. The tool response will indicate visibility status when relevant — relay that information to the user. Do NOT assume or state the workflow's visibility unless the tool response explicitly mentions it.
+5. The tool response may mention owner-only sharing for newly published workflows — relay that information to the user. Do NOT assume or state the workflow's sharing subjects unless the tool response explicitly mentions them.
 
 ### Searching the Registry
 

--- a/pkg/servers/system/skills/workflows.md
+++ b/pkg/servers/system/skills/workflows.md
@@ -283,14 +283,15 @@ To publish a workflow, use the `publishArtifact` tool:
 2. Call `publishArtifact` with the workflow directory name. For example: `publishArtifact({ "workflowName": "code-review" })`.
 3. The tool bundles all files in the directory and uploads to Obot. The `SKILL.md` frontmatter is the source of truth for artifact metadata.
 4. The first publish creates version 1. Subsequent publishes of the same workflow create new versions (v2, v3, etc.).
-5. Newly published workflows start owner-only unless the subjects are updated.
-6. To change who the workflow is shared with, use `setArtifactSubjects({ "id": "<artifact-id>", "subjects": [...] })`.
-7. Supported subjects are:
+5. Version 1 starts owner-only unless its subjects are updated.
+6. Each later published version defaults to the previous version's sharing settings.
+7. To change who a specific published version is shared with, use `setArtifactSubjects({ "id": "<artifact-id>", "version": <n>, "subjects": [...] })`. If `version` is omitted, the latest version is updated.
+8. Supported subjects are:
    - `{ "type": "user", "id": "<user-id>" }`
    - `{ "type": "group", "id": "<group-id>" }`
    - `{ "type": "selector", "id": "*" }` for all Obot users
-8. An empty `subjects` list makes the workflow owner-only again.
-9. To find valid user or group IDs before setting subjects, use `listSubjects({ "type": "user" | "group", "query": "..." })`. Leave `query` blank to list everything visible.
+9. An empty `subjects` list makes that version owner-only again.
+10. To find valid user or group IDs before setting subjects, use `listSubjects({ "type": "user" | "group", "query": "..." })`. Leave `query` blank to list everything visible.
 
 ### Searching the Registry
 


### PR DESCRIPTION
The way that artifacts (workflows) are shared in Obot is changing from a simple public/private toggle to subjects (group/user/selector) on a per-version basis. These changes are to support that.

For https://github.com/obot-platform/obot/issues/6255