### PR TITLE
fix: return 500 instead of 503 for permanent health check failure

### DIFF
--- a/pkg/mcp/httpserver.go
+++ b/pkg/mcp/httpserver.go
@@ -264,7 +264,7 @@ func (h *HTTPServer) healthz(rw http.ResponseWriter, req *http.Request) {
 	if healthErr == nil {
 		http.Error(rw, "waiting for startup", http.StatusTooEarly)
 	} else if *healthErr != nil {
-		http.Error(rw, (*healthErr).Error(), http.StatusServiceUnavailable)
+		http.Error(rw, (*healthErr).Error(), http.StatusInternalServerError)
 	} else {
 		rw.WriteHeader(http.StatusOK)
 	}


### PR DESCRIPTION
Change the healthz endpoint to return HTTP 500 (Internal Server Error)
instead of 503 (Service Unavailable) when tool listing permanently
fails. This allows consumers to distinguish nanobot's permanent failure
from transient 503 responses generated by service mesh proxies (e.g.
Istio's envoy) during sidecar startup.

Addresses https://github.com/obot-platform/obot/issues/6326
