### PR TITLE
chore: run biome format and lint fixes across codebase

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,10 +7,7 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"includes": [
-			"**/*",
-			"!packages/*/dist/**/*"
-		]
+		"includes": ["**/*", "!packages/*/dist/**/*"]
 	},
 	"formatter": {
 		"enabled": true,
@@ -19,12 +16,26 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"correctness": {
+				"noUnknownProperty": "off"
+			}
 		}
 	},
 	"javascript": {
 		"formatter": {
 			"quoteStyle": "double"
+		}
+	},
+	"css": {
+		"parser": {
+			"tailwindDirectives": true
+		},
+		"formatter": {
+			"quoteStyle": "single"
+		},
+		"linter": {
+			"enabled": false
 		}
 	},
 	"assist": {

--- a/docs/agents/schemas/agent.frontmatter.schema.json
+++ b/docs/agents/schemas/agent.frontmatter.schema.json
@@ -1,239 +1,239 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://nanobot.dev/schemas/agent.frontmatter.schema.json",
-  "title": "Nanobot Agent Front Matter",
-  "type": "object",
-  "additionalProperties": false,
-  "required": ["name"],
-  "properties": {
-    "name": { "type": "string", "minLength": 1 },
-    "description": { "type": "string" },
-    "metadata": {
-      "type": "object",
-      "description": "Free-form metadata.",
-      "additionalProperties": true,
-      "default": {}
-    },
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://nanobot.dev/schemas/agent.frontmatter.schema.json",
+	"title": "Nanobot Agent Front Matter",
+	"type": "object",
+	"additionalProperties": false,
+	"required": ["name"],
+	"properties": {
+		"name": { "type": "string", "minLength": 1 },
+		"description": { "type": "string" },
+		"metadata": {
+			"type": "object",
+			"description": "Free-form metadata.",
+			"additionalProperties": true,
+			"default": {}
+		},
 
-    "model": { "type": "string" },
-    "allowed_models": {
-      "type": "array",
-      "items": { "type": "string" },
-      "default": []
-    },
-    "temperature": { "type": "number" },
-    "max_tokens": { "type": "integer", "minimum": 1 },
+		"model": { "type": "string" },
+		"allowed_models": {
+			"type": "array",
+			"items": { "type": "string" },
+			"default": []
+		},
+		"temperature": { "type": "number" },
+		"max_tokens": { "type": "integer", "minimum": 1 },
 
-    "tools": {
-      "description": "Tools visible/available to the agent. If omitted, defaults to [\"inherit\"]. Built-ins are logical names (e.g. Read/Write). MCP tools are mcpServer/toolName.",
-      "type": "array",
-      "items": {
-        "oneOf": [
-          { "type": "string", "enum": ["inherit"] },
-          { "type": "string", "minLength": 1 }
-        ]
-      }
-    },
+		"tools": {
+			"description": "Tools visible/available to the agent. If omitted, defaults to [\"inherit\"]. Built-ins are logical names (e.g. Read/Write). MCP tools are mcpServer/toolName.",
+			"type": "array",
+			"items": {
+				"oneOf": [
+					{ "type": "string", "enum": ["inherit"] },
+					{ "type": "string", "minLength": 1 }
+				]
+			}
+		},
 
-    "tool_approvals": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["default"],
-      "properties": {
-        "default": {
-          "description": "Default authorization behavior. Currently only 'approve' is supported.",
-          "type": "string",
-          "enum": ["approve"],
-          "default": "approve"
-        },
-        "rules": {
-          "description": "Ordered allow rules; first matching rule wins.",
-          "type": "array",
-          "items": { "$ref": "#/$defs/toolApprovalRule" },
-          "default": []
-        }
-      }
-    },
+		"tool_approvals": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["default"],
+			"properties": {
+				"default": {
+					"description": "Default authorization behavior. Currently only 'approve' is supported.",
+					"type": "string",
+					"enum": ["approve"],
+					"default": "approve"
+				},
+				"rules": {
+					"description": "Ordered allow rules; first matching rule wins.",
+					"type": "array",
+					"items": { "$ref": "#/$defs/toolApprovalRule" },
+					"default": []
+				}
+			}
+		},
 
-    "skills": {
-      "description": "Skills visible/available to the agent. If omitted, defaults to [\"inherit\"]. Skill IDs are directory names.",
-      "type": "array",
-      "items": {
-        "oneOf": [
-          { "type": "string", "enum": ["inherit"] },
-          { "type": "string", "minLength": 1 }
-        ]
-      }
-    },
+		"skills": {
+			"description": "Skills visible/available to the agent. If omitted, defaults to [\"inherit\"]. Skill IDs are directory names.",
+			"type": "array",
+			"items": {
+				"oneOf": [
+					{ "type": "string", "enum": ["inherit"] },
+					{ "type": "string", "minLength": 1 }
+				]
+			}
+		},
 
-    "tasks": {
-      "description": "Tasks visible/available to the agent (task IDs are directory paths under .nanobot/tasks).",
-      "type": "array",
-      "items": { "type": "string", "minLength": 1 },
-      "default": ["inherit"]
-    },
+		"tasks": {
+			"description": "Tasks visible/available to the agent (task IDs are directory paths under .nanobot/tasks).",
+			"type": "array",
+			"items": { "type": "string", "minLength": 1 },
+			"default": ["inherit"]
+		},
 
-    "task_approvals": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["default"],
-      "properties": {
-        "default": {
-          "description": "Default task authorization behavior. Currently only 'approve' is supported.",
-          "type": "string",
-          "enum": ["approve"],
-          "default": "approve"
-        },
-        "rules": {
-          "description": "Ordered allow rules; first matching rule wins.",
-          "type": "array",
-          "items": { "$ref": "#/$defs/taskApprovalRule" },
-          "default": []
-        }
-      }
-    }
-  },
+		"task_approvals": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["default"],
+			"properties": {
+				"default": {
+					"description": "Default task authorization behavior. Currently only 'approve' is supported.",
+					"type": "string",
+					"enum": ["approve"],
+					"default": "approve"
+				},
+				"rules": {
+					"description": "Ordered allow rules; first matching rule wins.",
+					"type": "array",
+					"items": { "$ref": "#/$defs/taskApprovalRule" },
+					"default": []
+				}
+			}
+		}
+	},
 
-  "$defs": {
-    "toolApprovalRule": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["tool", "allow"],
-      "properties": {
-        "tool": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Tool identifier (must match an entry in tools)."
-        },
-        "allow": { "type": "boolean" },
-        "when": {
-          "description": "Optional matchers keyed by tool argument name.",
-          "type": "object",
-          "additionalProperties": { "$ref": "#/$defs/matcher" }
-        }
-      }
-    },
+	"$defs": {
+		"toolApprovalRule": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["tool", "allow"],
+			"properties": {
+				"tool": {
+					"type": "string",
+					"minLength": 1,
+					"description": "Tool identifier (must match an entry in tools)."
+				},
+				"allow": { "type": "boolean" },
+				"when": {
+					"description": "Optional matchers keyed by tool argument name.",
+					"type": "object",
+					"additionalProperties": { "$ref": "#/$defs/matcher" }
+				}
+			}
+		},
 
-    "taskApprovalRule": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["task", "allow"],
-      "properties": {
-        "task": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Task identifier (must match an entry in tasks)."
-        },
-        "allow": { "type": "boolean" },
-        "when": {
-          "description": "Optional matchers keyed by task input name.",
-          "type": "object",
-          "additionalProperties": { "$ref": "#/$defs/matcher" }
-        }
-      }
-    },
+		"taskApprovalRule": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["task", "allow"],
+			"properties": {
+				"task": {
+					"type": "string",
+					"minLength": 1,
+					"description": "Task identifier (must match an entry in tasks)."
+				},
+				"allow": { "type": "boolean" },
+				"when": {
+					"description": "Optional matchers keyed by task input name.",
+					"type": "object",
+					"additionalProperties": { "$ref": "#/$defs/matcher" }
+				}
+			}
+		},
 
-    "matcher": {
-      "description": "A value matcher for a tool argument key.",
-      "oneOf": [
-        { "$ref": "#/$defs/equalsMatcher" },
-        { "$ref": "#/$defs/inMatcher" },
-        { "$ref": "#/$defs/startsWithMatcher" },
-        { "$ref": "#/$defs/matchesMatcher" },
-        { "$ref": "#/$defs/containsMatcher" },
-        { "$ref": "#/$defs/containsAllMatcher" },
-        { "$ref": "#/$defs/anyOfMatcher" },
-        { "$ref": "#/$defs/allOfMatcher" }
-      ]
-    },
+		"matcher": {
+			"description": "A value matcher for a tool argument key.",
+			"oneOf": [
+				{ "$ref": "#/$defs/equalsMatcher" },
+				{ "$ref": "#/$defs/inMatcher" },
+				{ "$ref": "#/$defs/startsWithMatcher" },
+				{ "$ref": "#/$defs/matchesMatcher" },
+				{ "$ref": "#/$defs/containsMatcher" },
+				{ "$ref": "#/$defs/containsAllMatcher" },
+				{ "$ref": "#/$defs/anyOfMatcher" },
+				{ "$ref": "#/$defs/allOfMatcher" }
+			]
+		},
 
-    "equalsMatcher": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["equals"],
-      "properties": {
-        "equals": {}
-      }
-    },
+		"equalsMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["equals"],
+			"properties": {
+				"equals": {}
+			}
+		},
 
-    "inMatcher": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["in"],
-      "properties": {
-        "in": {
-          "type": "array",
-          "items": {}
-        }
-      }
-    },
+		"inMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["in"],
+			"properties": {
+				"in": {
+					"type": "array",
+					"items": {}
+				}
+			}
+		},
 
-    "startsWithMatcher": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["startsWith"],
-      "properties": {
-        "startsWith": { "type": "string" }
-      }
-    },
+		"startsWithMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["startsWith"],
+			"properties": {
+				"startsWith": { "type": "string" }
+			}
+		},
 
-    "matchesMatcher": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["matches"],
-      "properties": {
-        "matches": {
-          "type": "string",
-          "description": "Regex string."
-        }
-      }
-    },
+		"matchesMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["matches"],
+			"properties": {
+				"matches": {
+					"type": "string",
+					"description": "Regex string."
+				}
+			}
+		},
 
-    "containsMatcher": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["contains"],
-      "properties": {
-        "contains": {}
-      }
-    },
+		"containsMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["contains"],
+			"properties": {
+				"contains": {}
+			}
+		},
 
-    "containsAllMatcher": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["containsAll"],
-      "properties": {
-        "containsAll": {
-          "type": "array",
-          "items": {}
-        }
-      }
-    },
+		"containsAllMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["containsAll"],
+			"properties": {
+				"containsAll": {
+					"type": "array",
+					"items": {}
+				}
+			}
+		},
 
-    "anyOfMatcher": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["anyOf"],
-      "properties": {
-        "anyOf": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/$defs/matcher" }
-        }
-      }
-    },
+		"anyOfMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["anyOf"],
+			"properties": {
+				"anyOf": {
+					"type": "array",
+					"minItems": 1,
+					"items": { "$ref": "#/$defs/matcher" }
+				}
+			}
+		},
 
-    "allOfMatcher": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["allOf"],
-      "properties": {
-        "allOf": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/$defs/matcher" }
-        }
-      }
-    }
-  }
+		"allOfMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["allOf"],
+			"properties": {
+				"allOf": {
+					"type": "array",
+					"minItems": 1,
+					"items": { "$ref": "#/$defs/matcher" }
+				}
+			}
+		}
+	}
 }

--- a/docs/agents/schemas/mcp.schema.json
+++ b/docs/agents/schemas/mcp.schema.json
@@ -1,76 +1,76 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://nanobot.dev/schemas/mcp.schema.json",
-  "title": "Nanobot MCP Configuration",
-  "type": "object",
-  "additionalProperties": false,
-  "required": ["mcpServers"],
-  "properties": {
-    "mcpServers": {
-      "description": "Map of MCP server name -> server configuration.",
-      "type": "object",
-      "additionalProperties": { "$ref": "#/$defs/mcpServerConfig" },
-      "default": {}
-    },
-    "mcpRegistries": {
-      "description": "Map of registry name -> registry configuration.",
-      "type": "object",
-      "additionalProperties": { "$ref": "#/$defs/mcpRegistryConfig" },
-      "default": {}
-    }
-  },
-  "$defs": {
-    "mcpServerConfig": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["command"],
-      "properties": {
-        "command": {
-          "description": "Executable used to start the MCP server.",
-          "type": "string",
-          "minLength": 1
-        },
-        "args": {
-          "description": "Arguments passed to the command.",
-          "type": "array",
-          "items": { "type": "string" },
-          "default": []
-        },
-        "env": {
-          "description": "Environment variables for the MCP server process.",
-          "type": "object",
-          "additionalProperties": { "type": "string" },
-          "default": {}
-        },
-        "cwd": {
-          "description": "Optional working directory for the MCP server process.",
-          "type": "string"
-        },
-        "allow_tools": {
-          "description": "Optional allowlist of tool names exposed by this server (toolName portion of server/toolName). If omitted, all server tools are available to be authorized by agents.",
-          "type": "array",
-          "items": { "type": "string", "minLength": 1 }
-        },
-        "timeout_ms": {
-          "description": "Startup/connection timeout.",
-          "type": "integer",
-          "minimum": 0,
-          "default": 30000
-        }
-      }
-    },
-    "mcpRegistryConfig": {
-      "description": "A registry pointing at a standard MCP registry endpoint.",
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["url"],
-      "properties": {
-        "url": {
-          "description": "Base URL of the MCP registry.",
-          "type": "string",
-          "minLength": 1
-        }
-      }
-    }
-  }
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://nanobot.dev/schemas/mcp.schema.json",
+	"title": "Nanobot MCP Configuration",
+	"type": "object",
+	"additionalProperties": false,
+	"required": ["mcpServers"],
+	"properties": {
+		"mcpServers": {
+			"description": "Map of MCP server name -> server configuration.",
+			"type": "object",
+			"additionalProperties": { "$ref": "#/$defs/mcpServerConfig" },
+			"default": {}
+		},
+		"mcpRegistries": {
+			"description": "Map of registry name -> registry configuration.",
+			"type": "object",
+			"additionalProperties": { "$ref": "#/$defs/mcpRegistryConfig" },
+			"default": {}
+		}
+	},
+	"$defs": {
+		"mcpServerConfig": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["command"],
+			"properties": {
+				"command": {
+					"description": "Executable used to start the MCP server.",
+					"type": "string",
+					"minLength": 1
+				},
+				"args": {
+					"description": "Arguments passed to the command.",
+					"type": "array",
+					"items": { "type": "string" },
+					"default": []
+				},
+				"env": {
+					"description": "Environment variables for the MCP server process.",
+					"type": "object",
+					"additionalProperties": { "type": "string" },
+					"default": {}
+				},
+				"cwd": {
+					"description": "Optional working directory for the MCP server process.",
+					"type": "string"
+				},
+				"allow_tools": {
+					"description": "Optional allowlist of tool names exposed by this server (toolName portion of server/toolName). If omitted, all server tools are available to be authorized by agents.",
+					"type": "array",
+					"items": { "type": "string", "minLength": 1 }
+				},
+				"timeout_ms": {
+					"description": "Startup/connection timeout.",
+					"type": "integer",
+					"minimum": 0,
+					"default": 30000
+				}
+			}
+		},
+		"mcpRegistryConfig": {
+			"description": "A registry pointing at a standard MCP registry endpoint.",
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["url"],
+			"properties": {
+				"url": {
+					"description": "Base URL of the MCP registry.",
+					"type": "string",
+					"minLength": 1
+				}
+			}
+		}
+	}
 }

--- a/docs/agents/schemas/skill.frontmatter.schema.json
+++ b/docs/agents/schemas/skill.frontmatter.schema.json
@@ -1,253 +1,253 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://nanobot.dev/schemas/skill.frontmatter.schema.json",
-  "title": "Nanobot Skill Front Matter (Agent Skills compatible)",
-  "type": "object",
-  "additionalProperties": false,
-  "required": ["name", "description"],
-  "properties": {
-    "name": {
-      "type": "string",
-      "minLength": 1,
-      "maxLength": 64,
-      "pattern": "^(?!-)(?!.*--)[a-z0-9-]+(?<!-)$",
-      "description": "Must be 1-64 chars, lowercase letters/numbers/hyphens, no leading/trailing hyphen, no consecutive hyphens. Must also match directory name (enforced outside JSON Schema)."
-    },
-    "description": {
-      "type": "string",
-      "minLength": 1,
-      "maxLength": 1024,
-      "description": "Describe what the skill does and when to use it."
-    },
-    "license": {
-      "type": "string",
-      "description": "License name or reference to bundled license file."
-    },
-    "compatibility": {
-      "type": "string",
-      "minLength": 1,
-      "maxLength": 500,
-      "description": "Environment requirements (product, packages, network access, etc.)."
-    },
-    "metadata": {
-      "type": "object",
-      "description": "Arbitrary key-value mapping.",
-      "additionalProperties": {
-        "oneOf": [
-          { "type": "string" },
-          { "type": "number" },
-          { "type": "integer" },
-          { "type": "boolean" }
-        ]
-      },
-      "default": {}
-    },
-    "allowed-tools": {
-      "type": "string",
-      "description": "Space-delimited list of pre-approved tools (experimental). E.g. 'Bash(git:*) Read'."
-    },
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://nanobot.dev/schemas/skill.frontmatter.schema.json",
+	"title": "Nanobot Skill Front Matter (Agent Skills compatible)",
+	"type": "object",
+	"additionalProperties": false,
+	"required": ["name", "description"],
+	"properties": {
+		"name": {
+			"type": "string",
+			"minLength": 1,
+			"maxLength": 64,
+			"pattern": "^(?!-)(?!.*--)[a-z0-9-]+(?<!-)$",
+			"description": "Must be 1-64 chars, lowercase letters/numbers/hyphens, no leading/trailing hyphen, no consecutive hyphens. Must also match directory name (enforced outside JSON Schema)."
+		},
+		"description": {
+			"type": "string",
+			"minLength": 1,
+			"maxLength": 1024,
+			"description": "Describe what the skill does and when to use it."
+		},
+		"license": {
+			"type": "string",
+			"description": "License name or reference to bundled license file."
+		},
+		"compatibility": {
+			"type": "string",
+			"minLength": 1,
+			"maxLength": 500,
+			"description": "Environment requirements (product, packages, network access, etc.)."
+		},
+		"metadata": {
+			"type": "object",
+			"description": "Arbitrary key-value mapping.",
+			"additionalProperties": {
+				"oneOf": [
+					{ "type": "string" },
+					{ "type": "number" },
+					{ "type": "integer" },
+					{ "type": "boolean" }
+				]
+			},
+			"default": {}
+		},
+		"allowed-tools": {
+			"type": "string",
+			"description": "Space-delimited list of pre-approved tools (experimental). E.g. 'Bash(git:*) Read'."
+		},
 
-    "tools": {
-      "description": "Nanobot extension: tools visible/available while executing this skill. If omitted, defaults to [\"inherit\"].",
-      "type": "array",
-      "items": {
-        "oneOf": [
-          { "type": "string", "enum": ["inherit"] },
-          { "type": "string", "minLength": 1 }
-        ]
-      }
-    },
+		"tools": {
+			"description": "Nanobot extension: tools visible/available while executing this skill. If omitted, defaults to [\"inherit\"].",
+			"type": "array",
+			"items": {
+				"oneOf": [
+					{ "type": "string", "enum": ["inherit"] },
+					{ "type": "string", "minLength": 1 }
+				]
+			}
+		},
 
-    "tool_approvals": {
-      "description": "Nanobot extension: tool approval policy while executing this skill.",
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["default"],
-      "properties": {
-        "default": {
-          "description": "Default authorization behavior. Currently only 'approve' is supported.",
-          "type": "string",
-          "enum": ["approve"],
-          "default": "approve"
-        },
-        "rules": {
-          "description": "Ordered allow rules; first matching rule wins.",
-          "type": "array",
-          "items": { "$ref": "#/$defs/toolApprovalRule" },
-          "default": []
-        }
-      }
-    },
+		"tool_approvals": {
+			"description": "Nanobot extension: tool approval policy while executing this skill.",
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["default"],
+			"properties": {
+				"default": {
+					"description": "Default authorization behavior. Currently only 'approve' is supported.",
+					"type": "string",
+					"enum": ["approve"],
+					"default": "approve"
+				},
+				"rules": {
+					"description": "Ordered allow rules; first matching rule wins.",
+					"type": "array",
+					"items": { "$ref": "#/$defs/toolApprovalRule" },
+					"default": []
+				}
+			}
+		},
 
-    "skills": {
-      "description": "Nanobot extension: skills visible/available while executing this skill. If omitted, defaults to [\"inherit\"].",
-      "type": "array",
-      "items": {
-        "oneOf": [
-          { "type": "string", "enum": ["inherit"] },
-          { "type": "string", "minLength": 1 }
-        ]
-      }
-    },
+		"skills": {
+			"description": "Nanobot extension: skills visible/available while executing this skill. If omitted, defaults to [\"inherit\"].",
+			"type": "array",
+			"items": {
+				"oneOf": [
+					{ "type": "string", "enum": ["inherit"] },
+					{ "type": "string", "minLength": 1 }
+				]
+			}
+		},
 
-    "tasks": {
-      "description": "Nanobot extension: tasks visible/available while executing this skill (task IDs are directory paths under .nanobot/tasks).",
-      "type": "array",
-      "items": { "type": "string", "minLength": 1 },
-      "default": ["inherit"]
-    },
+		"tasks": {
+			"description": "Nanobot extension: tasks visible/available while executing this skill (task IDs are directory paths under .nanobot/tasks).",
+			"type": "array",
+			"items": { "type": "string", "minLength": 1 },
+			"default": ["inherit"]
+		},
 
-    "task_approvals": {
-      "description": "Nanobot extension: task approval policy while executing this skill.",
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["default"],
-      "properties": {
-        "default": {
-          "description": "Default task authorization behavior. Currently only 'approve' is supported.",
-          "type": "string",
-          "enum": ["approve"],
-          "default": "approve"
-        },
-        "rules": {
-          "description": "Ordered allow rules; first matching rule wins.",
-          "type": "array",
-          "items": { "$ref": "#/$defs/taskApprovalRule" },
-          "default": []
-        }
-      }
-    }
-  },
+		"task_approvals": {
+			"description": "Nanobot extension: task approval policy while executing this skill.",
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["default"],
+			"properties": {
+				"default": {
+					"description": "Default task authorization behavior. Currently only 'approve' is supported.",
+					"type": "string",
+					"enum": ["approve"],
+					"default": "approve"
+				},
+				"rules": {
+					"description": "Ordered allow rules; first matching rule wins.",
+					"type": "array",
+					"items": { "$ref": "#/$defs/taskApprovalRule" },
+					"default": []
+				}
+			}
+		}
+	},
 
-  "$defs": {
-    "toolApprovalRule": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["tool", "allow"],
-      "properties": {
-        "tool": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Tool identifier (must match an entry in tools)."
-        },
-        "allow": { "type": "boolean" },
-        "when": {
-          "description": "Optional matchers keyed by tool argument name.",
-          "type": "object",
-          "additionalProperties": { "$ref": "#/$defs/matcher" }
-        }
-      }
-    },
+	"$defs": {
+		"toolApprovalRule": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["tool", "allow"],
+			"properties": {
+				"tool": {
+					"type": "string",
+					"minLength": 1,
+					"description": "Tool identifier (must match an entry in tools)."
+				},
+				"allow": { "type": "boolean" },
+				"when": {
+					"description": "Optional matchers keyed by tool argument name.",
+					"type": "object",
+					"additionalProperties": { "$ref": "#/$defs/matcher" }
+				}
+			}
+		},
 
-    "taskApprovalRule": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["task", "allow"],
-      "properties": {
-        "task": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Task identifier (must match an entry in tasks)."
-        },
-        "allow": { "type": "boolean" },
-        "when": {
-          "description": "Optional matchers keyed by task input name.",
-          "type": "object",
-          "additionalProperties": { "$ref": "#/$defs/matcher" }
-        }
-      }
-    },
+		"taskApprovalRule": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["task", "allow"],
+			"properties": {
+				"task": {
+					"type": "string",
+					"minLength": 1,
+					"description": "Task identifier (must match an entry in tasks)."
+				},
+				"allow": { "type": "boolean" },
+				"when": {
+					"description": "Optional matchers keyed by task input name.",
+					"type": "object",
+					"additionalProperties": { "$ref": "#/$defs/matcher" }
+				}
+			}
+		},
 
-    "matcher": {
-      "description": "A value matcher for a tool argument key.",
-      "oneOf": [
-        { "$ref": "#/$defs/equalsMatcher" },
-        { "$ref": "#/$defs/inMatcher" },
-        { "$ref": "#/$defs/startsWithMatcher" },
-        { "$ref": "#/$defs/matchesMatcher" },
-        { "$ref": "#/$defs/containsMatcher" },
-        { "$ref": "#/$defs/containsAllMatcher" },
-        { "$ref": "#/$defs/anyOfMatcher" },
-        { "$ref": "#/$defs/allOfMatcher" }
-      ]
-    },
+		"matcher": {
+			"description": "A value matcher for a tool argument key.",
+			"oneOf": [
+				{ "$ref": "#/$defs/equalsMatcher" },
+				{ "$ref": "#/$defs/inMatcher" },
+				{ "$ref": "#/$defs/startsWithMatcher" },
+				{ "$ref": "#/$defs/matchesMatcher" },
+				{ "$ref": "#/$defs/containsMatcher" },
+				{ "$ref": "#/$defs/containsAllMatcher" },
+				{ "$ref": "#/$defs/anyOfMatcher" },
+				{ "$ref": "#/$defs/allOfMatcher" }
+			]
+		},
 
-    "equalsMatcher": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["equals"],
-      "properties": { "equals": {} }
-    },
+		"equalsMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["equals"],
+			"properties": { "equals": {} }
+		},
 
-    "inMatcher": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["in"],
-      "properties": {
-        "in": {
-          "type": "array",
-          "items": {}
-        }
-      }
-    },
+		"inMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["in"],
+			"properties": {
+				"in": {
+					"type": "array",
+					"items": {}
+				}
+			}
+		},
 
-    "startsWithMatcher": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["startsWith"],
-      "properties": { "startsWith": { "type": "string" } }
-    },
+		"startsWithMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["startsWith"],
+			"properties": { "startsWith": { "type": "string" } }
+		},
 
-    "matchesMatcher": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["matches"],
-      "properties": { "matches": { "type": "string" } }
-    },
+		"matchesMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["matches"],
+			"properties": { "matches": { "type": "string" } }
+		},
 
-    "containsMatcher": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["contains"],
-      "properties": { "contains": {} }
-    },
+		"containsMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["contains"],
+			"properties": { "contains": {} }
+		},
 
-    "containsAllMatcher": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["containsAll"],
-      "properties": {
-        "containsAll": {
-          "type": "array",
-          "items": {}
-        }
-      }
-    },
+		"containsAllMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["containsAll"],
+			"properties": {
+				"containsAll": {
+					"type": "array",
+					"items": {}
+				}
+			}
+		},
 
-    "anyOfMatcher": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["anyOf"],
-      "properties": {
-        "anyOf": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/$defs/matcher" }
-        }
-      }
-    },
+		"anyOfMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["anyOf"],
+			"properties": {
+				"anyOf": {
+					"type": "array",
+					"minItems": 1,
+					"items": { "$ref": "#/$defs/matcher" }
+				}
+			}
+		},
 
-    "allOfMatcher": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["allOf"],
-      "properties": {
-        "allOf": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/$defs/matcher" }
-        }
-      }
-    }
-  }
+		"allOfMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["allOf"],
+			"properties": {
+				"allOf": {
+					"type": "array",
+					"minItems": 1,
+					"items": { "$ref": "#/$defs/matcher" }
+				}
+			}
+		}
+	}
 }

--- a/docs/agents/schemas/task.frontmatter.schema.json
+++ b/docs/agents/schemas/task.frontmatter.schema.json
@@ -1,145 +1,219 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://nanobot.dev/schemas/task.frontmatter.schema.json",
-  "title": "Nanobot Task Front Matter (TASK.md only)",
-  "type": "object",
-  "additionalProperties": false,
-  "required": ["name"],
-  "properties": {
-    "name": { "type": "string", "minLength": 1 },
-    "description": { "type": "string" },
-    "metadata": {
-      "type": "object",
-      "description": "Free-form metadata.",
-      "additionalProperties": true,
-      "default": {}
-    },
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://nanobot.dev/schemas/task.frontmatter.schema.json",
+	"title": "Nanobot Task Front Matter (TASK.md only)",
+	"type": "object",
+	"additionalProperties": false,
+	"required": ["name"],
+	"properties": {
+		"name": { "type": "string", "minLength": 1 },
+		"description": { "type": "string" },
+		"metadata": {
+			"type": "object",
+			"description": "Free-form metadata.",
+			"additionalProperties": true,
+			"default": {}
+		},
 
-    "agent": {
-      "description": "Agent ID to execute this task with.",
-      "type": "string",
-      "minLength": 1
-    },
+		"agent": {
+			"description": "Agent ID to execute this task with.",
+			"type": "string",
+			"minLength": 1
+		},
 
-    "tools": {
-      "description": "Tools visible/available while executing this task. If omitted, defaults to [\"inherit\"].",
-      "type": "array",
-      "items": {
-        "oneOf": [
-          { "type": "string", "enum": ["inherit"] },
-          { "type": "string", "minLength": 1 }
-        ]
-      }
-    },
+		"tools": {
+			"description": "Tools visible/available while executing this task. If omitted, defaults to [\"inherit\"].",
+			"type": "array",
+			"items": {
+				"oneOf": [
+					{ "type": "string", "enum": ["inherit"] },
+					{ "type": "string", "minLength": 1 }
+				]
+			}
+		},
 
-    "tool_approvals": {
-      "description": "Tool approval policy while executing this task.",
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["default"],
-      "properties": {
-        "default": { "type": "string", "enum": ["approve"], "default": "approve" },
-        "rules": { "type": "array", "items": { "$ref": "#/$defs/toolApprovalRule" }, "default": [] }
-      }
-    },
+		"tool_approvals": {
+			"description": "Tool approval policy while executing this task.",
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["default"],
+			"properties": {
+				"default": {
+					"type": "string",
+					"enum": ["approve"],
+					"default": "approve"
+				},
+				"rules": {
+					"type": "array",
+					"items": { "$ref": "#/$defs/toolApprovalRule" },
+					"default": []
+				}
+			}
+		},
 
-    "tasks": {
-      "description": "Tasks visible/available while executing this task (task IDs are directory paths under .nanobot/tasks).",
-      "type": "array",
-      "items": { "type": "string", "minLength": 1 },
-      "default": ["inherit"]
-    },
+		"tasks": {
+			"description": "Tasks visible/available while executing this task (task IDs are directory paths under .nanobot/tasks).",
+			"type": "array",
+			"items": { "type": "string", "minLength": 1 },
+			"default": ["inherit"]
+		},
 
-    "task_approvals": {
-      "description": "Task approval policy while executing this task.",
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["default"],
-      "properties": {
-        "default": { "type": "string", "enum": ["approve"], "default": "approve" },
-        "rules": { "type": "array", "items": { "$ref": "#/$defs/taskApprovalRule" }, "default": [] }
-      }
-    },
+		"task_approvals": {
+			"description": "Task approval policy while executing this task.",
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["default"],
+			"properties": {
+				"default": {
+					"type": "string",
+					"enum": ["approve"],
+					"default": "approve"
+				},
+				"rules": {
+					"type": "array",
+					"items": { "$ref": "#/$defs/taskApprovalRule" },
+					"default": []
+				}
+			}
+		},
 
-    "inputs": {
-      "description": "Task inputs (TASK.md only).",
-      "type": "array",
-      "items": { "$ref": "#/$defs/taskInput" },
-      "default": []
-    },
+		"inputs": {
+			"description": "Task inputs (TASK.md only).",
+			"type": "array",
+			"items": { "$ref": "#/$defs/taskInput" },
+			"default": []
+		},
 
-    "next": {
-      "description": "Relative path to the next step markdown file within the same task directory.",
-      "type": "string",
-      "minLength": 1
-    }
-  },
+		"next": {
+			"description": "Relative path to the next step markdown file within the same task directory.",
+			"type": "string",
+			"minLength": 1
+		}
+	},
 
-  "$defs": {
-    "taskInput": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "description"],
-      "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Input name."
-        },
-        "description": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Describe what the input means and expected format."
-        },
-        "default": {
-          "type": "string",
-          "description": "Optional default value (string)."
-        }
-      }
-    },
+	"$defs": {
+		"taskInput": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["name", "description"],
+			"properties": {
+				"name": {
+					"type": "string",
+					"minLength": 1,
+					"description": "Input name."
+				},
+				"description": {
+					"type": "string",
+					"minLength": 1,
+					"description": "Describe what the input means and expected format."
+				},
+				"default": {
+					"type": "string",
+					"description": "Optional default value (string)."
+				}
+			}
+		},
 
-    "toolApprovalRule": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["tool", "allow"],
-      "properties": {
-        "tool": { "type": "string", "minLength": 1 },
-        "allow": { "type": "boolean" },
-        "when": { "type": "object", "additionalProperties": { "$ref": "#/$defs/matcher" } }
-      }
-    },
+		"toolApprovalRule": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["tool", "allow"],
+			"properties": {
+				"tool": { "type": "string", "minLength": 1 },
+				"allow": { "type": "boolean" },
+				"when": {
+					"type": "object",
+					"additionalProperties": { "$ref": "#/$defs/matcher" }
+				}
+			}
+		},
 
-    "taskApprovalRule": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["task", "allow"],
-      "properties": {
-        "task": { "type": "string", "minLength": 1 },
-        "allow": { "type": "boolean" },
-        "when": { "type": "object", "additionalProperties": { "$ref": "#/$defs/matcher" } }
-      }
-    },
+		"taskApprovalRule": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["task", "allow"],
+			"properties": {
+				"task": { "type": "string", "minLength": 1 },
+				"allow": { "type": "boolean" },
+				"when": {
+					"type": "object",
+					"additionalProperties": { "$ref": "#/$defs/matcher" }
+				}
+			}
+		},
 
-    "matcher": {
-      "oneOf": [
-        { "$ref": "#/$defs/equalsMatcher" },
-        { "$ref": "#/$defs/inMatcher" },
-        { "$ref": "#/$defs/startsWithMatcher" },
-        { "$ref": "#/$defs/matchesMatcher" },
-        { "$ref": "#/$defs/containsMatcher" },
-        { "$ref": "#/$defs/containsAllMatcher" },
-        { "$ref": "#/$defs/anyOfMatcher" },
-        { "$ref": "#/$defs/allOfMatcher" }
-      ]
-    },
+		"matcher": {
+			"oneOf": [
+				{ "$ref": "#/$defs/equalsMatcher" },
+				{ "$ref": "#/$defs/inMatcher" },
+				{ "$ref": "#/$defs/startsWithMatcher" },
+				{ "$ref": "#/$defs/matchesMatcher" },
+				{ "$ref": "#/$defs/containsMatcher" },
+				{ "$ref": "#/$defs/containsAllMatcher" },
+				{ "$ref": "#/$defs/anyOfMatcher" },
+				{ "$ref": "#/$defs/allOfMatcher" }
+			]
+		},
 
-    "equalsMatcher": { "type": "object", "additionalProperties": false, "required": ["equals"], "properties": { "equals": {} } },
-    "inMatcher": { "type": "object", "additionalProperties": false, "required": ["in"], "properties": { "in": { "type": "array", "items": {} } } },
-    "startsWithMatcher": { "type": "object", "additionalProperties": false, "required": ["startsWith"], "properties": { "startsWith": { "type": "string" } } },
-    "matchesMatcher": { "type": "object", "additionalProperties": false, "required": ["matches"], "properties": { "matches": { "type": "string" } } },
-    "containsMatcher": { "type": "object", "additionalProperties": false, "required": ["contains"], "properties": { "contains": {} } },
-    "containsAllMatcher": { "type": "object", "additionalProperties": false, "required": ["containsAll"], "properties": { "containsAll": { "type": "array", "items": {} } } },
-    "anyOfMatcher": { "type": "object", "additionalProperties": false, "required": ["anyOf"], "properties": { "anyOf": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/matcher" } } } },
-    "allOfMatcher": { "type": "object", "additionalProperties": false, "required": ["allOf"], "properties": { "allOf": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/matcher" } } } }
-  }
+		"equalsMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["equals"],
+			"properties": { "equals": {} }
+		},
+		"inMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["in"],
+			"properties": { "in": { "type": "array", "items": {} } }
+		},
+		"startsWithMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["startsWith"],
+			"properties": { "startsWith": { "type": "string" } }
+		},
+		"matchesMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["matches"],
+			"properties": { "matches": { "type": "string" } }
+		},
+		"containsMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["contains"],
+			"properties": { "contains": {} }
+		},
+		"containsAllMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["containsAll"],
+			"properties": { "containsAll": { "type": "array", "items": {} } }
+		},
+		"anyOfMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["anyOf"],
+			"properties": {
+				"anyOf": {
+					"type": "array",
+					"minItems": 1,
+					"items": { "$ref": "#/$defs/matcher" }
+				}
+			}
+		},
+		"allOfMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["allOf"],
+			"properties": {
+				"allOf": {
+					"type": "array",
+					"minItems": 1,
+					"items": { "$ref": "#/$defs/matcher" }
+				}
+			}
+		}
+	}
 }

--- a/docs/agents/schemas/task.step.frontmatter.schema.json
+++ b/docs/agents/schemas/task.step.frontmatter.schema.json
@@ -1,114 +1,180 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://nanobot.dev/schemas/task.step.frontmatter.schema.json",
-  "title": "Nanobot Task Step Front Matter",
-  "type": "object",
-  "additionalProperties": false,
-  "required": ["name"],
-  "properties": {
-    "name": { "type": "string", "minLength": 1 },
-    "description": { "type": "string" },
-    "metadata": {
-      "type": "object",
-      "description": "Free-form metadata.",
-      "additionalProperties": true,
-      "default": {}
-    },
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://nanobot.dev/schemas/task.step.frontmatter.schema.json",
+	"title": "Nanobot Task Step Front Matter",
+	"type": "object",
+	"additionalProperties": false,
+	"required": ["name"],
+	"properties": {
+		"name": { "type": "string", "minLength": 1 },
+		"description": { "type": "string" },
+		"metadata": {
+			"type": "object",
+			"description": "Free-form metadata.",
+			"additionalProperties": true,
+			"default": {}
+		},
 
-    "agent": {
-      "description": "Agent ID to execute this step with.",
-      "type": "string",
-      "minLength": 1
-    },
+		"agent": {
+			"description": "Agent ID to execute this step with.",
+			"type": "string",
+			"minLength": 1
+		},
 
-    "tools": {
-      "description": "Tools visible/available while executing this step. If omitted, defaults to [\"inherit\"].",
-      "type": "array",
-      "items": {
-        "oneOf": [
-          { "type": "string", "enum": ["inherit"] },
-          { "type": "string", "minLength": 1 }
-        ]
-      }
-    },
+		"tools": {
+			"description": "Tools visible/available while executing this step. If omitted, defaults to [\"inherit\"].",
+			"type": "array",
+			"items": {
+				"oneOf": [
+					{ "type": "string", "enum": ["inherit"] },
+					{ "type": "string", "minLength": 1 }
+				]
+			}
+		},
 
-    "tool_approvals": {
-      "description": "Tool approval policy while executing this step.",
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["default"],
-      "properties": {
-        "default": { "type": "string", "enum": ["approve"], "default": "approve" },
-        "rules": { "type": "array", "items": { "$ref": "#/$defs/toolApprovalRule" }, "default": [] }
-      }
-    },
+		"tool_approvals": {
+			"description": "Tool approval policy while executing this step.",
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["default"],
+			"properties": {
+				"default": {
+					"type": "string",
+					"enum": ["approve"],
+					"default": "approve"
+				},
+				"rules": {
+					"type": "array",
+					"items": { "$ref": "#/$defs/toolApprovalRule" },
+					"default": []
+				}
+			}
+		},
 
-    "skills": {
-      "description": "Skills visible/available while executing this step. If omitted, defaults to [\"inherit\"].",
-      "type": "array",
-      "items": {
-        "oneOf": [
-          { "type": "string", "enum": ["inherit"] },
-          { "type": "string", "minLength": 1 }
-        ]
-      }
-    },
+		"skills": {
+			"description": "Skills visible/available while executing this step. If omitted, defaults to [\"inherit\"].",
+			"type": "array",
+			"items": {
+				"oneOf": [
+					{ "type": "string", "enum": ["inherit"] },
+					{ "type": "string", "minLength": 1 }
+				]
+			}
+		},
 
-    "tasks": {
-      "description": "Tasks visible/available while executing this step (task IDs are directory paths under .nanobot/tasks).",
-      "type": "array",
-      "items": { "type": "string", "minLength": 1 },
-      "default": ["inherit"]
-    },
+		"tasks": {
+			"description": "Tasks visible/available while executing this step (task IDs are directory paths under .nanobot/tasks).",
+			"type": "array",
+			"items": { "type": "string", "minLength": 1 },
+			"default": ["inherit"]
+		},
 
-    "next": {
-      "description": "Relative path to the next step markdown file within the same task directory.",
-      "type": "string",
-      "minLength": 1
-    }
-  },
+		"next": {
+			"description": "Relative path to the next step markdown file within the same task directory.",
+			"type": "string",
+			"minLength": 1
+		}
+	},
 
-  "$defs": {
-    "toolApprovalRule": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["tool", "allow"],
-      "properties": {
-        "tool": { "type": "string", "minLength": 1 },
-        "allow": { "type": "boolean" },
-        "when": { "type": "object", "additionalProperties": { "$ref": "#/$defs/matcher" } }
-      }
-    },
-    "taskApprovalRule": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["task", "allow"],
-      "properties": {
-        "task": { "type": "string", "minLength": 1 },
-        "allow": { "type": "boolean" },
-        "when": { "type": "object", "additionalProperties": { "$ref": "#/$defs/matcher" } }
-      }
-    },
+	"$defs": {
+		"toolApprovalRule": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["tool", "allow"],
+			"properties": {
+				"tool": { "type": "string", "minLength": 1 },
+				"allow": { "type": "boolean" },
+				"when": {
+					"type": "object",
+					"additionalProperties": { "$ref": "#/$defs/matcher" }
+				}
+			}
+		},
+		"taskApprovalRule": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["task", "allow"],
+			"properties": {
+				"task": { "type": "string", "minLength": 1 },
+				"allow": { "type": "boolean" },
+				"when": {
+					"type": "object",
+					"additionalProperties": { "$ref": "#/$defs/matcher" }
+				}
+			}
+		},
 
-    "matcher": {
-      "oneOf": [
-        { "$ref": "#/$defs/equalsMatcher" },
-        { "$ref": "#/$defs/inMatcher" },
-        { "$ref": "#/$defs/startsWithMatcher" },
-        { "$ref": "#/$defs/matchesMatcher" },
-        { "$ref": "#/$defs/containsMatcher" },
-        { "$ref": "#/$defs/containsAllMatcher" },
-        { "$ref": "#/$defs/anyOfMatcher" },
-        { "$ref": "#/$defs/allOfMatcher" }
-      ]
-    },
-    "equalsMatcher": { "type": "object", "additionalProperties": false, "required": ["equals"], "properties": { "equals": {} } },
-    "inMatcher": { "type": "object", "additionalProperties": false, "required": ["in"], "properties": { "in": { "type": "array", "items": {} } } },
-    "startsWithMatcher": { "type": "object", "additionalProperties": false, "required": ["startsWith"], "properties": { "startsWith": { "type": "string" } } },
-    "matchesMatcher": { "type": "object", "additionalProperties": false, "required": ["matches"], "properties": { "matches": { "type": "string" } } },
-    "containsMatcher": { "type": "object", "additionalProperties": false, "required": ["contains"], "properties": { "contains": {} } },
-    "containsAllMatcher": { "type": "object", "additionalProperties": false, "required": ["containsAll"], "properties": { "containsAll": { "type": "array", "items": {} } } },
-    "anyOfMatcher": { "type": "object", "additionalProperties": false, "required": ["anyOf"], "properties": { "anyOf": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/matcher" } } } },
-    "allOfMatcher": { "type": "object", "additionalProperties": false, "required": ["allOf"], "properties": { "allOf": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/matcher" } } } }
-  }
+		"matcher": {
+			"oneOf": [
+				{ "$ref": "#/$defs/equalsMatcher" },
+				{ "$ref": "#/$defs/inMatcher" },
+				{ "$ref": "#/$defs/startsWithMatcher" },
+				{ "$ref": "#/$defs/matchesMatcher" },
+				{ "$ref": "#/$defs/containsMatcher" },
+				{ "$ref": "#/$defs/containsAllMatcher" },
+				{ "$ref": "#/$defs/anyOfMatcher" },
+				{ "$ref": "#/$defs/allOfMatcher" }
+			]
+		},
+		"equalsMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["equals"],
+			"properties": { "equals": {} }
+		},
+		"inMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["in"],
+			"properties": { "in": { "type": "array", "items": {} } }
+		},
+		"startsWithMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["startsWith"],
+			"properties": { "startsWith": { "type": "string" } }
+		},
+		"matchesMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["matches"],
+			"properties": { "matches": { "type": "string" } }
+		},
+		"containsMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["contains"],
+			"properties": { "contains": {} }
+		},
+		"containsAllMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["containsAll"],
+			"properties": { "containsAll": { "type": "array", "items": {} } }
+		},
+		"anyOfMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["anyOf"],
+			"properties": {
+				"anyOf": {
+					"type": "array",
+					"minItems": 1,
+					"items": { "$ref": "#/$defs/matcher" }
+				}
+			}
+		},
+		"allOfMatcher": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["allOf"],
+			"properties": {
+				"allOf": {
+					"type": "array",
+					"minItems": 1,
+					"items": { "$ref": "#/$defs/matcher" }
+				}
+			}
+		}
+	}
 }

--- a/packages/ui/eslint.config.js
+++ b/packages/ui/eslint.config.js
@@ -1,13 +1,13 @@
-import prettier from 'eslint-config-prettier';
-import { includeIgnoreFile } from '@eslint/compat';
-import js from '@eslint/js';
-import svelte from 'eslint-plugin-svelte';
-import globals from 'globals';
-import { fileURLToPath } from 'node:url';
-import ts from 'typescript-eslint';
-import svelteConfig from './svelte.config.js';
+import { fileURLToPath } from "node:url";
+import { includeIgnoreFile } from "@eslint/compat";
+import js from "@eslint/js";
+import prettier from "eslint-config-prettier";
+import svelte from "eslint-plugin-svelte";
+import globals from "globals";
+import ts from "typescript-eslint";
+import svelteConfig from "./svelte.config.js";
 
-const gitignorePath = fileURLToPath(new URL('./.gitignore', import.meta.url));
+const gitignorePath = fileURLToPath(new URL("./.gitignore", import.meta.url));
 
 export default ts.config(
 	includeIgnoreFile(gitignorePath),
@@ -18,27 +18,30 @@ export default ts.config(
 	...svelte.configs.prettier,
 	{
 		languageOptions: {
-			globals: { ...globals.browser, ...globals.node }
+			globals: { ...globals.browser, ...globals.node },
 		},
 		rules: {
 			// typescript-eslint strongly recommend that you do not use the no-undef lint rule on TypeScript projects.
 			// see: https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
-			'no-undef': 'off',
+			"no-undef": "off",
 			// Allow @html for markdown rendering - content is processed through trusted markdown parser
-			'svelte/no-at-html-tags': 'off',
+			"svelte/no-at-html-tags": "off",
 			// Allow unused variables with underscore prefix
-			'@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }]
-		}
+			"@typescript-eslint/no-unused-vars": [
+				"error",
+				{ argsIgnorePattern: "^_" },
+			],
+		},
 	},
 	{
-		files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],
+		files: ["**/*.svelte", "**/*.svelte.ts", "**/*.svelte.js"],
 		languageOptions: {
 			parserOptions: {
 				projectService: true,
-				extraFileExtensions: ['.svelte'],
+				extraFileExtensions: [".svelte"],
 				parser: ts.parser,
-				svelteConfig
-			}
-		}
-	}
+				svelteConfig,
+			},
+		},
+	},
 );

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -1,13 +1,13 @@
 @import 'tailwindcss';
 @import 'highlight.js/styles/atom-one-dark.css';
-@plugin "@tailwindcss/typography";
+@plugin '@tailwindcss/typography';
 
-@plugin "daisyui" {
+@plugin 'daisyui' {
 	themes:
 		nanobotlight --default,
 		nanobotdark --prefersdark;
 }
-@plugin "daisyui/theme" {
+@plugin 'daisyui/theme' {
 	name: 'nanobotlight';
 	default: true;
 	prefersdark: false;
@@ -41,10 +41,10 @@
 	--border: 1px;
 	--depth: 0;
 	--noise: 0;
-	--logo-url: /assets/nanobot.svg;
+	--logo-url: url('/assets/nanobot.svg');
 }
 
-@plugin "daisyui/theme" {
+@plugin 'daisyui/theme' {
 	name: 'nanobotdark';
 	default: false;
 	prefersdark: true;
@@ -78,7 +78,7 @@
 	--border: 1px;
 	--depth: 0;
 	--noise: 0;
-	--logo-url: /assets/nanobot_dark.svg;
+	--logo-url: url('/assets/nanobot_dark.svg');
 }
 
 /* Enhanced code block styling */

--- a/packages/ui/src/app.d.ts
+++ b/packages/ui/src/app.d.ts
@@ -1,8 +1,8 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
-import type { ChatService } from '$lib/chat.svelte';
+import type { ChatService } from "$lib/chat.svelte";
 
-declare module '@novnc/novnc/lib/rfb.js' {
+declare module "@novnc/novnc/lib/rfb.js" {
 	const RFB: any;
 	export default RFB;
 }
@@ -18,5 +18,3 @@ declare global {
 		// interface Platform {}
 	}
 }
-
-export {};

--- a/packages/ui/src/lib/chat.svelte.ts
+++ b/packages/ui/src/lib/chat.svelte.ts
@@ -2,13 +2,12 @@ import { SvelteDate, SvelteSet } from "svelte/reactivity";
 import { getNotificationContext } from "./context/notifications.svelte";
 import { SimpleClient } from "./mcpclient";
 import {
-	ChatPath,
-	UIPath,
 	type Agent,
 	type Agents,
 	type Attachment,
 	type Chat,
 	type ChatMessage,
+	ChatPath,
 	type ChatRequest,
 	type ChatResult,
 	type Elicitation,
@@ -20,6 +19,7 @@ import {
 	type ResourceContents,
 	type Resources,
 	type ToolOutputItem,
+	UIPath,
 	type UploadedFile,
 	type UploadingFile,
 } from "./types";
@@ -247,11 +247,14 @@ export class ChatAPI {
 			created: now(),
 			items: [
 				{
-					id: request.id + "_0",
+					id: `${request.id}_0`,
 					type: "text",
 					text: request.message,
 				},
-				...buildFileAttachmentPreviewItems(request.id, request.attachments || []),
+				...buildFileAttachmentPreviewItems(
+					request.id,
+					request.attachments || [],
+				),
 			],
 		};
 		return {
@@ -326,7 +329,7 @@ export class ChatAPI {
 
 		for (const type of opts?.events ?? []) {
 			eventSource.addEventListener(type, (e) => {
-				const idInt = parseInt(e.lastEventId);
+				const idInt = parseInt(e.lastEventId, 10);
 				const event: Event = {
 					id: idInt || e.lastEventId,
 					type: type as
@@ -426,7 +429,10 @@ function attachmentPreviewName(attachment: Attachment): string | undefined {
 	return decodedPath.split("/").filter(Boolean).pop() || decodedPath;
 }
 
-function buildFileAttachmentPreviewItems(messageID: string, attachments: Attachment[]) {
+function buildFileAttachmentPreviewItems(
+	messageID: string,
+	attachments: Attachment[],
+) {
 	const seen = new SvelteSet<string>();
 	return attachments
 		.filter((attachment) => {
@@ -510,13 +516,13 @@ export class ChatService {
 		}
 
 		this.listResources({ useDefaultSession: true }).then((r) => {
-			if (r && r.resources) {
+			if (r?.resources) {
 				this.resources = r.resources;
 			}
 		});
 
 		this.listPrompts({ useDefaultSession: true }).then((prompts) => {
-			if (prompts && prompts.prompts) {
+			if (prompts?.prompts) {
 				this.prompts = prompts.prompts;
 			}
 		});
@@ -585,26 +591,26 @@ export class ChatService {
 		this.closer = this.api.subscribe(
 			chatId,
 			(event) => {
-				if (event.type == "message" && event.message?.id) {
+				if (event.type === "message" && event.message?.id) {
 					if (this.history) {
 						this.history = appendMessage(this.history, event.message);
 					} else {
 						this.messages = appendMessage(this.messages, event.message);
 					}
-				} else if (event.type == "history-start") {
+				} else if (event.type === "history-start") {
 					this.history = [];
-				} else if (event.type == "history-end") {
+				} else if (event.type === "history-end") {
 					this.messages = this.history || [];
 					this.history = undefined;
-				} else if (event.type == "chat-in-progress") {
+				} else if (event.type === "chat-in-progress") {
 					this.isLoading = true;
-				} else if (event.type == "chat-done") {
+				} else if (event.type === "chat-done") {
 					this.isLoading = false;
 					for (const waiting of this.onChatDone) {
 						waiting();
 					}
 					this.onChatDone = [];
-				} else if (event.type == "elicitation/create") {
+				} else if (event.type === "elicitation/create") {
 					this.elicitations = [
 						...this.elicitations,
 						{
@@ -681,7 +687,7 @@ export class ChatService {
 			this.uploadedFiles = [];
 
 			this.messages = appendMessage(this.messages, result.message);
-			return new Promise<ChatResult | void>((resolve) => {
+			return new Promise<ChatResult | undefined>((resolve) => {
 				this.onChatDone.push(() => {
 					this.isLoading = false;
 					this.currentRequestId = undefined;

--- a/packages/ui/src/lib/components/AgentHeader.svelte
+++ b/packages/ui/src/lib/components/AgentHeader.svelte
@@ -1,45 +1,52 @@
 <script lang="ts">
-	import type { Agent, Attachment, ChatResult } from '$lib/types';
-	import { onMount } from 'svelte';
+import { onMount } from "svelte";
+import type { Agent, Attachment, ChatResult } from "$lib/types";
 
-	interface Props {
-		onSend?: (message: string, attachments?: Attachment[]) => Promise<ChatResult | void>;
-		agent?: Agent;
-	}
+interface Props {
+	onSend?: (
+		message: string,
+		attachments?: Attachment[],
+	) => Promise<ChatResult | undefined>;
+	agent?: Agent;
+}
 
-	let { onSend, agent }: Props = $props();
+const { onSend, agent }: Props = $props();
 
-	let imgRef = $state<HTMLImageElement>();
+const imgRef = $state<HTMLImageElement>();
 
-	onMount(() => {
-		const target = document.documentElement;
-		const observer = new MutationObserver((mutations) => {
-			for (const mutation of mutations) {
-				if (mutation.type === 'attributes' && mutation.attributeName === 'data-theme') {
-					updateLogo();
-				}
+onMount(() => {
+	const target = document.documentElement;
+	const observer = new MutationObserver((mutations) => {
+		for (const mutation of mutations) {
+			if (
+				mutation.type === "attributes" &&
+				mutation.attributeName === "data-theme"
+			) {
+				updateLogo();
 			}
-		});
-
-		observer.observe(target, {
-			attributes: true,
-			attributeFilter: ['data-theme']
-		});
+		}
 	});
 
-	function updateLogo() {
-		const isDark = document.documentElement.getAttribute('data-theme') === 'black';
-		const url = isDark ? agent?.iconDark || agent?.icon : agent?.icon;
-		if (url && imgRef) {
-			imgRef.src = url;
-		}
+	observer.observe(target, {
+		attributes: true,
+		attributeFilter: ["data-theme"],
+	});
+});
+
+function updateLogo() {
+	const isDark =
+		document.documentElement.getAttribute("data-theme") === "black";
+	const url = isDark ? agent?.iconDark || agent?.icon : agent?.icon;
+	if (url && imgRef) {
+		imgRef.src = url;
 	}
+}
 
-	$effect(() => {
-		if (imgRef) {
-			updateLogo();
-		}
-	});
+$effect(() => {
+	if (imgRef) {
+		updateLogo();
+	}
+});
 </script>
 
 <div class="flex flex-col items-center p-8 pt-20">

--- a/packages/ui/src/lib/components/BrowserViewer.svelte
+++ b/packages/ui/src/lib/components/BrowserViewer.svelte
@@ -1,270 +1,277 @@
 <script lang="ts">
-	import { onDestroy } from 'svelte';
-	import { Monitor, X, Maximize2, Minimize2 } from '@lucide/svelte';
-	import RFB from '@novnc/novnc/lib/rfb.js';
+import RFB from "@novnc/novnc/lib/rfb.js";
+import { onDestroy } from "svelte";
 
-	interface Props {
-		vncUrl?: string;
-		visible?: boolean;
+interface Props {
+	vncUrl?: string;
+	visible?: boolean;
+}
+
+function defaultVNCUrl() {
+	if (typeof window === "undefined") {
+		return "ws://localhost/browser";
 	}
 
-	function defaultVNCUrl() {
-		if (typeof window === 'undefined') {
-			return 'ws://localhost/browser';
-		}
+	const url = new URL("/browser", window.location.origin);
+	url.protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+	return url.toString();
+}
 
-		const url = new URL('/browser', window.location.origin);
-		url.protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-		return url.toString();
-	}
+const { vncUrl = defaultVNCUrl(), visible = $bindable(true) }: Props = $props();
 
-	let { vncUrl = defaultVNCUrl(), visible = $bindable(true) }: Props = $props();
+const container = $state<HTMLDivElement | undefined>(undefined);
+let rfb = $state<RFB | null>(null);
+let _connected = $state(false);
+let connecting = $state(false);
+let _error = $state<string | null>(null);
+let _isFullscreen = $state(false);
+let activeVNCUrl = $state<string | null>(null);
+let resizeTimer: ReturnType<typeof setTimeout> | null = null;
+let lastRequestedSize = $state<string | null>(null);
+let viewerActive = $state(false);
 
-	let container = $state<HTMLDivElement | undefined>(undefined);
-	let rfb = $state<RFB | null>(null);
-	let connected = $state(false);
-	let connecting = $state(false);
-	let error = $state<string | null>(null);
-	let isFullscreen = $state(false);
-	let activeVNCUrl = $state<string | null>(null);
-	let resizeTimer: ReturnType<typeof setTimeout> | null = null;
-	let lastRequestedSize = $state<string | null>(null);
-	let viewerActive = $state(false);
+async function connect() {
+	if (!container || rfb || connecting) return;
 
-	async function connect() {
-		if (!container || rfb || connecting) return;
+	connecting = true;
+	_error = null;
 
-		connecting = true;
-		error = null;
+	try {
+		const nextRfb = new RFB(container, vncUrl);
+		rfb = nextRfb;
+		activeVNCUrl = vncUrl;
 
-		try {
-			const nextRfb = new RFB(container, vncUrl);
-			rfb = nextRfb;
-			activeVNCUrl = vncUrl;
-
-			nextRfb.addEventListener('connect', () => {
-				if (rfb !== nextRfb) return;
-				connected = true;
-				connecting = false;
-				error = null;
-			});
-
-			nextRfb.addEventListener('disconnect', () => {
-				if (rfb === nextRfb) {
-					rfb = null;
-					activeVNCUrl = null;
-				}
-				connected = false;
-				connecting = false;
-			});
-
-			nextRfb.addEventListener('credentialsrequired', () => {
-				if (rfb !== nextRfb) return;
-				connecting = false;
-				error = 'Password required (but none configured)';
-			});
-
-			nextRfb.addEventListener('securityfailure', (e) => {
-				if (rfb !== nextRfb) return;
-				connecting = false;
-				error = `Security failure: ${e.detail.status}`;
-			});
-
-			nextRfb.scaleViewport = true;
-			nextRfb.resizeSession = true;
-			nextRfb.dragViewport = false;
-			nextRfb.clipViewport = false;
-		} catch (err) {
-			rfb = null;
-			activeVNCUrl = null;
+		nextRfb.addEventListener("connect", () => {
+			if (rfb !== nextRfb) return;
+			_connected = true;
 			connecting = false;
-			error = err instanceof Error ? err.message : 'Connection failed';
-		}
-	}
-
-	function disconnect() {
-		if (rfb) {
-			rfb.disconnect();
-		}
-		rfb = null;
-		activeVNCUrl = null;
-		connected = false;
-		connecting = false;
-	}
-
-	async function syncRemoteClipboard(text: string) {
-		if (!text || !rfb) return;
-		rfb.focus();
-		rfb.clipboardPasteFrom(text);
-	}
-
-	function sendRemotePasteShortcut() {
-		if (!rfb) return;
-		rfb.focus();
-		rfb.sendKey(0xffe3, 'ControlLeft', true);
-		rfb.sendKey(0x0076, 'KeyV', true);
-		rfb.sendKey(0x0076, 'KeyV', false);
-		rfb.sendKey(0xffe3, 'ControlLeft', false);
-	}
-
-	async function handleLocalPaste() {
-		if (!viewerActive || !rfb || typeof navigator === 'undefined' || !navigator.clipboard) {
-			return;
-		}
-
-		try {
-			const text = await navigator.clipboard.readText();
-			await syncRemoteClipboard(text);
-			sendRemotePasteShortcut();
-		} catch {
-			// Clipboard reads are permission-gated in the browser; ignore failures.
-		}
-	}
-
-	function resizeUrl(currentVNCUrl: string) {
-		const url = new URL(currentVNCUrl);
-		url.protocol = url.protocol === 'wss:' ? 'https:' : 'http:';
-		url.pathname = `${url.pathname.replace(/\/$/, '')}/resize`;
-		url.search = '';
-		url.hash = '';
-		return url.toString();
-	}
-
-	function queueResize(width: number, height: number) {
-		const targetWidth = Math.max(640, Math.ceil(width * window.devicePixelRatio));
-		const targetHeight = Math.max(480, Math.ceil(height * window.devicePixelRatio));
-		const sizeKey = `${targetWidth}x${targetHeight}`;
-		if (sizeKey === lastRequestedSize) return;
-
-		if (resizeTimer) {
-			clearTimeout(resizeTimer);
-		}
-
-		resizeTimer = setTimeout(async () => {
-			try {
-				const response = await fetch(resizeUrl(vncUrl), {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-					},
-					body: JSON.stringify({
-						width: targetWidth,
-						height: targetHeight,
-					}),
-				});
-
-				if (!response.ok) {
-					throw new Error(`resize failed: ${response.status}`);
-				}
-
-				lastRequestedSize = sizeKey;
-			} catch {
-				// Resize is best-effort and should not disrupt the viewer.
-			}
-		}, 150);
-	}
-
-	function toggleFullscreen() {
-		if (!container) return;
-
-		if (!document.fullscreenElement) {
-			container.requestFullscreen();
-			isFullscreen = true;
-		} else {
-			document.exitFullscreen();
-			isFullscreen = false;
-		}
-	}
-
-	onDestroy(() => {
-		if (resizeTimer) {
-			clearTimeout(resizeTimer);
-		}
-		disconnect();
-	});
-
-	$effect(() => {
-		if (!visible || !container || typeof ResizeObserver === 'undefined') {
-			return;
-		}
-
-		const observer = new ResizeObserver((entries) => {
-			const entry = entries[0];
-			if (!entry) return;
-			queueResize(entry.contentRect.width, entry.contentRect.height);
+			_error = null;
 		});
 
-		observer.observe(container);
-		const rect = container.getBoundingClientRect();
-		queueResize(rect.width, rect.height);
+		nextRfb.addEventListener("disconnect", () => {
+			if (rfb === nextRfb) {
+				rfb = null;
+				activeVNCUrl = null;
+			}
+			_connected = false;
+			connecting = false;
+		});
 
-		return () => {
-			observer.disconnect();
-		};
-	});
+		nextRfb.addEventListener("credentialsrequired", () => {
+			if (rfb !== nextRfb) return;
+			connecting = false;
+			_error = "Password required (but none configured)";
+		});
 
-	$effect(() => {
-		if (!visible || !container) {
-			viewerActive = false;
-			return;
-		}
+		nextRfb.addEventListener("securityfailure", (e) => {
+			if (rfb !== nextRfb) return;
+			connecting = false;
+			_error = `Security failure: ${e.detail.status}`;
+		});
 
-		const handlePointerDown = (event: PointerEvent) => {
-			if (!container) return;
-			viewerActive = container.contains(event.target as Node);
-		};
+		nextRfb.scaleViewport = true;
+		nextRfb.resizeSession = true;
+		nextRfb.dragViewport = false;
+		nextRfb.clipViewport = false;
+	} catch (err) {
+		rfb = null;
+		activeVNCUrl = null;
+		connecting = false;
+		_error = err instanceof Error ? err.message : "Connection failed";
+	}
+}
 
-		const handlePaste = async (event: ClipboardEvent) => {
-			if (!viewerActive || !rfb) return;
+function disconnect() {
+	if (rfb) {
+		rfb.disconnect();
+	}
+	rfb = null;
+	activeVNCUrl = null;
+	_connected = false;
+	connecting = false;
+}
 
-			const text = event.clipboardData?.getData('text/plain') ?? '';
-			if (!text) return;
+async function syncRemoteClipboard(text: string) {
+	if (!text || !rfb) return;
+	rfb.focus();
+	rfb.clipboardPasteFrom(text);
+}
 
-			event.preventDefault();
-			await syncRemoteClipboard(text);
-			sendRemotePasteShortcut();
-		};
+function sendRemotePasteShortcut() {
+	if (!rfb) return;
+	rfb.focus();
+	rfb.sendKey(0xffe3, "ControlLeft", true);
+	rfb.sendKey(0x0076, "KeyV", true);
+	rfb.sendKey(0x0076, "KeyV", false);
+	rfb.sendKey(0xffe3, "ControlLeft", false);
+}
 
-		const handleKeyDown = async (event: KeyboardEvent) => {
-			const modifierPressed = event.metaKey || event.ctrlKey;
-			if (!viewerActive || !modifierPressed || event.key.toLowerCase() !== 'v') {
-				return;
+async function handleLocalPaste() {
+	if (
+		!viewerActive ||
+		!rfb ||
+		typeof navigator === "undefined" ||
+		!navigator.clipboard
+	) {
+		return;
+	}
+
+	try {
+		const text = await navigator.clipboard.readText();
+		await syncRemoteClipboard(text);
+		sendRemotePasteShortcut();
+	} catch {
+		// Clipboard reads are permission-gated in the browser; ignore failures.
+	}
+}
+
+function resizeUrl(currentVNCUrl: string) {
+	const url = new URL(currentVNCUrl);
+	url.protocol = url.protocol === "wss:" ? "https:" : "http:";
+	url.pathname = `${url.pathname.replace(/\/$/, "")}/resize`;
+	url.search = "";
+	url.hash = "";
+	return url.toString();
+}
+
+function queueResize(width: number, height: number) {
+	const targetWidth = Math.max(640, Math.ceil(width * window.devicePixelRatio));
+	const targetHeight = Math.max(
+		480,
+		Math.ceil(height * window.devicePixelRatio),
+	);
+	const sizeKey = `${targetWidth}x${targetHeight}`;
+	if (sizeKey === lastRequestedSize) return;
+
+	if (resizeTimer) {
+		clearTimeout(resizeTimer);
+	}
+
+	resizeTimer = setTimeout(async () => {
+		try {
+			const response = await fetch(resizeUrl(vncUrl), {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					width: targetWidth,
+					height: targetHeight,
+				}),
+			});
+
+			if (!response.ok) {
+				throw new Error(`resize failed: ${response.status}`);
 			}
 
-			event.preventDefault();
-			await handleLocalPaste();
-		};
+			lastRequestedSize = sizeKey;
+		} catch {
+			// Resize is best-effort and should not disrupt the viewer.
+		}
+	}, 150);
+}
 
-		document.addEventListener('pointerdown', handlePointerDown, true);
-		window.addEventListener('paste', handlePaste);
-		window.addEventListener('keydown', handleKeyDown, true);
+function _toggleFullscreen() {
+	if (!container) return;
 
-		return () => {
-			document.removeEventListener('pointerdown', handlePointerDown, true);
-			window.removeEventListener('paste', handlePaste);
-			window.removeEventListener('keydown', handleKeyDown, true);
-		};
+	if (!document.fullscreenElement) {
+		container.requestFullscreen();
+		_isFullscreen = true;
+	} else {
+		document.exitFullscreen();
+		_isFullscreen = false;
+	}
+}
+
+onDestroy(() => {
+	if (resizeTimer) {
+		clearTimeout(resizeTimer);
+	}
+	disconnect();
+});
+
+$effect(() => {
+	if (!visible || !container || typeof ResizeObserver === "undefined") {
+		return;
+	}
+
+	const observer = new ResizeObserver((entries) => {
+		const entry = entries[0];
+		if (!entry) return;
+		queueResize(entry.contentRect.width, entry.contentRect.height);
 	});
 
-	$effect(() => {
-		const desiredVisible = visible;
-		const desiredUrl = vncUrl;
-		const hasContainer = !!container;
+	observer.observe(container);
+	const rect = container.getBoundingClientRect();
+	queueResize(rect.width, rect.height);
 
-		if (!desiredVisible || !hasContainer) {
-			disconnect();
+	return () => {
+		observer.disconnect();
+	};
+});
+
+$effect(() => {
+	if (!visible || !container) {
+		viewerActive = false;
+		return;
+	}
+
+	const handlePointerDown = (event: PointerEvent) => {
+		if (!container) return;
+		viewerActive = container.contains(event.target as Node);
+	};
+
+	const handlePaste = async (event: ClipboardEvent) => {
+		if (!viewerActive || !rfb) return;
+
+		const text = event.clipboardData?.getData("text/plain") ?? "";
+		if (!text) return;
+
+		event.preventDefault();
+		await syncRemoteClipboard(text);
+		sendRemotePasteShortcut();
+	};
+
+	const handleKeyDown = async (event: KeyboardEvent) => {
+		const modifierPressed = event.metaKey || event.ctrlKey;
+		if (!viewerActive || !modifierPressed || event.key.toLowerCase() !== "v") {
 			return;
 		}
 
-		if (rfb && activeVNCUrl !== desiredUrl) {
-			disconnect();
-			return;
-		}
+		event.preventDefault();
+		await handleLocalPaste();
+	};
 
-		if (!rfb && !connecting) {
-			void connect();
-		}
-	});
+	document.addEventListener("pointerdown", handlePointerDown, true);
+	window.addEventListener("paste", handlePaste);
+	window.addEventListener("keydown", handleKeyDown, true);
+
+	return () => {
+		document.removeEventListener("pointerdown", handlePointerDown, true);
+		window.removeEventListener("paste", handlePaste);
+		window.removeEventListener("keydown", handleKeyDown, true);
+	};
+});
+
+$effect(() => {
+	const desiredVisible = visible;
+	const desiredUrl = vncUrl;
+	const hasContainer = !!container;
+
+	if (!desiredVisible || !hasContainer) {
+		disconnect();
+		return;
+	}
+
+	if (rfb && activeVNCUrl !== desiredUrl) {
+		disconnect();
+		return;
+	}
+
+	if (!rfb && !connecting) {
+		void connect();
+	}
+});
 </script>
 
 {#if visible}

--- a/packages/ui/src/lib/components/Elicitation.svelte
+++ b/packages/ui/src/lib/components/Elicitation.svelte
@@ -1,247 +1,262 @@
 <script lang="ts">
-	interface Props {
-		elicitation: Elicitation;
-		open?: boolean;
-		onresult?: (result: ElicitationResult) => void;
-	}
+interface Props {
+	elicitation: Elicitation;
+	open?: boolean;
+	onresult?: (result: ElicitationResult) => void;
+}
 
-	import type { Elicitation, ElicitationResult, PrimitiveSchemaDefinition } from '$lib/types';
-	import { Copy, ChevronLeft, ChevronRight, SkipForward, Pencil } from '@lucide/svelte';
-	import { SvelteSet, SvelteMap } from 'svelte/reactivity';
+import { SvelteMap, SvelteSet } from "svelte/reactivity";
+import type {
+	Elicitation,
+	ElicitationResult,
+	PrimitiveSchemaDefinition,
+} from "$lib/types";
 
-	const stepColors = [
-		{ bg: 'bg-primary', text: 'text-primary-content', ring: 'ring-primary/30' },
-		{ bg: 'bg-secondary', text: 'text-secondary-content', ring: 'ring-secondary/30' },
-		{ bg: 'bg-accent', text: 'text-accent-content', ring: 'ring-accent/30' },
-		{ bg: 'bg-info', text: 'text-info-content', ring: 'ring-info/30' }
-	];
+const _stepColors = [
+	{ bg: "bg-primary", text: "text-primary-content", ring: "ring-primary/30" },
+	{
+		bg: "bg-secondary",
+		text: "text-secondary-content",
+		ring: "ring-secondary/30",
+	},
+	{ bg: "bg-accent", text: "text-accent-content", ring: "ring-accent/30" },
+	{ bg: "bg-info", text: "text-info-content", ring: "ring-info/30" },
+];
 
-	let { elicitation, open = false, onresult }: Props = $props();
+const { elicitation, open = false, onresult }: Props = $props();
 
-	let formData = $state<{ [key: string]: string | number | boolean }>({});
-	let showCopiedTooltip = $state(false);
+let formData = $state<{ [key: string]: string | number | boolean }>({});
+let _showCopiedTooltip = $state(false);
 
-	// Question-specific types
-	interface QuestionOptionData {
-		label: string;
-		description?: string;
-	}
-	interface QuestionData {
-		question: string;
-		header?: string;
-		multiple?: boolean;
-		options: QuestionOptionData[];
-	}
+// Question-specific types
+interface QuestionOptionData {
+	label: string;
+	description?: string;
+}
+interface QuestionData {
+	question: string;
+	header?: string;
+	multiple?: boolean;
+	options: QuestionOptionData[];
+}
 
-	// Question-specific state
-	let currentStep = $state(0);
-	let reviewMode = $state(false);
-	let selectedOptions = new SvelteMap<number, SvelteSet<string>>();
-	let customAnswers = new SvelteMap<number, string>();
-	let showCustomInput = new SvelteMap<number, boolean>();
+// Question-specific state
+let currentStep = $state(0);
+let _reviewMode = $state(false);
+const selectedOptions = new SvelteMap<number, SvelteSet<string>>();
+const customAnswers = new SvelteMap<number, string>();
+const showCustomInput = new SvelteMap<number, boolean>();
 
-	// Initialize form data with defaults
-	$effect(() => {
-		const newFormData: { [key: string]: string | number | boolean } = {};
+// Initialize form data with defaults
+$effect(() => {
+	const newFormData: { [key: string]: string | number | boolean } = {};
 
-		for (const [key, schema] of Object.entries(elicitation.requestedSchema.properties)) {
-			if (schema.type === 'boolean' && schema.default !== undefined) {
-				newFormData[key] = schema.default;
-			} else if (
-				schema.type === 'string' ||
-				schema.type === 'number' ||
-				schema.type === 'integer'
-			) {
-				newFormData[key] = schema.type === 'string' ? '' : 0;
-			} else if ('enum' in schema && schema.enum) {
-				newFormData[key] = (schema.enum as string[])[0] || '';
-			}
+	for (const [key, schema] of Object.entries(
+		elicitation.requestedSchema.properties,
+	)) {
+		if (schema.type === "boolean" && schema.default !== undefined) {
+			newFormData[key] = schema.default;
+		} else if (
+			schema.type === "string" ||
+			schema.type === "number" ||
+			schema.type === "integer"
+		) {
+			newFormData[key] = schema.type === "string" ? "" : 0;
+		} else if ("enum" in schema && schema.enum) {
+			newFormData[key] = (schema.enum as string[])[0] || "";
 		}
+	}
 
-		formData = newFormData;
+	formData = newFormData;
+});
+
+// Reset question state when elicitation changes
+$effect(() => {
+	if (isQuestionElicitation()) {
+		currentStep = 0;
+		_reviewMode = false;
+		selectedOptions.clear();
+		customAnswers.clear();
+		showCustomInput.clear();
+	}
+});
+
+function handleAccept() {
+	onresult?.({
+		action: "accept",
+		content: { ...formData },
 	});
+}
 
-	// Reset question state when elicitation changes
-	$effect(() => {
-		if (isQuestionElicitation()) {
-			currentStep = 0;
-			reviewMode = false;
-			selectedOptions.clear();
-			customAnswers.clear();
-			showCustomInput.clear();
-		}
+function _handleDecline() {
+	onresult?.({
+		action: "decline",
 	});
+}
 
-	function handleAccept() {
-		onresult?.({
-			action: 'accept',
-			content: { ...formData }
-		});
-	}
-
-	function handleDecline() {
-		onresult?.({
-			action: 'decline'
-		});
-	}
-
-	function handleCancel() {
-		onresult?.({
-			action: 'cancel'
-		});
-	}
-
-	function isRequired(key: string): boolean {
-		return elicitation.requestedSchema.required?.includes(key) ?? false;
-	}
-
-	function getFieldTitle(key: string, schema: PrimitiveSchemaDefinition): string {
-		return schema.title || key;
-	}
-
-	function validateForm(): boolean {
-		if (!elicitation.requestedSchema.required) return true;
-
-		for (const requiredField of elicitation.requestedSchema.required) {
-			const value = formData[requiredField];
-			if (value === undefined || value === '' || value === null) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	function isOAuthElicitation(): boolean {
-		return Boolean(elicitation._meta?.['ai.nanobot.meta/oauth-url']);
-	}
-
-	function getOAuthUrl(): string {
-		return elicitation._meta?.['ai.nanobot.meta/oauth-url'] as string;
-	}
-
-	function getServerName(): string {
-		return (elicitation._meta?.['ai.nanobot.meta/server-name'] as string) || 'MCP Server';
-	}
-
-	function openOAuthLink() {
-		const url = getOAuthUrl();
-		window.open(url, '_blank');
-		handleAccept();
-	}
-
-	async function copyToClipboard() {
-		const url = getOAuthUrl();
-		await navigator.clipboard.writeText(url);
-		showCopiedTooltip = true;
-		setTimeout(() => {
-			showCopiedTooltip = false;
-		}, 2000);
-	}
-
-	// Question elicitation functions
-	function isQuestionElicitation(): boolean {
-		return Boolean(elicitation._meta?.['ai.nanobot.meta/question']);
-	}
-
-	const questions: QuestionData[] = $derived.by(() => {
-		const raw = elicitation._meta?.['ai.nanobot.meta/question'];
-		if (!raw) return [];
-
-		if (typeof raw === 'string') {
-			try {
-				const parsed = JSON.parse(raw);
-				if (Array.isArray(parsed)) return parsed as QuestionData[];
-				if (parsed && typeof parsed === 'object') return [parsed as QuestionData];
-				return [];
-			} catch {
-				return [];
-			}
-		}
-
-		if (Array.isArray(raw)) return raw as QuestionData[];
-		if (raw && typeof raw === 'object') return [raw as QuestionData];
-		return [];
+function _handleCancel() {
+	onresult?.({
+		action: "cancel",
 	});
+}
 
-	function toggleOption(qIndex: number, label: string) {
-		let current = selectedOptions.get(qIndex);
-		if (!current) {
-			current = new SvelteSet();
-			selectedOptions.set(qIndex, current);
+function _isRequired(key: string): boolean {
+	return elicitation.requestedSchema.required?.includes(key) ?? false;
+}
+
+function _getFieldTitle(
+	key: string,
+	schema: PrimitiveSchemaDefinition,
+): string {
+	return schema.title || key;
+}
+
+function _validateForm(): boolean {
+	if (!elicitation.requestedSchema.required) return true;
+
+	for (const requiredField of elicitation.requestedSchema.required) {
+		const value = formData[requiredField];
+		if (value === undefined || value === "" || value === null) {
+			return false;
 		}
+	}
+	return true;
+}
 
-		if (questions[qIndex].multiple) {
-			if (current.has(label)) current.delete(label);
-			else current.add(label);
+function _isOAuthElicitation(): boolean {
+	return Boolean(elicitation._meta?.["ai.nanobot.meta/oauth-url"]);
+}
+
+function getOAuthUrl(): string {
+	return elicitation._meta?.["ai.nanobot.meta/oauth-url"] as string;
+}
+
+function _getServerName(): string {
+	return (
+		(elicitation._meta?.["ai.nanobot.meta/server-name"] as string) ||
+		"MCP Server"
+	);
+}
+
+function _openOAuthLink() {
+	const url = getOAuthUrl();
+	window.open(url, "_blank");
+	handleAccept();
+}
+
+async function _copyToClipboard() {
+	const url = getOAuthUrl();
+	await navigator.clipboard.writeText(url);
+	_showCopiedTooltip = true;
+	setTimeout(() => {
+		_showCopiedTooltip = false;
+	}, 2000);
+}
+
+// Question elicitation functions
+function isQuestionElicitation(): boolean {
+	return Boolean(elicitation._meta?.["ai.nanobot.meta/question"]);
+}
+
+const questions: QuestionData[] = $derived.by(() => {
+	const raw = elicitation._meta?.["ai.nanobot.meta/question"];
+	if (!raw) return [];
+
+	if (typeof raw === "string") {
+		try {
+			const parsed = JSON.parse(raw);
+			if (Array.isArray(parsed)) return parsed as QuestionData[];
+			if (parsed && typeof parsed === "object") return [parsed as QuestionData];
+			return [];
+		} catch {
+			return [];
+		}
+	}
+
+	if (Array.isArray(raw)) return raw as QuestionData[];
+	if (raw && typeof raw === "object") return [raw as QuestionData];
+	return [];
+});
+
+function _toggleOption(qIndex: number, label: string) {
+	let current = selectedOptions.get(qIndex);
+	if (!current) {
+		current = new SvelteSet();
+		selectedOptions.set(qIndex, current);
+	}
+
+	if (questions[qIndex].multiple) {
+		if (current.has(label)) current.delete(label);
+		else current.add(label);
+	} else {
+		current.clear();
+		current.add(label);
+		showCustomInput.set(qIndex, false);
+		customAnswers.set(qIndex, "");
+	}
+}
+
+function _toggleCustomInput(qIndex: number) {
+	const current = showCustomInput.get(qIndex) ?? false;
+	showCustomInput.set(qIndex, !current);
+	if (current) {
+		customAnswers.set(qIndex, "");
+	} else if (!questions[qIndex].multiple) {
+		selectedOptions.set(qIndex, new SvelteSet());
+	}
+}
+
+function _updateCustomAnswer(qIndex: number, value: string) {
+	customAnswers.set(qIndex, value);
+}
+
+function _hasAnswer(qIndex: number): boolean {
+	const selected = selectedOptions.get(qIndex);
+	const custom = customAnswers.get(qIndex)?.trim();
+	return (selected !== undefined && selected.size > 0) || !!custom;
+}
+
+function _getAnswerSummary(qIndex: number): string {
+	const selected = Array.from(selectedOptions.get(qIndex) ?? []);
+	const custom = customAnswers.get(qIndex)?.trim();
+	if (custom) selected.push(custom);
+	return selected.length > 0 ? selected.join(", ") : "(skipped)";
+}
+
+function _goToStep(step: number) {
+	currentStep = step;
+	_reviewMode = false;
+}
+
+function _nextStep() {
+	if (currentStep < questions.length - 1) {
+		currentStep++;
+	} else {
+		if (questions.length > 1) {
+			_reviewMode = true;
 		} else {
-			current.clear();
-			current.add(label);
-			showCustomInput.set(qIndex, false);
-			customAnswers.set(qIndex, '');
+			handleQuestionSubmit();
 		}
 	}
+}
 
-	function toggleCustomInput(qIndex: number) {
-		const current = showCustomInput.get(qIndex) ?? false;
-		showCustomInput.set(qIndex, !current);
-		if (current) {
-			customAnswers.set(qIndex, '');
-		} else if (!questions[qIndex].multiple) {
-			selectedOptions.set(qIndex, new SvelteSet());
-		}
-	}
+function _prevStep() {
+	if (currentStep > 0) currentStep--;
+}
 
-	function updateCustomAnswer(qIndex: number, value: string) {
-		customAnswers.set(qIndex, value);
-	}
+function handleQuestionSubmit() {
+	const content: Record<string, string | number | boolean> = {};
 
-	function hasAnswer(qIndex: number): boolean {
-		const selected = selectedOptions.get(qIndex);
-		const custom = customAnswers.get(qIndex)?.trim();
-		return (selected !== undefined && selected.size > 0) || !!custom;
-	}
-
-	function getAnswerSummary(qIndex: number): string {
-		const selected = Array.from(selectedOptions.get(qIndex) ?? []);
-		const custom = customAnswers.get(qIndex)?.trim();
+	for (let i = 0; i < questions.length; i++) {
+		const key = `q${i}`;
+		const selected = Array.from(selectedOptions.get(i) ?? []);
+		const custom = customAnswers.get(i)?.trim();
 		if (custom) selected.push(custom);
-		return selected.length > 0 ? selected.join(', ') : '(skipped)';
+		content[key] = JSON.stringify(selected);
 	}
 
-	function goToStep(step: number) {
-		currentStep = step;
-		reviewMode = false;
-	}
-
-	function nextStep() {
-		if (currentStep < questions.length - 1) {
-			currentStep++;
-		} else {
-			if (questions.length > 1) {
-				reviewMode = true;
-			} else {
-				handleQuestionSubmit();
-			}
-		}
-	}
-
-	function prevStep() {
-		if (currentStep > 0) currentStep--;
-	}
-
-	function handleQuestionSubmit() {
-		const content: Record<string, string | number | boolean> = {};
-
-		for (let i = 0; i < questions.length; i++) {
-			const key = `q${i}`;
-			const selected = Array.from(selectedOptions.get(i) ?? []);
-			const custom = customAnswers.get(i)?.trim();
-			if (custom) selected.push(custom);
-			content[key] = JSON.stringify(selected);
-		}
-
-		onresult?.({ action: 'accept', content });
-	}
+	onresult?.({ action: "accept", content });
+}
 </script>
 
 {#if open && isQuestionElicitation()}

--- a/packages/ui/src/lib/components/Message.svelte
+++ b/packages/ui/src/lib/components/Message.svelte
@@ -1,29 +1,37 @@
 <script lang="ts">
-	import MessageItem from './MessageItem.svelte';
-	import type { Attachment, ChatMessage, ChatResult, ResourceContents } from '$lib/types';
-	import MessageItemText from '$lib/components/MessageItemText.svelte';
+import type {
+	Attachment,
+	ChatMessage,
+	ChatResult,
+	ResourceContents,
+} from "$lib/types";
 
-	interface Props {
-		message: ChatMessage;
-		timestamp?: Date;
-		onSend?: (message: string, attachments?: Attachment[]) => Promise<ChatResult | void>;
-		onReadResource?: (uri: string) => Promise<{ contents: ResourceContents[] }>;
+interface Props {
+	message: ChatMessage;
+	timestamp?: Date;
+	onSend?: (
+		message: string,
+		attachments?: Attachment[],
+	) => Promise<ChatResult | undefined>;
+	onReadResource?: (uri: string) => Promise<{ contents: ResourceContents[] }>;
+}
+
+const { message, timestamp, onSend, onReadResource }: Props = $props();
+
+const _displayTime = $derived(
+	timestamp || (message.created ? new Date(message.created) : new Date()),
+);
+const _toolCall = $derived.by(() => {
+	try {
+		const item = message.items?.[0];
+		return message.role === "user" && item?.type === "text"
+			? JSON.parse(item.text)
+			: null;
+	} catch {
+		// ignore parse error
+		return null;
 	}
-
-	let { message, timestamp, onSend, onReadResource }: Props = $props();
-
-	const displayTime = $derived(
-		timestamp || (message.created ? new Date(message.created) : new Date())
-	);
-	const toolCall = $derived.by(() => {
-		try {
-			const item = message.items?.[0];
-			return message.role === 'user' && item?.type === 'text' ? JSON.parse(item.text) : null;
-		} catch {
-			// ignore parse error
-			return null;
-		}
-	});
+});
 </script>
 
 {#if message.items?.[0]?._meta?.['ai.nanobot.meta/attachment']}

--- a/packages/ui/src/lib/components/MessageAttachments.svelte
+++ b/packages/ui/src/lib/components/MessageAttachments.svelte
@@ -1,18 +1,18 @@
 <script module lang="ts">
-	export function getFileIcon(type?: string) {
-		if (type?.startsWith('image/')) {
-			return '🖼️';
-		} else if (type === 'application/pdf') {
-			return '📄';
-		} else if (type?.includes('text/') || type?.includes('json')) {
-			return '📝';
-		} else if (type?.includes('spreadsheet') || type?.includes('csv')) {
-			return '📊';
-		} else if (type?.includes('document')) {
-			return '📋';
-		}
-		return '📎';
+export function getFileIcon(type?: string) {
+	if (type?.startsWith("image/")) {
+		return "🖼️";
+	} else if (type === "application/pdf") {
+		return "📄";
+	} else if (type?.includes("text/") || type?.includes("json")) {
+		return "📝";
+	} else if (type?.includes("spreadsheet") || type?.includes("csv")) {
+		return "📊";
+	} else if (type?.includes("document")) {
+		return "📋";
 	}
+	return "📎";
+}
 </script>
 
 <script lang="ts">

--- a/packages/ui/src/lib/components/MessageInput.svelte
+++ b/packages/ui/src/lib/components/MessageInput.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-import { Paperclip, Send, Square } from "@lucide/svelte";
-import MessageAttachments from "$lib/components/MessageAttachments.svelte";
-import MessageResources from "$lib/components/MessageResources.svelte";
 import type MessageSlashPromptsType from "$lib/components/MessageSlashPrompts.svelte";
-import MessageSlashPrompts from "$lib/components/MessageSlashPrompts.svelte";
 import type {
 	Agent,
 	Attachment,
@@ -19,7 +15,7 @@ interface Props {
 	onSend?: (
 		message: string,
 		attachments?: Attachment[],
-	) => Promise<ChatResult | void>;
+	) => Promise<ChatResult | undefined>;
 	onPrompt?: (promptName: string) => void;
 	onFileUpload?: (
 		file: File,
@@ -72,7 +68,7 @@ let slashInput: MessageSlashPromptsType;
 let isUploading = $state(false);
 
 let selectedResources = $state<Resource[]>([]);
-const showAgentDropdown = $derived(agents.length > 1);
+const _showAgentDropdown = $derived(agents.length > 1);
 
 async function handleSubmit(e: Event) {
 	e.preventDefault();
@@ -84,11 +80,11 @@ async function handleSubmit(e: Event) {
 	}
 }
 
-function removeSelectedResource(resource: Resource) {
+function _removeSelectedResource(resource: Resource) {
 	selectedResources = selectedResources.filter((r) => r.uri !== resource.uri);
 }
 
-function toggleResource(resource: Resource) {
+function _toggleResource(resource: Resource) {
 	const isSelected = selectedResources.some((r) => r.uri === resource.uri);
 	if (isSelected) {
 		selectedResources = selectedResources.filter((r) => r.uri !== resource.uri);
@@ -97,11 +93,11 @@ function toggleResource(resource: Resource) {
 	}
 }
 
-function handleAttach() {
+function _handleAttach() {
 	fileInput?.click();
 }
 
-async function handleFileSelect(e: Event) {
+async function _handleFileSelect(e: Event) {
 	const target = e.target as HTMLInputElement;
 	const file = target.files?.[0];
 
@@ -121,7 +117,7 @@ async function handleFileSelect(e: Event) {
 	}
 }
 
-function handleKeydown(e: KeyboardEvent) {
+function _handleKeydown(e: KeyboardEvent) {
 	if (slashInput.handleKeydown(e)) {
 		return;
 	}

--- a/packages/ui/src/lib/components/MessageItem.svelte
+++ b/packages/ui/src/lib/components/MessageItem.svelte
@@ -1,21 +1,22 @@
 <script lang="ts">
-	import type { Attachment, ChatResult, ChatMessageItem, ResourceContents } from '$lib/types';
-	import MessageItemText from './MessageItemText.svelte';
-	import MessageItemImage from './MessageItemImage.svelte';
-	import MessageItemAudio from './MessageItemAudio.svelte';
-	import MessageItemResourceLink from './MessageItemResourceLink.svelte';
-	import MessageItemResource from './MessageItemResource.svelte';
-	import MessageItemReasoning from './MessageItemReasoning.svelte';
-	import MessageItemTool from './MessageItemTool.svelte';
+import type {
+	Attachment,
+	ChatMessageItem,
+	ChatResult,
+	ResourceContents,
+} from "$lib/types";
 
-	interface Props {
-		item: ChatMessageItem;
-		role: 'user' | 'assistant';
-		onSend?: (message: string, attachments?: Attachment[]) => Promise<ChatResult | void>;
-		onReadResource?: (uri: string) => Promise<{ contents: ResourceContents[] }>;
-	}
+interface Props {
+	item: ChatMessageItem;
+	role: "user" | "assistant";
+	onSend?: (
+		message: string,
+		attachments?: Attachment[],
+	) => Promise<ChatResult | undefined>;
+	onReadResource?: (uri: string) => Promise<{ contents: ResourceContents[] }>;
+}
 
-	let { item, role, onSend, onReadResource }: Props = $props();
+const { item, role, onSend, onReadResource }: Props = $props();
 </script>
 
 {#if item.type === 'text'}

--- a/packages/ui/src/lib/components/MessageItemAudio.svelte
+++ b/packages/ui/src/lib/components/MessageItemAudio.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import type { ChatMessageItemAudio } from '$lib/types';
+import type { ChatMessageItemAudio } from "$lib/types";
 
-	interface Props {
-		item: ChatMessageItemAudio;
-	}
+interface Props {
+	item: ChatMessageItemAudio;
+}
 
-	let { item }: Props = $props();
+const { item }: Props = $props();
 </script>
 
 <div class="mb-3 rounded-lg bg-base-200 p-3">

--- a/packages/ui/src/lib/components/MessageItemImage.svelte
+++ b/packages/ui/src/lib/components/MessageItemImage.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import type { ChatMessageItemImage } from '$lib/types';
+import type { ChatMessageItemImage } from "$lib/types";
 
-	interface Props {
-		item: ChatMessageItemImage;
-	}
+interface Props {
+	item: ChatMessageItemImage;
+}
 
-	let { item }: Props = $props();
+const { item }: Props = $props();
 </script>
 
 <div class="mb-3 rounded-lg bg-base-200 p-3">

--- a/packages/ui/src/lib/components/MessageItemReasoning.svelte
+++ b/packages/ui/src/lib/components/MessageItemReasoning.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-	import { Lightbulb } from '@lucide/svelte';
-	import type { ChatMessageItemReasoning } from '$lib/types';
+import type { ChatMessageItemReasoning } from "$lib/types";
 
-	interface Props {
-		item: ChatMessageItemReasoning;
-	}
+interface Props {
+	item: ChatMessageItemReasoning;
+}
 
-	let { item }: Props = $props();
+const { item }: Props = $props();
 </script>
 
 <div class="mb-3 rounded-lg border-l-4 border-neutral bg-neutral/20 p-3">

--- a/packages/ui/src/lib/components/MessageItemResource.svelte
+++ b/packages/ui/src/lib/components/MessageItemResource.svelte
@@ -1,79 +1,79 @@
 <script lang="ts">
-	import { AlertTriangle } from '@lucide/svelte';
-	import { getFileIcon } from '$lib/components/MessageAttachments.svelte';
-	import type { ChatMessageItemResource } from '$lib/types';
+import type { ChatMessageItemResource } from "$lib/types";
 
-	interface Props {
-		item: ChatMessageItemResource;
-	}
+interface Props {
+	item: ChatMessageItemResource;
+}
 
-	let { item }: Props = $props();
+const { item }: Props = $props();
 
-	let isError = $derived(item.resource.mimeType === 'application/vnd.nanobot.error+json');
-	let modal = $state<HTMLDialogElement>();
+const _isError = $derived(
+	item.resource.mimeType === "application/vnd.nanobot.error+json",
+);
+const modal = $state<HTMLDialogElement>();
 
-	function openModal() {
-		modal?.showModal();
-	}
+function _openModal() {
+	modal?.showModal();
+}
 
-	function isTextType(mimeType: string): boolean {
-		return (
-			mimeType.startsWith('text/') ||
-			mimeType.includes('json') ||
-			mimeType.includes('xml') ||
-			mimeType === 'application/javascript' ||
-			mimeType === 'application/typescript'
-		);
-	}
+function _isTextType(mimeType: string): boolean {
+	return (
+		mimeType.startsWith("text/") ||
+		mimeType.includes("json") ||
+		mimeType.includes("xml") ||
+		mimeType === "application/javascript" ||
+		mimeType === "application/typescript"
+	);
+}
 
-	function isPdfType(mimeType: string): boolean {
-		return mimeType === 'application/pdf';
-	}
+function _isPdfType(mimeType: string): boolean {
+	return mimeType === "application/pdf";
+}
 
-	function getResourceDisplayName(): string {
-		// Use title or name if available, otherwise generate from MIME type
-		if (item.resource.title) return item.resource.title;
-		if (item.resource.name) return item.resource.name;
+function _getResourceDisplayName(): string {
+	// Use title or name if available, otherwise generate from MIME type
+	if (item.resource.title) return item.resource.title;
+	if (item.resource.name) return item.resource.name;
 
-		// Generate friendly name from MIME type
-		const mimeType = item.resource.mimeType;
-		if (mimeType === 'application/json') return 'JSON Data';
-		if (mimeType === 'application/xml') return 'XML Document';
-		if (mimeType === 'application/pdf') return 'PDF Document';
-		if (mimeType.startsWith('text/')) return 'Text Document';
-		if (mimeType.startsWith('image/')) return 'Image';
-		if (mimeType.includes('json')) return 'JSON Resource';
-		if (mimeType.includes('html')) return 'HTML Document';
-		if (mimeType.includes('csv')) return 'CSV Data';
-		if (mimeType.includes('markdown')) return 'Markdown';
+	// Generate friendly name from MIME type
+	const mimeType = item.resource.mimeType;
+	if (mimeType === "application/json") return "JSON Data";
+	if (mimeType === "application/xml") return "XML Document";
+	if (mimeType === "application/pdf") return "PDF Document";
+	if (mimeType.startsWith("text/")) return "Text Document";
+	if (mimeType.startsWith("image/")) return "Image";
+	if (mimeType.includes("json")) return "JSON Resource";
+	if (mimeType.includes("html")) return "HTML Document";
+	if (mimeType.includes("csv")) return "CSV Data";
+	if (mimeType.includes("markdown")) return "Markdown";
 
-		// Fallback to MIME type
-		return mimeType;
-	}
+	// Fallback to MIME type
+	return mimeType;
+}
 
-	function formatFileSize(bytes?: number): string {
-		if (!bytes) return '';
-		if (bytes < 1024) return `${bytes} B`;
-		if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-	}
+function _formatFileSize(bytes?: number): string {
+	if (!bytes) return "";
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
-	function getDecodedText(): string {
-		if (!item.resource.blob) return '';
+function _getDecodedText(): string {
+	if (!item.resource.blob) return "";
+	try {
+		// Unicode-safe base64 decoding
+		const binaryString = atob(item.resource.blob);
+		const bytes = Uint8Array.from(binaryString, (c) => c.charCodeAt(0));
+		const str = new TextDecoder("utf-8").decode(bytes);
 		try {
-			// Unicode-safe base64 decoding
-			const binaryString = atob(item.resource.blob);
-			const bytes = Uint8Array.from(binaryString, (c) => c.charCodeAt(0));
-			const str = new TextDecoder('utf-8').decode(bytes);
-			try {
-				return JSON.stringify(JSON.parse(str), null, 2);
-			} catch {
-				return str;
-			}
+			return JSON.stringify(JSON.parse(str), null, 2);
 		} catch {
-			return 'Error decoding content';
+			return str;
 		}
+	} catch {
+		return "Error decoding content";
 	}
+}
 </script>
 
 {#if isError}

--- a/packages/ui/src/lib/components/MessageItemResourceLink.svelte
+++ b/packages/ui/src/lib/components/MessageItemResourceLink.svelte
@@ -1,168 +1,167 @@
 <script lang="ts">
-	import { ExternalLink } from '@lucide/svelte';
-	import { getFileIcon } from '$lib/components/MessageAttachments.svelte';
-	import type { ChatMessageItemResourceLink, ResourceContents } from '$lib/types';
+import type { ChatMessageItemResourceLink, ResourceContents } from "$lib/types";
 
-	interface Props {
-		item: ChatMessageItemResourceLink;
-		onReadResource?: (uri: string) => Promise<{ contents: ResourceContents[] }>;
+interface Props {
+	item: ChatMessageItemResourceLink;
+	onReadResource?: (uri: string) => Promise<{ contents: ResourceContents[] }>;
+}
+
+const { item, onReadResource }: Props = $props();
+const modal = $state<HTMLDialogElement>();
+let fetchedResource = $state<ResourceContents | null>(null);
+let loading = $state(false);
+let _loadError = $state<string | null>(null);
+let _isMissing = $state(false);
+
+const _displayName = $derived(item.name || getNameFromURI(item.uri));
+const _previewMimeType = $derived(
+	fetchedResource?.mimeType || item.mimeType || inferMimeType(item.uri),
+);
+const _previewBlob = $derived(fetchedResource?.blob || "");
+const _previewText = $derived(fetchedResource?.text || "");
+
+const extensionMimeTypes: Record<string, string> = {
+	txt: "text/plain",
+	md: "text/markdown",
+	markdown: "text/markdown",
+	json: "application/json",
+	yaml: "application/yaml",
+	yml: "application/yaml",
+	xml: "application/xml",
+	html: "text/html",
+	htm: "text/html",
+	csv: "text/csv",
+	js: "application/javascript",
+	ts: "application/typescript",
+	py: "text/x-python",
+	go: "text/x-go",
+	sh: "application/x-sh",
+	log: "text/plain",
+	pdf: "application/pdf",
+	png: "image/png",
+	jpg: "image/jpeg",
+	jpeg: "image/jpeg",
+	gif: "image/gif",
+	webp: "image/webp",
+	svg: "image/svg+xml",
+	mp3: "audio/mpeg",
+	wav: "audio/wav",
+	ogg: "audio/ogg",
+	m4a: "audio/mp4",
+	mp4: "video/mp4",
+	webm: "video/webm",
+};
+
+async function _openModal() {
+	modal?.showModal();
+	if (fetchedResource || loading) {
+		return;
 	}
 
-	let { item, onReadResource }: Props = $props();
-	let modal = $state<HTMLDialogElement>();
-	let fetchedResource = $state<ResourceContents | null>(null);
-	let loading = $state(false);
-	let loadError = $state<string | null>(null);
-	let isMissing = $state(false);
+	if (!onReadResource) {
+		_loadError = "Resource reading is not available.";
+		return;
+	}
 
-	const displayName = $derived(item.name || getNameFromURI(item.uri));
-	const previewMimeType = $derived(
-		fetchedResource?.mimeType || item.mimeType || inferMimeType(item.uri)
+	loading = true;
+	_loadError = null;
+
+	try {
+		const result = await onReadResource(item.uri);
+		const content =
+			result.contents?.find((c) => c.uri === item.uri) || result.contents?.[0];
+		if (!content) {
+			_loadError = "No content available for this resource.";
+			_isMissing = true;
+			return;
+		}
+		fetchedResource = content;
+		_isMissing = false;
+	} catch (e) {
+		const errorMessage = e instanceof Error ? e.message : String(e);
+		_loadError = errorMessage;
+		if (isMissingResourceError(errorMessage)) {
+			_isMissing = true;
+		}
+	} finally {
+		loading = false;
+	}
+}
+
+function getNameFromURI(uri: string): string {
+	try {
+		const url = new URL(uri);
+		const decodedPath = decodeURIComponent(url.pathname || "");
+		const fromPath = decodedPath.split("/").filter(Boolean).pop();
+		if (fromPath) {
+			return fromPath;
+		}
+	} catch {
+		// ignore URL parse failures and fall back to raw URI parsing
+	}
+
+	const sanitized = uri.split("#")[0].split("?")[0];
+	const fromRaw = sanitized.split("/").filter(Boolean).pop();
+	return fromRaw || uri;
+}
+
+function inferMimeType(uri: string): string {
+	const name = getNameFromURI(uri).toLowerCase();
+	const ext = name.includes(".") ? name.split(".").pop() : "";
+	if (!ext) {
+		return "application/octet-stream";
+	}
+	return extensionMimeTypes[ext] || "application/octet-stream";
+}
+
+function isMissingResourceError(message: string): boolean {
+	const lower = message.toLowerCase();
+	return (
+		lower.includes("not found") ||
+		lower.includes("does not exist") ||
+		lower.includes("missing") ||
+		lower.includes("404")
 	);
-	const previewBlob = $derived(fetchedResource?.blob || '');
-	const previewText = $derived(fetchedResource?.text || '');
+}
 
-	const extensionMimeTypes: Record<string, string> = {
-		txt: 'text/plain',
-		md: 'text/markdown',
-		markdown: 'text/markdown',
-		json: 'application/json',
-		yaml: 'application/yaml',
-		yml: 'application/yaml',
-		xml: 'application/xml',
-		html: 'text/html',
-		htm: 'text/html',
-		csv: 'text/csv',
-		js: 'application/javascript',
-		ts: 'application/typescript',
-		py: 'text/x-python',
-		go: 'text/x-go',
-		sh: 'application/x-sh',
-		log: 'text/plain',
-		pdf: 'application/pdf',
-		png: 'image/png',
-		jpg: 'image/jpeg',
-		jpeg: 'image/jpeg',
-		gif: 'image/gif',
-		webp: 'image/webp',
-		svg: 'image/svg+xml',
-		mp3: 'audio/mpeg',
-		wav: 'audio/wav',
-		ogg: 'audio/ogg',
-		m4a: 'audio/mp4',
-		mp4: 'video/mp4',
-		webm: 'video/webm'
-	};
+function _isTextType(mimeType: string): boolean {
+	return (
+		mimeType.startsWith("text/") ||
+		mimeType.includes("json") ||
+		mimeType.includes("xml") ||
+		mimeType.includes("yaml") ||
+		mimeType === "application/javascript" ||
+		mimeType === "application/typescript"
+	);
+}
 
-	async function openModal() {
-		modal?.showModal();
-		if (fetchedResource || loading) {
-			return;
-		}
+function _isPdfType(mimeType: string): boolean {
+	return mimeType === "application/pdf";
+}
 
-		if (!onReadResource) {
-			loadError = 'Resource reading is not available.';
-			return;
-		}
-
-		loading = true;
-		loadError = null;
-
+function _getDecodedText(blob?: string, text?: string): string {
+	if (text) {
 		try {
-			const result = await onReadResource(item.uri);
-			const content = result.contents?.find((c) => c.uri === item.uri) || result.contents?.[0];
-			if (!content) {
-				loadError = 'No content available for this resource.';
-				isMissing = true;
-				return;
-			}
-			fetchedResource = content;
-			isMissing = false;
-		} catch (e) {
-			const errorMessage = e instanceof Error ? e.message : String(e);
-			loadError = errorMessage;
-			if (isMissingResourceError(errorMessage)) {
-				isMissing = true;
-			}
-		} finally {
-			loading = false;
-		}
-	}
-
-	function getNameFromURI(uri: string): string {
-		try {
-			const url = new URL(uri);
-			const decodedPath = decodeURIComponent(url.pathname || '');
-			const fromPath = decodedPath.split('/').filter(Boolean).pop();
-			if (fromPath) {
-				return fromPath;
-			}
+			return JSON.stringify(JSON.parse(text), null, 2);
 		} catch {
-			// ignore URL parse failures and fall back to raw URI parsing
+			return text;
 		}
-
-		const sanitized = uri.split('#')[0].split('?')[0];
-		const fromRaw = sanitized.split('/').filter(Boolean).pop();
-		return fromRaw || uri;
 	}
-
-	function inferMimeType(uri: string): string {
-		const name = getNameFromURI(uri).toLowerCase();
-		const ext = name.includes('.') ? name.split('.').pop() : '';
-		if (!ext) {
-			return 'application/octet-stream';
-		}
-		return extensionMimeTypes[ext] || 'application/octet-stream';
-	}
-
-	function isMissingResourceError(message: string): boolean {
-		const lower = message.toLowerCase();
-		return (
-			lower.includes('not found') ||
-			lower.includes('does not exist') ||
-			lower.includes('missing') ||
-			lower.includes('404')
-		);
-	}
-
-	function isTextType(mimeType: string): boolean {
-		return (
-			mimeType.startsWith('text/') ||
-			mimeType.includes('json') ||
-			mimeType.includes('xml') ||
-			mimeType.includes('yaml') ||
-			mimeType === 'application/javascript' ||
-			mimeType === 'application/typescript'
-		);
-	}
-
-	function isPdfType(mimeType: string): boolean {
-		return mimeType === 'application/pdf';
-	}
-
-	function getDecodedText(blob?: string, text?: string): string {
-		if (text) {
-			try {
-				return JSON.stringify(JSON.parse(text), null, 2);
-			} catch {
-				return text;
-			}
-		}
-		if (!blob) return '';
+	if (!blob) return "";
+	try {
+		// Unicode-safe base64 decoding
+		const binaryString = atob(blob);
+		const bytes = Uint8Array.from(binaryString, (c) => c.charCodeAt(0));
+		const str = new TextDecoder("utf-8").decode(bytes);
 		try {
-			// Unicode-safe base64 decoding
-			const binaryString = atob(blob);
-			const bytes = Uint8Array.from(binaryString, (c) => c.charCodeAt(0));
-			const str = new TextDecoder('utf-8').decode(bytes);
-			try {
-				return JSON.stringify(JSON.parse(str), null, 2);
-			} catch {
-				return str;
-			}
+			return JSON.stringify(JSON.parse(str), null, 2);
 		} catch {
-			return 'Error decoding content';
+			return str;
 		}
+	} catch {
+		return "Error decoding content";
 	}
+}
 </script>
 
 <button

--- a/packages/ui/src/lib/components/MessageItemText.svelte
+++ b/packages/ui/src/lib/components/MessageItemText.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
-	import { renderMarkdown } from '$lib/markdown';
-	import type { ChatMessageItemText } from '$lib/types';
+import { renderMarkdown } from "$lib/markdown";
+import type { ChatMessageItemText } from "$lib/types";
 
-	interface Props {
-		item: ChatMessageItemText;
-		role: 'user' | 'assistant';
-	}
+interface Props {
+	item: ChatMessageItemText;
+	role: "user" | "assistant";
+}
 
-	let { item, role }: Props = $props();
+const { item, role }: Props = $props();
 
-	const renderedContent = $derived(role === 'assistant' ? renderMarkdown(item.text) : item.text);
+const _renderedContent = $derived(
+	role === "assistant" ? renderMarkdown(item.text) : item.text,
+);
 </script>
 
 <div

--- a/packages/ui/src/lib/components/MessageItemTool.svelte
+++ b/packages/ui/src/lib/components/MessageItemTool.svelte
@@ -1,98 +1,111 @@
 <script lang="ts">
-	import { Eye, Settings } from '@lucide/svelte';
-	import { renderMarkdown } from '$lib/markdown';
-	import type { Attachment, ChatResult, ChatMessageItemToolCall, ToolOutputItem } from '$lib/types';
-	import '@mcp-ui/client/ui-resource-renderer.wc.js';
-	import MessageItemUI from '$lib/components/MessageItemUI.svelte';
-	import { isUIResource } from '@mcp-ui/client';
+import { renderMarkdown } from "$lib/markdown";
+import type {
+	Attachment,
+	ChatMessageItemToolCall,
+	ChatResult,
+	ToolOutputItem,
+} from "$lib/types";
+import "@mcp-ui/client/ui-resource-renderer.wc.js";
+import { isUIResource } from "@mcp-ui/client";
 
-	interface Props {
-		item: ChatMessageItemToolCall;
-		onSend?: (message: string, attachments?: Attachment[]) => Promise<ChatResult | void>;
+interface Props {
+	item: ChatMessageItemToolCall;
+	onSend?: (
+		message: string,
+		attachments?: Attachment[],
+	) => Promise<ChatResult | undefined>;
+}
+
+const { item, onSend }: Props = $props();
+const imagePreviewModal = $state<HTMLDialogElement>();
+let _selectedImagePreview = $state<{
+	data: string;
+	mimeType: string;
+	index: number;
+} | null>(null);
+const _singleUIResource = $derived(
+	item.output?.content &&
+		item.output?.content?.filter((i) => {
+			return (
+				isUIResource(i) && !i.resource?._meta?.["ai.nanobo.meta/workspace"]
+			);
+		}).length === 1,
+);
+
+function _parseToolInput(input: string) {
+	try {
+		const parsed = JSON.parse(input);
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			return { success: true, data: parsed };
+		}
+	} catch {
+		// JSON parsing failed, fall back to string display
+	}
+	return { success: false, data: input };
+}
+
+function _getStyle(
+	item: ToolOutputItem,
+	singleUIResource: boolean = false,
+): Record<string, string> {
+	if (singleUIResource) {
+		return {};
+	}
+	if (
+		isUIResource(item) &&
+		item.resource._meta?.["mcpui.dev/ui-preferred-frame-size"]
+	) {
+		const coords = item.resource._meta["mcpui.dev/ui-preferred-frame-size"];
+		if (Array.isArray(coords) && coords[0] && coords[1]) {
+			return {
+				width: `${coords[0]}`,
+				height: `${coords[1]}`,
+			};
+		} else if (
+			coords &&
+			typeof coords === "object" &&
+			"height" in coords &&
+			"width" in coords
+		) {
+			return {
+				width: `${coords.width}`,
+				height: `${coords.height}`,
+			};
+		}
+	}
+	return {
+		width: "300px",
+		height: "400px",
+	};
+}
+
+function _parseToolOutput(output: string) {
+	try {
+		const parsed = JSON.parse(output);
+		const formattedJson = JSON.stringify(parsed, null, 2);
+		const highlightedJson = renderMarkdown(
+			`\`\`\`json\n${formattedJson}\n\`\`\``,
+		);
+		return { success: true, data: highlightedJson };
+	} catch {
+		// JSON parsing failed, fall back to string display
+	}
+	return { success: false, data: output };
+}
+
+function _openImagePreview(item: ToolOutputItem, index: number) {
+	if (item.type !== "image") {
+		return;
 	}
 
-	let { item, onSend }: Props = $props();
-	let imagePreviewModal = $state<HTMLDialogElement>();
-	let selectedImagePreview = $state<{
-		data: string;
-		mimeType: string;
-		index: number;
-	} | null>(null);
-	let singleUIResource = $derived(
-		item.output?.content &&
-			item.output?.content?.filter((i) => {
-				return isUIResource(i) && !i.resource?._meta?.['ai.nanobo.meta/workspace'];
-			}).length === 1
-	);
-
-	function parseToolInput(input: string) {
-		try {
-			const parsed = JSON.parse(input);
-			if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-				return { success: true, data: parsed };
-			}
-		} catch {
-			// JSON parsing failed, fall back to string display
-		}
-		return { success: false, data: input };
-	}
-
-	function getStyle(
-		item: ToolOutputItem,
-		singleUIResource: boolean = false
-	): Record<string, string> {
-		if (singleUIResource) {
-			return {};
-		}
-		if (isUIResource(item) && item.resource._meta?.['mcpui.dev/ui-preferred-frame-size']) {
-			const coords = item.resource._meta['mcpui.dev/ui-preferred-frame-size'];
-			if (Array.isArray(coords) && coords[0] && coords[1]) {
-				return {
-					width: `${coords[0]}`,
-					height: `${coords[1]}`
-				};
-			} else if (
-				coords &&
-				typeof coords === 'object' &&
-				'height' in coords &&
-				'width' in coords
-			) {
-				return {
-					width: `${coords.width}`,
-					height: `${coords.height}`
-				};
-			}
-		}
-		return {
-			width: '300px',
-			height: '400px'
-		};
-	}
-
-	function parseToolOutput(output: string) {
-		try {
-			const parsed = JSON.parse(output);
-			const formattedJson = JSON.stringify(parsed, null, 2);
-			const highlightedJson = renderMarkdown('```json\n' + formattedJson + '\n```');
-			return { success: true, data: highlightedJson };
-		} catch {
-			// JSON parsing failed, fall back to string display
-		}
-		return { success: false, data: output };
-	}
-
-	function openImagePreview(item: ToolOutputItem, index: number) {
-		if (item.type !== 'image') {
-			return;
-		}
-
-		selectedImagePreview = {
-			data: item.data,
-			mimeType: item.mimeType || 'image/png',
-			index,
-		};
-		imagePreviewModal?.showModal();
-	}
+	_selectedImagePreview = {
+		data: item.data,
+		mimeType: item.mimeType || "image/png",
+		index,
+	};
+	imagePreviewModal?.showModal();
+}
 </script>
 
 <div

--- a/packages/ui/src/lib/components/MessageItemUI.svelte
+++ b/packages/ui/src/lib/components/MessageItemUI.svelte
@@ -1,104 +1,111 @@
 <script lang="ts">
-	import type { Attachment, ChatResult, ChatMessageItemResource } from '$lib/types';
-	import React from 'react';
-	import ReactDOM from 'react-dom/client';
-	import {
-		UIResourceRenderer,
-		basicComponentLibrary,
-		remoteButtonDefinition,
-		remoteTextDefinition,
-		remoteCardDefinition,
-		remoteImageDefinition,
-		remoteStackDefinition,
-		type UIActionResult
-	} from '@mcp-ui/client';
-	import { onMount } from 'svelte';
+import {
+	basicComponentLibrary,
+	remoteButtonDefinition,
+	remoteCardDefinition,
+	remoteImageDefinition,
+	remoteStackDefinition,
+	remoteTextDefinition,
+	type UIActionResult,
+	UIResourceRenderer,
+} from "@mcp-ui/client";
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { onMount } from "svelte";
+import type {
+	Attachment,
+	ChatMessageItemResource,
+	ChatResult,
+} from "$lib/types";
 
-	interface Props {
-		item: ChatMessageItemResource;
-		onSend?: (message: string, attachments?: Attachment[]) => Promise<ChatResult | void>;
-		style?: Record<string, string>;
+interface Props {
+	item: ChatMessageItemResource;
+	onSend?: (
+		message: string,
+		attachments?: Attachment[],
+	) => Promise<ChatResult | undefined>;
+	style?: Record<string, string>;
+}
+
+const { item, onSend, style = {} }: Props = $props();
+let container: HTMLDivElement;
+const iFrameRef = $state(React.createRef<HTMLIFrameElement>());
+
+$effect(() => {
+	if (iFrameRef.current) {
+		// iFrameRef.current.classList.add('mx-auto');
+		// console.log('Iframe ref:', iFrameRef.current);
 	}
+});
 
-	let { item, onSend, style = {} }: Props = $props();
-	let container: HTMLDivElement;
-	const iFrameRef = $state(React.createRef<HTMLIFrameElement>());
-
-	$effect(() => {
-		if (iFrameRef.current) {
-			// iFrameRef.current.classList.add('mx-auto');
-			// console.log('Iframe ref:', iFrameRef.current);
-		}
-	});
-
-	async function onUIAction(e: UIActionResult) {
-		console.log('UI Action', e);
-		switch (e.type) {
-			case 'intent':
-				if (
-					e.payload.intent === 'link' &&
-					e.payload.params?.url &&
-					typeof e.payload.params.url === 'string'
-				) {
-					window.open(e.payload.params.url, '_blank');
-				} else {
-					console.log('UI Action:', e);
-					onSend?.(JSON.stringify(e));
-				}
-				break;
-			case 'tool':
-				console.log('UI Action:', e);
-				if (onSend) {
-					const reply = await onSend(JSON.stringify(e));
-					if (reply) {
-						for (const item of reply.message?.items || []) {
-							if (item.type === 'tool' && item.output) {
-								console.log('Tool output:', $state.snapshot(item.output));
-								return $state.snapshot(item.output);
-							}
+async function onUIAction(e: UIActionResult) {
+	console.log("UI Action", e);
+	switch (e.type) {
+		case "intent":
+			if (
+				e.payload.intent === "link" &&
+				e.payload.params?.url &&
+				typeof e.payload.params.url === "string"
+			) {
+				window.open(e.payload.params.url, "_blank");
+			} else {
+				console.log("UI Action:", e);
+				onSend?.(JSON.stringify(e));
+			}
+			break;
+		case "tool":
+			console.log("UI Action:", e);
+			if (onSend) {
+				const reply = await onSend(JSON.stringify(e));
+				if (reply) {
+					for (const item of reply.message?.items || []) {
+						if (item.type === "tool" && item.output) {
+							console.log("Tool output:", $state.snapshot(item.output));
+							return $state.snapshot(item.output);
 						}
 					}
 				}
-				break;
-			case 'prompt':
-			case 'notify':
-				console.log('UI Action:', e);
-				onSend?.(JSON.stringify(e));
-				break;
-			case 'link':
-				window.open(e.payload.url, '_blank');
-				break;
-		}
+			}
+			break;
+		case "prompt":
+		case "notify":
+			console.log("UI Action:", e);
+			onSend?.(JSON.stringify(e));
+			break;
+		case "link":
+			window.open(e.payload.url, "_blank");
+			break;
 	}
+}
 
-	onMount(() => {
-		const root = ReactDOM.createRoot(container);
-		root.render(
-			React.createElement(UIResourceRenderer, {
-				onUIAction,
-				resource: $state.snapshot(item.resource),
-				remoteDomProps: {
-					library: basicComponentLibrary,
-					remoteElements: [
-						remoteButtonDefinition,
-						remoteTextDefinition,
-						remoteCardDefinition,
-						remoteImageDefinition,
-						remoteStackDefinition
-					]
+onMount(() => {
+	const root = ReactDOM.createRoot(container);
+	root.render(
+		React.createElement(UIResourceRenderer, {
+			onUIAction,
+			resource: $state.snapshot(item.resource),
+			remoteDomProps: {
+				library: basicComponentLibrary,
+				remoteElements: [
+					remoteButtonDefinition,
+					remoteTextDefinition,
+					remoteCardDefinition,
+					remoteImageDefinition,
+					remoteStackDefinition,
+				],
+			},
+			htmlProps: {
+				style: {
+					...style,
 				},
-				htmlProps: {
-					style: {
-						...style
-					},
-					autoResizeIframe: true,
-					iframeProps: {
-						ref: iFrameRef
-					}
-				}
-			})
-		);
-	});
+				autoResizeIframe: true,
+				iframeProps: {
+					ref: iFrameRef,
+				},
+			},
+		}),
+	);
+});
 </script>
 
 <div bind:this={container} class="contents"></div>

--- a/packages/ui/src/lib/components/MessageResources.svelte
+++ b/packages/ui/src/lib/components/MessageResources.svelte
@@ -1,73 +1,71 @@
 <script lang="ts">
-	import { Library } from '@lucide/svelte';
-	import { getFileIcon } from '$lib/components/MessageAttachments.svelte';
-	import type { Resource, ChatMessage } from '$lib/types';
+import type { ChatMessage, Resource } from "$lib/types";
 
-	interface Props {
-		disabled?: boolean;
-		resources?: Resource[];
-		selectedResources: Resource[];
-		toggleResource: (resource: Resource) => void;
-		messages?: ChatMessage[];
-	}
+interface Props {
+	disabled?: boolean;
+	resources?: Resource[];
+	selectedResources: Resource[];
+	toggleResource: (resource: Resource) => void;
+	messages?: ChatMessage[];
+}
 
-	let {
-		disabled = false,
-		resources = [],
-		messages = [],
-		toggleResource,
-		selectedResources
-	}: Props = $props();
+const {
+	disabled = false,
+	resources = [],
+	messages = [],
+	toggleResource,
+	selectedResources,
+}: Props = $props();
 
-	// No need for dropdown state with DaisyUI dropdown
+// No need for dropdown state with DaisyUI dropdown
 
-	// Extract embedded resources from messages and combine with resources prop
-	let allResources = $derived.by(() => {
-		const embeddedResources: Resource[] = [];
+// Extract embedded resources from messages and combine with resources prop
+const _allResources = $derived.by(() => {
+	const embeddedResources: Resource[] = [];
 
-		for (const message of messages || []) {
-			if (message.role !== 'assistant') continue;
+	for (const message of messages || []) {
+		if (message.role !== "assistant") continue;
 
-			for (const item of message.items || []) {
-				if (item.type !== 'tool') continue;
+		for (const item of message.items || []) {
+			if (item.type !== "tool") continue;
 
-				for (const content of item.output?.content || []) {
-					if (content.type === 'resource') {
-						embeddedResources.push({
-							uri: content.resource.uri,
-							name:
-								content.resource.name ||
-								content.resource.uri.split('/').pop() ||
-								content.resource.uri,
-							description: content.resource.description,
-							title: content.resource.title,
-							mimeType: content.resource.mimeType,
-							size: content.resource.size,
-							annotations: content.resource.annotations,
-							_meta: content.resource._meta
-						});
-					} else if (content.type === 'resource_link') {
-						embeddedResources.push({
-							uri: content.uri,
-							name: content.name || content.uri.split('/').pop() || content.uri,
-							title: content.name || content.uri.split('/').pop() || content.uri,
-							description: content.description
-						});
-					}
+			for (const content of item.output?.content || []) {
+				if (content.type === "resource") {
+					embeddedResources.push({
+						uri: content.resource.uri,
+						name:
+							content.resource.name ||
+							content.resource.uri.split("/").pop() ||
+							content.resource.uri,
+						description: content.resource.description,
+						title: content.resource.title,
+						mimeType: content.resource.mimeType,
+						size: content.resource.size,
+						annotations: content.resource.annotations,
+						_meta: content.resource._meta,
+					});
+				} else if (content.type === "resource_link") {
+					embeddedResources.push({
+						uri: content.uri,
+						name: content.name || content.uri.split("/").pop() || content.uri,
+						title: content.name || content.uri.split("/").pop() || content.uri,
+						description: content.description,
+					});
 				}
 			}
 		}
+	}
 
-		// Remove duplicates based on URI and combine with existing resources
-		return [...resources, ...embeddedResources].filter(
-			(resource, index, self) =>
-				index === self.findIndex((r) => r.uri === resource.uri) &&
-				!resource.uri.startsWith('ui:') &&
-				!resource.uri.startsWith('chat:')
-		);
-	});
+	// Remove duplicates based on URI and combine with existing resources
+	return [...resources, ...embeddedResources].filter(
+		(resource, index, self) =>
+			index === self.findIndex((r) => r.uri === resource.uri) &&
+			!resource.uri.startsWith("ui:") &&
+			!resource.uri.startsWith("chat:"),
+	);
+});
 
-	// No need for click handler with DaisyUI dropdown
+// No need for click handler with DaisyUI dropdown
 </script>
 
 <!-- Resources dropdown using DaisyUI -->

--- a/packages/ui/src/lib/components/MessageSlashPrompts.svelte
+++ b/packages/ui/src/lib/components/MessageSlashPrompts.svelte
@@ -1,55 +1,58 @@
 <script lang="ts">
-	import type { Prompt } from '$lib/types.js';
+import type { Prompt } from "$lib/types.js";
 
-	interface Props {
-		prompts: Prompt[];
-		onPrompt?: (promptName: string) => void;
-		message: string;
-	}
+interface Props {
+	prompts: Prompt[];
+	onPrompt?: (promptName: string) => void;
+	message: string;
+}
 
-	let { prompts, onPrompt, message }: Props = $props();
+const { prompts, onPrompt, message }: Props = $props();
 
-	// Slash command state
-	let showSlashCommands = $derived(message.trim().startsWith('/'));
-	let filteredPrompts = $derived.by(() => {
-		if (!showSlashCommands) return [];
-		const query = message.trim().slice(1).toLowerCase();
-		return prompts.filter(
-			(prompt) =>
-				prompt.name.toLowerCase().includes(query) ||
-				prompt.title?.toLowerCase().includes(query) ||
-				prompt.description?.toLowerCase().includes(query)
-		);
-	});
-	let selectedCommandIndex = $state(0);
-	let slashQuery = $derived(message.trim().slice(1).toLowerCase());
+// Slash command state
+const showSlashCommands = $derived(message.trim().startsWith("/"));
+const filteredPrompts = $derived.by(() => {
+	if (!showSlashCommands) return [];
+	const query = message.trim().slice(1).toLowerCase();
+	return prompts.filter(
+		(prompt) =>
+			prompt.name.toLowerCase().includes(query) ||
+			prompt.title?.toLowerCase().includes(query) ||
+			prompt.description?.toLowerCase().includes(query),
+	);
+});
+let selectedCommandIndex = $state(0);
+const _slashQuery = $derived(message.trim().slice(1).toLowerCase());
 
-	export function handleKeydown(e: KeyboardEvent): boolean {
-		// Handle slash command navigation
-		if (showSlashCommands) {
-			switch (e.key) {
-				case 'ArrowDown':
-					e.preventDefault();
-					selectedCommandIndex = Math.min(selectedCommandIndex + 1, filteredPrompts.length - 1);
-					return true;
-				case 'ArrowUp':
-					e.preventDefault();
-					selectedCommandIndex = Math.max(selectedCommandIndex - 1, 0);
-					return true;
-				case 'Enter':
-					e.preventDefault();
-					if (filteredPrompts[selectedCommandIndex]) {
-						executeSlashCommand(filteredPrompts[selectedCommandIndex]);
-					}
-					return true;
-			}
+export function handleKeydown(e: KeyboardEvent): boolean {
+	// Handle slash command navigation
+	if (showSlashCommands) {
+		switch (e.key) {
+			case "ArrowDown":
+				e.preventDefault();
+				selectedCommandIndex = Math.min(
+					selectedCommandIndex + 1,
+					filteredPrompts.length - 1,
+				);
+				return true;
+			case "ArrowUp":
+				e.preventDefault();
+				selectedCommandIndex = Math.max(selectedCommandIndex - 1, 0);
+				return true;
+			case "Enter":
+				e.preventDefault();
+				if (filteredPrompts[selectedCommandIndex]) {
+					executeSlashCommand(filteredPrompts[selectedCommandIndex]);
+				}
+				return true;
 		}
-		return false;
 	}
+	return false;
+}
 
-	function executeSlashCommand(prompt: Prompt) {
-		onPrompt?.(prompt.name);
-	}
+function executeSlashCommand(prompt: Prompt) {
+	onPrompt?.(prompt.name);
+}
 </script>
 
 {#if showSlashCommands}

--- a/packages/ui/src/lib/components/Messages.svelte
+++ b/packages/ui/src/lib/components/Messages.svelte
@@ -1,44 +1,57 @@
 <script lang="ts">
-	import Message from './Message.svelte';
-	import type { ChatMessage, ChatResult, Agent, Attachment, ResourceContents } from '$lib/types';
-	import AgentHeader from '$lib/components/AgentHeader.svelte';
+import type {
+	Agent,
+	Attachment,
+	ChatMessage,
+	ChatResult,
+	ResourceContents,
+} from "$lib/types";
 
-	interface Props {
-		messages: ChatMessage[];
-		onSend?: (message: string, attachments?: Attachment[]) => Promise<ChatResult | void>;
-		isLoading?: boolean;
-		agent?: Agent;
-		onReadResource?: (uri: string) => Promise<{ contents: ResourceContents[] }>;
-	}
+interface Props {
+	messages: ChatMessage[];
+	onSend?: (
+		message: string,
+		attachments?: Attachment[],
+	) => Promise<ChatResult | undefined>;
+	isLoading?: boolean;
+	agent?: Agent;
+	onReadResource?: (uri: string) => Promise<{ contents: ResourceContents[] }>;
+}
 
-	let { messages, onSend, isLoading = false, agent, onReadResource }: Props = $props();
-	let messageGroups = $derived.by(() => {
-		return messages.reduce((acc, message) => {
-			if (message.role === 'user' || acc.length === 0) {
-				acc.push([message]);
-			} else {
-				acc[acc.length - 1].push(message);
-			}
-			return acc;
-		}, [] as ChatMessage[][]);
-	});
+const {
+	messages,
+	onSend,
+	isLoading = false,
+	agent,
+	onReadResource,
+}: Props = $props();
+const messageGroups = $derived.by(() => {
+	return messages.reduce((acc, message) => {
+		if (message.role === "user" || acc.length === 0) {
+			acc.push([message]);
+		} else {
+			acc[acc.length - 1].push(message);
+		}
+		return acc;
+	}, [] as ChatMessage[][]);
+});
 
-	// Check if any messages have content (text items)
-	let hasMessageContent = $derived(
-		messageGroups[messageGroups.length - 1]?.some(
-			(message) =>
-				message.role === 'assistant' &&
-				message.items &&
-				message.items.some(
-					(item) =>
-						item.type === 'tool' ||
-						(item.type === 'text' && item.text && item.text.trim().length > 0)
-				)
-		)
-	);
+// Check if any messages have content (text items)
+const hasMessageContent = $derived(
+	messageGroups[messageGroups.length - 1]?.some(
+		(message) =>
+			message.role === "assistant" &&
+			message.items &&
+			message.items.some(
+				(item) =>
+					item.type === "tool" ||
+					(item.type === "text" && item.text && item.text.trim().length > 0),
+			),
+	),
+);
 
-	// Show loading indicator when loading and no content has been printed yet
-	let showLoadingIndicator = $derived(isLoading && !hasMessageContent);
+// Show loading indicator when loading and no content has been printed yet
+const _showLoadingIndicator = $derived(isLoading && !hasMessageContent);
 </script>
 
 <div id="message-groups" class="flex flex-col space-y-4 pt-4">

--- a/packages/ui/src/lib/components/Notifications.svelte
+++ b/packages/ui/src/lib/components/Notifications.svelte
@@ -1,43 +1,41 @@
 <script lang="ts">
-	import { slide } from 'svelte/transition';
-	import { X, CheckCircle, AlertCircle, AlertTriangle, Info, Copy } from '@lucide/svelte';
-	import type { Notification } from '$lib/types';
-	import { getNotificationContext } from '$lib/context/notifications.svelte';
+import { getNotificationContext } from "$lib/context/notifications.svelte";
+import type { Notification } from "$lib/types";
 
-	let copiedTooltipId = $state<string | null>(null);
-	const notifications = getNotificationContext();
+let _copiedTooltipId = $state<string | null>(null);
+const notifications = getNotificationContext();
 
-	function getNotificationClasses(type: Notification['type']): string {
-		const baseClasses = 'alert shadow-lg border';
+function _getNotificationClasses(type: Notification["type"]): string {
+	const baseClasses = "alert shadow-lg border";
 
-		switch (type) {
-			case 'success':
-				return `${baseClasses} alert-success`;
-			case 'error':
-				return `${baseClasses} alert-error`;
-			case 'warning':
-				return `${baseClasses} alert-warning`;
-			case 'info':
-				return `${baseClasses} alert-info`;
-			default:
-				return `${baseClasses}`;
-		}
+	switch (type) {
+		case "success":
+			return `${baseClasses} alert-success`;
+		case "error":
+			return `${baseClasses} alert-error`;
+		case "warning":
+			return `${baseClasses} alert-warning`;
+		case "info":
+			return `${baseClasses} alert-info`;
+		default:
+			return `${baseClasses}`;
 	}
+}
 
-	function handleClose(id: string) {
-		notifications.remove(id);
-	}
+function _handleClose(id: string) {
+	notifications.remove(id);
+}
 
-	async function copyNotificationContent(notification: Notification) {
-		const content = notification.message
-			? `${notification.title}\n${notification.message}`
-			: notification.title;
-		await navigator.clipboard.writeText(content);
-		copiedTooltipId = notification.id;
-		setTimeout(() => {
-			copiedTooltipId = null;
-		}, 2000);
-	}
+async function _copyNotificationContent(notification: Notification) {
+	const content = notification.message
+		? `${notification.title}\n${notification.message}`
+		: notification.title;
+	await navigator.clipboard.writeText(content);
+	_copiedTooltipId = notification.id;
+	setTimeout(() => {
+		_copiedTooltipId = null;
+	}, 2000);
+}
 </script>
 
 <!-- Notification container -->

--- a/packages/ui/src/lib/components/Prompt.svelte
+++ b/packages/ui/src/lib/components/Prompt.svelte
@@ -1,80 +1,91 @@
 <script lang="ts">
-	import type { Attachment, ChatResult, Prompt, PromptArgument } from '$lib/types';
+import type {
+	Attachment,
+	ChatResult,
+	Prompt,
+	PromptArgument,
+} from "$lib/types";
 
-	interface Props {
-		prompt: Prompt;
-		onSend?: (message: string, attachments?: Attachment[]) => Promise<ChatResult | void>;
-		onCancel?: () => void;
-		open?: boolean;
-	}
+interface Props {
+	prompt: Prompt;
+	onSend?: (
+		message: string,
+		attachments?: Attachment[],
+	) => Promise<ChatResult | undefined>;
+	onCancel?: () => void;
+	open?: boolean;
+}
 
-	let { prompt, onSend, onCancel, open: showDialog = false }: Props = $props();
+let { prompt, onSend, onCancel, open: showDialog = false }: Props = $props();
 
-	let formData = $state<{ [key: string]: string }>({});
+let formData = $state<{ [key: string]: string }>({});
 
-	// Initialize form data when dialog opens
-	$effect(() => {
-		if (showDialog && prompt.arguments) {
-			const newFormData: { [key: string]: string } = {};
-			for (const arg of prompt.arguments) {
-				newFormData[arg.name] = '';
-			}
-			formData = newFormData;
-		} else if (showDialog) {
-			executePrompt({});
-		}
-	});
-
-	function handleClick() {
-		if (prompt.arguments && prompt.arguments.length > 0) {
-			showDialog = true;
-		} else {
-			executePrompt({});
-		}
-	}
-
-	function handleKeyDown(event: KeyboardEvent) {
-		if (event.key === 'Enter' || event.key === ' ') {
-			event.preventDefault();
-			handleClick();
-		}
-	}
-
-	function executePrompt(args: { [key: string]: string }) {
-		const promptMessage = JSON.stringify({
-			type: 'prompt',
-			payload: {
-				promptName: prompt.name,
-				params: args
-			}
-		});
-		onSend?.(promptMessage);
-		showDialog = false;
-	}
-
-	function handleAccept() {
-		executePrompt(formData);
-	}
-
-	function handleCancel() {
-		showDialog = false;
-		onCancel?.();
-	}
-
-	function isRequired(arg: PromptArgument): boolean {
-		return arg.required ?? false;
-	}
-
-	function validateForm(): boolean {
-		if (!prompt.arguments) return true;
-
+// Initialize form data when dialog opens
+$effect(() => {
+	if (showDialog && prompt.arguments) {
+		const newFormData: { [key: string]: string } = {};
 		for (const arg of prompt.arguments) {
-			if (isRequired(arg) && (!formData[arg.name] || formData[arg.name].trim() === '')) {
-				return false;
-			}
+			newFormData[arg.name] = "";
 		}
-		return true;
+		formData = newFormData;
+	} else if (showDialog) {
+		executePrompt({});
 	}
+});
+
+function handleClick() {
+	if (prompt.arguments && prompt.arguments.length > 0) {
+		showDialog = true;
+	} else {
+		executePrompt({});
+	}
+}
+
+function _handleKeyDown(event: KeyboardEvent) {
+	if (event.key === "Enter" || event.key === " ") {
+		event.preventDefault();
+		handleClick();
+	}
+}
+
+function executePrompt(args: { [key: string]: string }) {
+	const promptMessage = JSON.stringify({
+		type: "prompt",
+		payload: {
+			promptName: prompt.name,
+			params: args,
+		},
+	});
+	onSend?.(promptMessage);
+	showDialog = false;
+}
+
+function _handleAccept() {
+	executePrompt(formData);
+}
+
+function _handleCancel() {
+	showDialog = false;
+	onCancel?.();
+}
+
+function isRequired(arg: PromptArgument): boolean {
+	return arg.required ?? false;
+}
+
+function _validateForm(): boolean {
+	if (!prompt.arguments) return true;
+
+	for (const arg of prompt.arguments) {
+		if (
+			isRequired(arg) &&
+			(!formData[arg.name] || formData[arg.name].trim() === "")
+		) {
+			return false;
+		}
+	}
+	return true;
+}
 </script>
 
 {#if !open}

--- a/packages/ui/src/lib/components/Thread.svelte
+++ b/packages/ui/src/lib/components/Thread.svelte
@@ -1,8 +1,4 @@
 <script lang="ts">
-import { ChevronDown, Monitor, Upload } from "@lucide/svelte";
-import Elicitation from "$lib/components/Elicitation.svelte";
-import Prompt from "$lib/components/Prompt.svelte";
-import BrowserViewer from "$lib/components/BrowserViewer.svelte";
 import type {
 	Agent,
 	Attachment,
@@ -16,8 +12,6 @@ import type {
 	UploadedFile,
 	UploadingFile,
 } from "$lib/types";
-import MessageInput from "./MessageInput.svelte";
-import Messages from "./Messages.svelte";
 
 interface Props {
 	messages: ChatMessage[];
@@ -31,7 +25,7 @@ interface Props {
 	onSendMessage?: (
 		message: string,
 		attachments?: Attachment[],
-	) => Promise<ChatResult | void>;
+	) => Promise<ChatResult | undefined>;
 	onFileUpload?: (
 		file: File,
 		opts?: { controller?: AbortController },
@@ -70,12 +64,12 @@ const {
 }: Props = $props();
 
 let messagesContainer: HTMLElement;
-let showScrollButton = $state(false);
+let _showScrollButton = $state(false);
 let previousLastMessageId = $state<string | null>(null);
-const hasMessages = $derived(messages && messages.length > 0);
-let selectedPrompt = $state<string | undefined>();
-let showBrowserViewer = $state(false);
-let browserViewerWidth = $state(50); // percentage
+const _hasMessages = $derived(messages && messages.length > 0);
+const _selectedPrompt = $state<string | undefined>();
+let _showBrowserViewer = $state(false);
+let _browserViewerWidth = $state(50); // percentage
 let isResizing = $state(false);
 let browserAvailable = $state(false);
 
@@ -87,7 +81,7 @@ function browserStatusUrl() {
 	return new URL("/browser/status", window.location.origin).toString();
 }
 
-function startResize(e: MouseEvent) {
+function _startResize(e: MouseEvent) {
 	isResizing = true;
 	e.preventDefault();
 }
@@ -96,7 +90,7 @@ function stopResize() {
 	isResizing = false;
 }
 
-function resize(e: MouseEvent) {
+function _resize(e: MouseEvent) {
 	if (!isResizing) return;
 	const container = e.currentTarget as HTMLElement;
 	if (!container) return;
@@ -105,7 +99,7 @@ function resize(e: MouseEvent) {
 	const newWidth = ((rect.right - e.clientX) / rect.width) * 100;
 
 	// Constrain between 20% and 80%
-	browserViewerWidth = Math.max(20, Math.min(80, newWidth));
+	_browserViewerWidth = Math.max(20, Math.min(80, newWidth));
 }
 
 $effect(() => {
@@ -124,10 +118,12 @@ $effect(() => {
 
 	const handleStatus = (event: Event) => {
 		try {
-			const data = JSON.parse((event as MessageEvent<string>).data) as { available?: boolean };
+			const data = JSON.parse((event as MessageEvent<string>).data) as {
+				available?: boolean;
+			};
 			browserAvailable = !!data.available;
 			if (!browserAvailable) {
-				showBrowserViewer = false;
+				_showBrowserViewer = false;
 			}
 		} catch {
 			// Ignore malformed status events and keep the last known state.
@@ -143,10 +139,10 @@ $effect(() => {
 });
 
 // Split elicitations: question type renders inline, others render as modal
-const questionElicitation = $derived(
+const _questionElicitation = $derived(
 	elicitations?.find((e) => e._meta?.["ai.nanobot.meta/question"]) ?? null,
 );
-const modalElicitation = $derived(
+const _modalElicitation = $derived(
 	elicitations?.find((e) => !e._meta?.["ai.nanobot.meta/question"]) ?? null,
 );
 
@@ -171,12 +167,12 @@ $effect(() => {
 	}
 });
 
-function handleScroll() {
+function _handleScroll() {
 	if (!messagesContainer) return;
 
 	const { scrollTop, scrollHeight, clientHeight } = messagesContainer;
 	const isNearBottom = scrollTop + clientHeight >= scrollHeight - 10; // 10px threshold
-	showScrollButton = !isNearBottom;
+	_showScrollButton = !isNearBottom;
 }
 
 function scrollToBottom() {
@@ -189,33 +185,33 @@ function scrollToBottom() {
 }
 
 // Drag-and-drop file upload
-let isDragging = $state(false);
+let _isDragging = $state(false);
 let dragCounter = 0;
 
-function handleDragEnter(e: DragEvent) {
+function _handleDragEnter(e: DragEvent) {
 	e.preventDefault();
 	dragCounter++;
 	if (e.dataTransfer?.types.includes("Files")) {
-		isDragging = true;
+		_isDragging = true;
 	}
 }
 
-function handleDragLeave(e: DragEvent) {
+function _handleDragLeave(e: DragEvent) {
 	e.preventDefault();
 	dragCounter--;
 	if (dragCounter === 0) {
-		isDragging = false;
+		_isDragging = false;
 	}
 }
 
-function handleDragOver(e: DragEvent) {
+function _handleDragOver(e: DragEvent) {
 	e.preventDefault();
 }
 
-async function handleDrop(e: DragEvent) {
+async function _handleDrop(e: DragEvent) {
 	e.preventDefault();
 	dragCounter = 0;
-	isDragging = false;
+	_isDragging = false;
 
 	if (!onFileUpload || !e.dataTransfer?.files.length) return;
 

--- a/packages/ui/src/lib/components/ThreadFromChat.svelte
+++ b/packages/ui/src/lib/components/ThreadFromChat.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import type { ChatService } from "$lib/chat.svelte";
-import Thread from "$lib/components/Thread.svelte";
 
 interface Props {
 	chat: ChatService;

--- a/packages/ui/src/lib/components/Threads.svelte
+++ b/packages/ui/src/lib/components/Threads.svelte
@@ -1,69 +1,74 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import { MoreVertical, Edit, Trash2, X, Check } from '@lucide/svelte';
-	import type { Chat } from '$lib/types';
-	import { resolve } from '$app/paths';
+import { goto } from "$app/navigation";
+import { resolve } from "$app/paths";
+import type { Chat } from "$lib/types";
 
-	interface Props {
-		threads: Chat[];
-		onRename: (threadId: string, newTitle: string) => void;
-		onDelete: (threadId: string) => void;
-		isLoading?: boolean;
-		onThreadClick?: () => void;
-	}
+interface Props {
+	threads: Chat[];
+	onRename: (threadId: string, newTitle: string) => void;
+	onDelete: (threadId: string) => void;
+	isLoading?: boolean;
+	onThreadClick?: () => void;
+}
 
-	let { threads, onRename, onDelete, isLoading = false, onThreadClick }: Props = $props();
+const {
+	threads,
+	onRename,
+	onDelete,
+	isLoading = false,
+	onThreadClick,
+}: Props = $props();
 
-	let editingThreadId = $state<string | null>(null);
-	let editTitle = $state('');
+let editingThreadId = $state<string | null>(null);
+let editTitle = $state("");
 
-	function navigateToThread(threadId: string) {
-		goto(resolve(`/c/${threadId}`));
-		onThreadClick?.();
-	}
+function _navigateToThread(threadId: string) {
+	goto(resolve(`/c/${threadId}`));
+	onThreadClick?.();
+}
 
-	function formatTime(timestamp: string): string {
-		const now = new Date();
-		const diff = now.getTime() - new Date(timestamp).getTime();
-		const minutes = Math.floor(diff / (1000 * 60));
-		const hours = Math.floor(diff / (1000 * 60 * 60));
-		const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+function _formatTime(timestamp: string): string {
+	const now = new Date();
+	const diff = now.getTime() - new Date(timestamp).getTime();
+	const minutes = Math.floor(diff / (1000 * 60));
+	const hours = Math.floor(diff / (1000 * 60 * 60));
+	const days = Math.floor(diff / (1000 * 60 * 60 * 24));
 
-		if (minutes < 1) return 'now';
-		if (minutes < 60) return `${minutes}m`;
-		if (hours < 24) return `${hours}h`;
-		return `${days}d`;
-	}
+	if (minutes < 1) return "now";
+	if (minutes < 60) return `${minutes}m`;
+	if (hours < 24) return `${hours}h`;
+	return `${days}d`;
+}
 
-	function startRename(threadId: string, currentTitle: string) {
-		editingThreadId = threadId;
-		editTitle = currentTitle || '';
-	}
+function _startRename(threadId: string, currentTitle: string) {
+	editingThreadId = threadId;
+	editTitle = currentTitle || "";
+}
 
-	function saveRename() {
-		if (editingThreadId && editTitle.trim()) {
-			onRename(editingThreadId, editTitle.trim());
-			editingThreadId = null;
-			editTitle = '';
-		}
-	}
-
-	function cancelRename() {
+function saveRename() {
+	if (editingThreadId && editTitle.trim()) {
+		onRename(editingThreadId, editTitle.trim());
 		editingThreadId = null;
-		editTitle = '';
+		editTitle = "";
 	}
+}
 
-	function handleDelete(threadId: string) {
-		onDelete(threadId);
-	}
+function cancelRename() {
+	editingThreadId = null;
+	editTitle = "";
+}
 
-	function handleKeydown(e: KeyboardEvent) {
-		if (e.key === 'Enter') {
-			saveRename();
-		} else if (e.key === 'Escape') {
-			cancelRename();
-		}
+function _handleDelete(threadId: string) {
+	onDelete(threadId);
+}
+
+function _handleKeydown(e: KeyboardEvent) {
+	if (e.key === "Enter") {
+		saveRename();
+	} else if (e.key === "Escape") {
+		cancelRename();
 	}
+}
 </script>
 
 <div class="flex h-full flex-col">

--- a/packages/ui/src/lib/components/Workspace.svelte
+++ b/packages/ui/src/lib/components/Workspace.svelte
@@ -1,31 +1,41 @@
 <script lang="ts">
-	import type { Attachment, ChatMessage, ChatResult, ChatMessageItemResource } from '$lib/types';
-	import { isUIResource } from '@mcp-ui/client';
-	import MessageItemUI from '$lib/components/MessageItemUI.svelte';
+import { isUIResource } from "@mcp-ui/client";
+import type {
+	Attachment,
+	ChatMessage,
+	ChatMessageItemResource,
+	ChatResult,
+} from "$lib/types";
 
-	interface Props {
-		messages: ChatMessage[];
-		onSendMessage?: (message: string, attachments?: Attachment[]) => Promise<ChatResult | void>;
-	}
+interface Props {
+	messages: ChatMessage[];
+	onSendMessage?: (
+		message: string,
+		attachments?: Attachment[],
+	) => Promise<ChatResult | undefined>;
+}
 
-	let { messages, onSendMessage }: Props = $props();
+const { messages, onSendMessage }: Props = $props();
 
-	let sidecar = $derived.by(() => {
-		for (const message of messages.toReversed()) {
-			for (const item of (message.items ?? []).toReversed()) {
-				if (item.type === 'tool' && item.output && item.output?.content) {
-					for (const output of item.output.content.toReversed()) {
-						if (isUIResource(output) && output.resource._meta?.['ai.nanobot.meta/workspace']) {
-							return output satisfies ChatMessageItemResource;
-						}
+const sidecar = $derived.by(() => {
+	for (const message of messages.toReversed()) {
+		for (const item of (message.items ?? []).toReversed()) {
+			if (item.type === "tool" && item.output && item.output?.content) {
+				for (const output of item.output.content.toReversed()) {
+					if (
+						isUIResource(output) &&
+						output.resource._meta?.["ai.nanobot.meta/workspace"]
+					) {
+						return output satisfies ChatMessageItemResource;
 					}
 				}
 			}
 		}
-		return null;
-	});
+	}
+	return null;
+});
 
-	let key = $derived(sidecar?.resource?.text ?? sidecar?.resource?.blob ?? '');
+const _key = $derived(sidecar?.resource?.text ?? sidecar?.resource?.blob ?? "");
 </script>
 
 {#if key && sidecar}

--- a/packages/ui/src/lib/context/notifications.svelte.ts
+++ b/packages/ui/src/lib/context/notifications.svelte.ts
@@ -1,7 +1,7 @@
-import { getContext, setContext } from 'svelte';
-import type { NotificationStore } from '$lib/stores/notifications.svelte';
+import { getContext, setContext } from "svelte";
+import type { NotificationStore } from "$lib/stores/notifications.svelte";
 
-const NOTIFICATIONS_KEY = Symbol('notifications');
+const NOTIFICATIONS_KEY = Symbol("notifications");
 
 export function setNotificationContext(notifications: NotificationStore) {
 	setContext(NOTIFICATIONS_KEY, notifications);

--- a/packages/ui/src/lib/markdown.ts
+++ b/packages/ui/src/lib/markdown.ts
@@ -1,30 +1,30 @@
-import { Marked } from 'marked';
-import { markedHighlight } from 'marked-highlight';
-import hljs from 'highlight.js';
+import hljs from "highlight.js";
+import { Marked } from "marked";
+import { markedHighlight } from "marked-highlight";
 
 const marked = new Marked(
 	markedHighlight({
-		emptyLangClass: 'hljs',
-		langPrefix: 'hljs language-',
+		emptyLangClass: "hljs",
+		langPrefix: "hljs language-",
 		highlight(code, lang) {
-			const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+			const language = hljs.getLanguage(lang) ? lang : "plaintext";
 			return hljs.highlight(code, { language }).value;
-		}
-	})
+		},
+	}),
 );
 
 marked.setOptions({
 	breaks: true,
-	gfm: true
+	gfm: true,
 });
 
 marked.use({
 	renderer: {
 		link(arg) {
 			const base = marked.Renderer.prototype.link.call(this, arg);
-			return base.replace('<a', '<a target="_blank" rel="noopener noreferrer"');
-		}
-	}
+			return base.replace("<a", '<a target="_blank" rel="noopener noreferrer"');
+		},
+	},
 });
 
 /** Regex pattern for matching code fence lines */
@@ -56,7 +56,7 @@ function parseFenceLine(line: string): FenceLine | null {
 	return {
 		indent: match[1],
 		backtickCount: match[2].length,
-		lang: match[3] || ''
+		lang: match[3] || "",
 	};
 }
 
@@ -80,11 +80,13 @@ function identifyCodeFences(lines: string[]): FenceInfo[] {
 				lineIndex: i,
 				backtickCount: parsed.backtickCount,
 				isOpening: false,
-				lang: '',
-				matchedWith: openFence.startIndex
+				lang: "",
+				matchedWith: openFence.startIndex,
 			});
 
-			const openingInfo = fences.find((f) => f.lineIndex === openFence.startIndex && f.isOpening);
+			const openingInfo = fences.find(
+				(f) => f.lineIndex === openFence.startIndex && f.isOpening,
+			);
 			if (openingInfo) {
 				openingInfo.matchedWith = i;
 			}
@@ -94,7 +96,7 @@ function identifyCodeFences(lines: string[]): FenceInfo[] {
 				lineIndex: i,
 				backtickCount: parsed.backtickCount,
 				isOpening: true,
-				lang: parsed.lang
+				lang: parsed.lang,
 			});
 		}
 	}
@@ -102,10 +104,18 @@ function identifyCodeFences(lines: string[]): FenceInfo[] {
 	return fences;
 }
 
-function findMaxInnerBackticks(fences: FenceInfo[], startLine: number, endLine: number): number {
+function findMaxInnerBackticks(
+	fences: FenceInfo[],
+	startLine: number,
+	endLine: number,
+): number {
 	let max = 0;
 	for (const fence of fences) {
-		if (fence.isOpening && fence.lineIndex > startLine && fence.lineIndex < endLine) {
+		if (
+			fence.isOpening &&
+			fence.lineIndex > startLine &&
+			fence.lineIndex < endLine
+		) {
 			max = Math.max(max, fence.backtickCount);
 		}
 	}
@@ -118,7 +128,11 @@ function calculateAdjustments(fences: FenceInfo[]): Map<number, number> {
 	for (const fence of fences) {
 		if (!fence.isOpening || fence.matchedWith === undefined) continue;
 
-		const maxInnerBackticks = findMaxInnerBackticks(fences, fence.lineIndex, fence.matchedWith);
+		const maxInnerBackticks = findMaxInnerBackticks(
+			fences,
+			fence.lineIndex,
+			fence.matchedWith,
+		);
 
 		if (maxInnerBackticks >= fence.backtickCount) {
 			const newCount = maxInnerBackticks + 1;
@@ -130,7 +144,10 @@ function calculateAdjustments(fences: FenceInfo[]): Map<number, number> {
 	return adjustments;
 }
 
-function applyAdjustments(lines: string[], adjustments: Map<number, number>): string[] {
+function applyAdjustments(
+	lines: string[],
+	adjustments: Map<number, number>,
+): string[] {
 	return lines.map((line, i) => {
 		const newBacktickCount = adjustments.get(i);
 		if (newBacktickCount === undefined) return line;
@@ -138,7 +155,7 @@ function applyAdjustments(lines: string[], adjustments: Map<number, number>): st
 		const parsed = parseFenceLine(line);
 		if (!parsed) return line;
 
-		return parsed.indent + '`'.repeat(newBacktickCount) + parsed.lang;
+		return parsed.indent + "`".repeat(newBacktickCount) + parsed.lang;
 	});
 }
 
@@ -148,15 +165,15 @@ function applyAdjustments(lines: string[], adjustments: Map<number, number>): st
  * the outer fence is expanded to use more backticks to avoid premature closing.
  */
 function fixNestedCodeFences(content: string): string {
-	const lines = content.split('\n');
+	const lines = content.split("\n");
 	const fences = identifyCodeFences(lines);
 	const adjustments = calculateAdjustments(fences);
 	const adjustedLines = applyAdjustments(lines, adjustments);
-	return adjustedLines.join('\n');
+	return adjustedLines.join("\n");
 }
 
 export function renderMarkdown(content: string): string {
-	if (!content) return '';
+	if (!content) return "";
 	const processedContent = fixNestedCodeFences(content);
 	return marked.parse(processedContent) as string;
 }

--- a/packages/ui/src/lib/mcpclient.ts
+++ b/packages/ui/src/lib/mcpclient.ts
@@ -378,7 +378,10 @@ export class SimpleClient {
 			}
 			this.#clearSession();
 			// Retry once with new session
-			return this.exchange(method, params, { abort: opts?.abort, requestId: request.id });
+			return this.exchange(method, params, {
+				abort: opts?.abort,
+				requestId: request.id,
+			});
 		}
 
 		if (!resp.ok) {
@@ -526,7 +529,9 @@ export class SimpleClient {
 							// Fetch the updated resource details
 							this.#fetchResourceDetails(uri).then((resource) => {
 								if (resource) {
-									callbacks.forEach((callback) => callback(resource));
+									callbacks.forEach((callback) => {
+										callback(resource);
+									});
 								}
 							});
 						}
@@ -581,7 +586,7 @@ export class SimpleClient {
 		if (!this.#sseSubscriptions.has(prefix)) {
 			this.#sseSubscriptions.set(prefix, new Set());
 		}
-		this.#sseSubscriptions.get(prefix)!.add(callback);
+		this.#sseSubscriptions.get(prefix)?.add(callback);
 
 		// Ensure SSE connection is established
 		this.#ensureSSEConnection().then(async () => {

--- a/packages/ui/src/lib/notify.ts
+++ b/packages/ui/src/lib/notify.ts
@@ -1,12 +1,12 @@
-import { getNotificationContext } from '$lib/context/notifications.svelte';
+import { getNotificationContext } from "$lib/context/notifications.svelte";
 
 export function logError(error: unknown) {
 	try {
 		const notifications = getNotificationContext();
-		notifications.error('API Error', error?.toString());
+		notifications.error("API Error", error?.toString());
 	} catch {
 		// If context is not available (e.g., during SSR), just log
-		console.error('MCP Tool Error:', error);
+		console.error("MCP Tool Error:", error);
 	}
-	console.error('Error:', error);
+	console.error("Error:", error);
 }

--- a/packages/ui/src/lib/stores/notifications.svelte.ts
+++ b/packages/ui/src/lib/stores/notifications.svelte.ts
@@ -1,26 +1,31 @@
-import type { Notification } from '$lib/types';
-import { SvelteDate } from 'svelte/reactivity';
+import { SvelteDate } from "svelte/reactivity";
+import type { Notification } from "$lib/types";
 
 export class NotificationStore {
 	notifications = $state<Notification[]>([]);
 
-	add(notification: Omit<Notification, 'id' | 'timestamp'>): string {
+	add(notification: Omit<Notification, "id" | "timestamp">): string {
 		const id = crypto.randomUUID();
 		const newNotification: Notification = {
 			...notification,
 			id,
 			timestamp: new SvelteDate(),
 			autoClose:
-				typeof notification.autoClose === 'boolean'
+				typeof notification.autoClose === "boolean"
 					? notification.autoClose
-					: notification.type !== 'error',
-			duration: notification.duration || (notification.type === 'error' ? 0 : 5000) // errors don't auto-close
+					: notification.type !== "error",
+			duration:
+				notification.duration || (notification.type === "error" ? 0 : 5000), // errors don't auto-close
 		};
 
 		this.notifications.push(newNotification);
 
 		// Auto-dismiss if configured
-		if (newNotification.autoClose && newNotification.duration && newNotification.duration > 0) {
+		if (
+			newNotification.autoClose &&
+			newNotification.duration &&
+			newNotification.duration > 0
+		) {
 			setTimeout(() => {
 				this.remove(id);
 			}, newNotification.duration);
@@ -39,18 +44,18 @@ export class NotificationStore {
 
 	// Convenience methods
 	success(title: string, message?: string, duration?: number): string {
-		return this.add({ type: 'success', title, message, duration });
+		return this.add({ type: "success", title, message, duration });
 	}
 
 	error(title: string, message?: string): string {
-		return this.add({ type: 'error', title, message, autoClose: false });
+		return this.add({ type: "error", title, message, autoClose: false });
 	}
 
 	warning(title: string, message?: string, duration?: number): string {
-		return this.add({ type: 'warning', title, message, duration });
+		return this.add({ type: "warning", title, message, duration });
 	}
 
 	info(title: string, message?: string, duration?: number): string {
-		return this.add({ type: 'info', title, message, duration });
+		return this.add({ type: "info", title, message, duration });
 	}
 }

--- a/packages/ui/src/lib/types.ts
+++ b/packages/ui/src/lib/types.ts
@@ -1,4 +1,4 @@
-import type { ChatService } from '$lib/chat.svelte';
+import type { ChatService } from "$lib/chat.svelte";
 
 export interface Agent {
 	id: string;
@@ -18,7 +18,7 @@ export interface Chat {
 	id: string;
 	title: string;
 	created: string;
-	visibility?: 'public' | 'private';
+	visibility?: "public" | "private";
 	readonly?: boolean;
 	taskURI?: string;
 	workflowURIs?: string[];
@@ -27,12 +27,15 @@ export interface Chat {
 export interface ChatMessage {
 	id: string;
 	created?: string;
-	role: 'user' | 'assistant';
+	role: "user" | "assistant";
 	items?: ChatMessageItem[];
 	hasMore?: boolean;
 }
 
-export type ChatMessageItem = ToolOutputItem | ChatMessageItemToolCall | ChatMessageItemReasoning;
+export type ChatMessageItem =
+	| ToolOutputItem
+	| ChatMessageItemToolCall
+	| ChatMessageItemReasoning;
 
 export type ToolOutputItem =
 	| ChatMessageItemImage
@@ -42,7 +45,7 @@ export type ToolOutputItem =
 	| ChatMessageItemResourceLink;
 
 export interface ChatMessageItemToolCall extends ChatMessageItemBase {
-	type: 'tool';
+	type: "tool";
 	arguments?: string;
 	callID?: string;
 	name?: string;
@@ -54,24 +57,24 @@ export interface ChatMessageItemToolCall extends ChatMessageItemBase {
 }
 
 export interface ChatMessageItemImage extends ChatMessageItemBase {
-	type: 'image';
+	type: "image";
 	data: string;
 	mimeType: string;
 }
 
 export interface ChatMessageItemAudio extends ChatMessageItemBase {
-	type: 'audio';
+	type: "audio";
 	data: string;
 	mimeType: string;
 }
 
 export interface ChatMessageItemText extends ChatMessageItemBase {
-	type: 'text';
+	type: "text";
 	text: string;
 }
 
 export interface ChatMessageItemResourceLink extends ChatMessageItemBase {
-	type: 'resource_link';
+	type: "resource_link";
 	name?: string;
 	description?: string;
 	uri: string;
@@ -79,14 +82,14 @@ export interface ChatMessageItemResourceLink extends ChatMessageItemBase {
 }
 
 export interface ChatMessageItemReasoning extends ChatMessageItemBase {
-	type: 'reasoning';
+	type: "reasoning";
 	summary?: {
 		text: string;
 	}[];
 }
 
 export interface ChatMessageItemResource extends ChatMessageItemBase {
-	type: 'resource';
+	type: "resource";
 	resource: {
 		uri: string;
 		name?: string;
@@ -110,14 +113,14 @@ export interface ChatMessageItemBase {
 	hasMore?: boolean;
 	_meta?: { [key: string]: unknown };
 	type:
-		| 'text'
-		| 'image'
-		| 'audio'
-		| 'toolCall'
-		| 'resource'
-		| 'resource_link'
-		| 'tool'
-		| 'reasoning';
+		| "text"
+		| "image"
+		| "audio"
+		| "toolCall"
+		| "resource"
+		| "resource_link"
+		| "tool"
+		| "reasoning";
 }
 
 export interface ChatRequest {
@@ -141,13 +144,13 @@ export interface ChatResult {
 export interface Event {
 	id?: string | number;
 	type:
-		| 'message'
-		| 'history-start'
-		| 'history-end'
-		| 'chat-in-progress'
-		| 'chat-done'
-		| 'error'
-		| 'elicitation/create';
+		| "message"
+		| "history-start"
+		| "history-end"
+		| "chat-in-progress"
+		| "chat-done"
+		| "error"
+		| "elicitation/create";
 	message?: ChatMessage;
 	data?: unknown;
 	error?: string;
@@ -155,7 +158,7 @@ export interface Event {
 
 export interface Notification {
 	id: string;
-	type: 'success' | 'error' | 'warning' | 'info';
+	type: "success" | "error" | "warning" | "info";
 	title: string;
 	message?: string;
 	timestamp: Date;
@@ -243,7 +246,7 @@ export interface Icon {
 	 *
 	 * If not provided, the client should assume the icon can be used with any theme.
 	 */
-	theme?: 'light' | 'dark';
+	theme?: "light" | "dark";
 }
 
 export interface BaseMetadata {
@@ -266,7 +269,7 @@ export interface Elicitation {
 	id: string | number;
 	message: string;
 	requestedSchema: {
-		type: 'object';
+		type: "object";
 		properties: {
 			[key: string]: PrimitiveSchemaDefinition;
 		};
@@ -276,23 +279,27 @@ export interface Elicitation {
 }
 
 export interface ElicitationResult {
-	action: 'accept' | 'decline' | 'cancel';
+	action: "accept" | "decline" | "cancel";
 	content?: { [key: string]: string | number | boolean };
 }
 
-export type PrimitiveSchemaDefinition = StringSchema | NumberSchema | BooleanSchema | EnumSchema;
+export type PrimitiveSchemaDefinition =
+	| StringSchema
+	| NumberSchema
+	| BooleanSchema
+	| EnumSchema;
 
 export interface StringSchema {
-	type: 'string';
+	type: "string";
 	title?: string;
 	description?: string;
 	minLength?: number;
 	maxLength?: number;
-	format?: 'email' | 'uri' | 'date' | 'date-time';
+	format?: "email" | "uri" | "date" | "date-time";
 }
 
 export interface NumberSchema {
-	type: 'number' | 'integer';
+	type: "number" | "integer";
 	title?: string;
 	description?: string;
 	minimum?: number;
@@ -300,23 +307,23 @@ export interface NumberSchema {
 }
 
 export interface BooleanSchema {
-	type: 'boolean';
+	type: "boolean";
 	title?: string;
 	description?: string;
 	default?: boolean;
 }
 
 export interface EnumSchema {
-	type: 'string';
+	type: "string";
 	title?: string;
 	description?: string;
 	enum: string[];
 	enumNames?: string[]; // Display names for enum values
 }
 
-export const MessageMimeType = 'application/vnd.nanobot.chat.message+json';
-export const HistoryMimeType = 'application/vnd.nanobot.chat.history+json';
-export const ToolResultMimeType = 'application/vnd.nanobot.tool.result+json';
+export const MessageMimeType = "application/vnd.nanobot.chat.message+json";
+export const HistoryMimeType = "application/vnd.nanobot.chat.history+json";
+export const ToolResultMimeType = "application/vnd.nanobot.tool.result+json";
 
 export interface UploadedFile {
 	id: string;
@@ -332,10 +339,10 @@ export interface UploadingFile {
 }
 
 // Workspace types
-export const SessionMimeType = 'application/vnd.nanobot.session+json';
+export const SessionMimeType = "application/vnd.nanobot.session+json";
 
 // Forward declaration for WorkspaceClient
-export type { SimpleClient } from './mcpclient';
+export type { SimpleClient } from "./mcpclient";
 
 export interface Workspace extends Icons {
 	id: string;
@@ -384,7 +391,7 @@ export interface WorkspaceClient {
 export interface InitializationResult {
 	capabilities?: {
 		experimental?: {
-			'ai.nanobot'?: {
+			"ai.nanobot"?: {
 				session?: {
 					ui?: boolean;
 					workspace?: {
@@ -399,5 +406,5 @@ export interface InitializationResult {
 	};
 }
 
-export const UIPath = '/mcp/ui';
-export const ChatPath = '/mcp/chat';
+export const UIPath = "/mcp/ui";
+export const ChatPath = "/mcp/chat";

--- a/packages/ui/src/novnc.d.ts
+++ b/packages/ui/src/novnc.d.ts
@@ -1,4 +1,4 @@
-declare module '@novnc/novnc/lib/rfb.js' {
+declare module "@novnc/novnc/lib/rfb.js" {
 	interface RFBSecurityFailureDetail {
 		status: number | string;
 	}
@@ -27,7 +27,7 @@ declare module '@novnc/novnc/lib/rfb.js' {
 		addEventListener<K extends keyof RFBEventMap>(
 			type: K,
 			listener: (this: RFB, event: RFBEventMap[K]) => void,
-			options?: boolean | AddEventListenerOptions
+			options?: boolean | AddEventListenerOptions,
 		): void;
 	}
 

--- a/packages/ui/src/routes/+layout.svelte
+++ b/packages/ui/src/routes/+layout.svelte
@@ -1,116 +1,132 @@
 <script lang="ts">
-	import '../app.css';
-	import favicon from '$lib/assets/favicon.svg';
-	import Threads from '$lib/components/Threads.svelte';
-	import Notifications from '$lib/components/Notifications.svelte';
-	import { defaultChatApi } from '$lib/chat.svelte';
-	import { NotificationStore } from '$lib/stores/notifications.svelte';
-	import { setNotificationContext } from '$lib/context/notifications.svelte';
-	import { onMount } from 'svelte';
-	import { browser } from '$app/environment';
-	import { Menu, X, SidebarOpen, SidebarClose, Sun, Moon, SquarePen } from '@lucide/svelte';
-	import type { Chat } from '$lib/types';
-	import { resolve } from '$app/paths';
+import "../app.css";
+import { onMount } from "svelte";
+import { browser } from "$app/environment";
+import { resolve } from "$app/paths";
+import { defaultChatApi } from "$lib/chat.svelte";
+import { setNotificationContext } from "$lib/context/notifications.svelte";
+import { NotificationStore } from "$lib/stores/notifications.svelte";
+import type { Chat } from "$lib/types";
 
-	let { children } = $props();
+const { children } = $props();
 
-	let threads = $state<Chat[]>([]);
-	let isLoading = $state(true);
-	let isSidebarCollapsed = $state(false);
-	let isMobileSidebarOpen = $state(false);
-	let currentTheme = $state('nanobotlight');
-	let currentLogoUrl = $state('/assets/nanobot.svg');
-	const root = resolve('/');
-	const newThread = resolve('/');
-	const notifications = new NotificationStore();
+let threads = $state<Chat[]>([]);
+let _isLoading = $state(true);
+let isSidebarCollapsed = $state(false);
+let isMobileSidebarOpen = $state(false);
+let currentTheme = $state("nanobotlight");
+let _currentLogoUrl = $state("/assets/nanobot.svg");
+const _root = resolve("/");
+const _newThread = resolve("/");
+const notifications = new NotificationStore();
 
-	// Set notification context for global access
-	setNotificationContext(notifications);
+// Set notification context for global access
+setNotificationContext(notifications);
 
-	onMount(async () => {
-		// Load sidebar state from localStorage (desktop only)
-		if (browser && window.innerWidth >= 1024) {
-			const saved = localStorage.getItem('sidebar-collapsed');
-			if (saved !== null) {
-				isSidebarCollapsed = JSON.parse(saved);
-			}
-		}
-
-		// Load theme from localStorage or detect system preference
-		if (browser) {
-			const savedTheme = localStorage.getItem('theme');
-			if (savedTheme) {
-				currentTheme = savedTheme;
-			} else {
-				// Default to system preference
-				const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-				currentTheme = prefersDark ? 'nanobotdark' : 'nanobotlight';
-			}
-			// Set theme on document
-			document.documentElement.setAttribute('data-theme', currentTheme);
-		}
-
-		threads = await defaultChatApi.getThreads()
-		isLoading = false;
-	});
-
-	$effect(() => {
-		if (currentTheme) {
-			requestAnimationFrame(() => {
-				const logoUrlAttribute = getComputedStyle(document.documentElement).getPropertyValue('--logo-url');
-				currentLogoUrl = logoUrlAttribute || '/assets/nanobot.svg';
-			});
-		}
-	})
-
-	function toggleDesktopSidebar() {
-		if (browser && window.innerWidth >= 1024) {
-			isSidebarCollapsed = !isSidebarCollapsed;
-			localStorage.setItem('sidebar-collapsed', JSON.stringify(isSidebarCollapsed));
+onMount(async () => {
+	// Load sidebar state from localStorage (desktop only)
+	if (browser && window.innerWidth >= 1024) {
+		const saved = localStorage.getItem("sidebar-collapsed");
+		if (saved !== null) {
+			isSidebarCollapsed = JSON.parse(saved);
 		}
 	}
 
-	function toggleMobileSidebar() {
-		isMobileSidebarOpen = !isMobileSidebarOpen;
-	}
-
-	function closeMobileSidebar() {
-		isMobileSidebarOpen = false;
-	}
-
-	async function handleRenameThread(threadId: string, newTitle: string) {
-		try {
-			await defaultChatApi.renameThread(threadId, newTitle);
-			const threadIndex = threads.findIndex((t) => t.id === threadId);
-			if (threadIndex !== -1) {
-				threads[threadIndex].title = newTitle;
-			}
-			notifications.success('Thread Renamed', `Successfully renamed to "${newTitle}"`);
-		} catch (error) {
-			notifications.error('Rename Failed', 'Unable to rename the thread. Please try again.');
-			console.error('Failed to rename thread:', error);
+	// Load theme from localStorage or detect system preference
+	if (browser) {
+		const savedTheme = localStorage.getItem("theme");
+		if (savedTheme) {
+			currentTheme = savedTheme;
+		} else {
+			// Default to system preference
+			const prefersDark = window.matchMedia(
+				"(prefers-color-scheme: dark)",
+			).matches;
+			currentTheme = prefersDark ? "nanobotdark" : "nanobotlight";
 		}
+		// Set theme on document
+		document.documentElement.setAttribute("data-theme", currentTheme);
 	}
 
-	async function handleDeleteThread(threadId: string) {
-		try {
-			await defaultChatApi.deleteThread(threadId);
-			const threadToDelete = threads.find((t) => t.id === threadId);
-			threads = threads.filter((t) => t.id !== threadId);
-			notifications.success('Thread Deleted', `Deleted "${threadToDelete?.title || 'thread'}"`);
-		} catch (error) {
-			notifications.error('Delete Failed', 'Unable to delete the thread. Please try again.');
-			console.error('Failed to delete thread:', error);
-		}
-	}
+	threads = await defaultChatApi.getThreads();
+	_isLoading = false;
+});
 
-	function toggleTheme() {
-		if (browser) {
-			currentTheme = currentTheme === 'nanobotlight' ? 'nanobotdark' : 'nanobotlight';
-			document.documentElement.setAttribute('data-theme', currentTheme);
-			localStorage.setItem('theme', currentTheme);
-		}
+$effect(() => {
+	if (currentTheme) {
+		requestAnimationFrame(() => {
+			const logoUrlAttribute = getComputedStyle(
+				document.documentElement,
+			).getPropertyValue("--logo-url");
+			_currentLogoUrl = logoUrlAttribute || "/assets/nanobot.svg";
+		});
 	}
+});
+
+function _toggleDesktopSidebar() {
+	if (browser && window.innerWidth >= 1024) {
+		isSidebarCollapsed = !isSidebarCollapsed;
+		localStorage.setItem(
+			"sidebar-collapsed",
+			JSON.stringify(isSidebarCollapsed),
+		);
+	}
+}
+
+function _toggleMobileSidebar() {
+	isMobileSidebarOpen = !isMobileSidebarOpen;
+}
+
+function _closeMobileSidebar() {
+	isMobileSidebarOpen = false;
+}
+
+async function _handleRenameThread(threadId: string, newTitle: string) {
+	try {
+		await defaultChatApi.renameThread(threadId, newTitle);
+		const threadIndex = threads.findIndex((t) => t.id === threadId);
+		if (threadIndex !== -1) {
+			threads[threadIndex].title = newTitle;
+		}
+		notifications.success(
+			"Thread Renamed",
+			`Successfully renamed to "${newTitle}"`,
+		);
+	} catch (error) {
+		notifications.error(
+			"Rename Failed",
+			"Unable to rename the thread. Please try again.",
+		);
+		console.error("Failed to rename thread:", error);
+	}
+}
+
+async function _handleDeleteThread(threadId: string) {
+	try {
+		await defaultChatApi.deleteThread(threadId);
+		const threadToDelete = threads.find((t) => t.id === threadId);
+		threads = threads.filter((t) => t.id !== threadId);
+		notifications.success(
+			"Thread Deleted",
+			`Deleted "${threadToDelete?.title || "thread"}"`,
+		);
+	} catch (error) {
+		notifications.error(
+			"Delete Failed",
+			"Unable to delete the thread. Please try again.",
+		);
+		console.error("Failed to delete thread:", error);
+	}
+}
+
+function _toggleTheme() {
+	if (browser) {
+		currentTheme =
+			currentTheme === "nanobotlight" ? "nanobotdark" : "nanobotlight";
+		document.documentElement.setAttribute("data-theme", currentTheme);
+		localStorage.setItem("theme", currentTheme);
+	}
+}
 </script>
 
 <svelte:head>

--- a/packages/ui/src/routes/+page.svelte
+++ b/packages/ui/src/routes/+page.svelte
@@ -1,34 +1,33 @@
 <script lang="ts">
-	import '$lib/../app.css';
-	import { ChatService } from '$lib/chat.svelte';
-	import { onDestroy, onMount } from 'svelte';
-	import { goto } from '$app/navigation';
-	import { page } from '$app/state';
-	import { resolve } from '$app/paths';
-	import ThreadFromChat from "$lib/components/ThreadFromChat.svelte";
+import "$lib/../app.css";
+import { onDestroy, onMount } from "svelte";
+import { goto } from "$app/navigation";
+import { resolve } from "$app/paths";
+import { page } from "$app/state";
+import { ChatService } from "$lib/chat.svelte";
 
-	const chat = new ChatService();
-	let doClose = true;
+const chat = new ChatService();
+let doClose = true;
 
-	$effect(() => {
-		if (chat.chatId) {
-			doClose = false;
-			page.data.chat = chat;
-			goto(resolve(`/c/${chat.chatId}`));
-		}
-	});
+$effect(() => {
+	if (chat.chatId) {
+		doClose = false;
+		page.data.chat = chat;
+		goto(resolve(`/c/${chat.chatId}`));
+	}
+});
 
-	onMount(() => {
-		if (window.location.search.includes('new')) {
-			chat.newChat();
-		}
-	});
+onMount(() => {
+	if (window.location.search.includes("new")) {
+		chat.newChat();
+	}
+});
 
-	onDestroy(() => {
-		if (doClose) {
-			chat.close();
-		}
-	});
+onDestroy(() => {
+	if (doClose) {
+		chat.close();
+	}
+});
 </script>
 
 <svelte:head>

--- a/packages/ui/src/routes/c/[id]/+page.svelte
+++ b/packages/ui/src/routes/c/[id]/+page.svelte
@@ -1,29 +1,26 @@
 <script lang="ts">
-	import '$lib/../app.css';
-	import { page } from '$app/state';
-	import Thread from '$lib/components/Thread.svelte';
-	import { ChatService } from '$lib/chat.svelte';
-	import { onDestroy } from 'svelte';
-	import { getNotificationContext } from '$lib/context/notifications.svelte';
-	import Workspace from '$lib/components/Workspace.svelte';
-	import ThreadFromChat from "$lib/components/ThreadFromChat.svelte";
+import "$lib/../app.css";
+import { onDestroy } from "svelte";
+import { page } from "$app/state";
+import { ChatService } from "$lib/chat.svelte";
+import { getNotificationContext } from "$lib/context/notifications.svelte";
 
-	// The existing chat might have been set by / so don't recreate it because that will
-	// loose the event stream.
-	const chat = page.data.chat || new ChatService();
-	const notification = getNotificationContext();
+// The existing chat might have been set by / so don't recreate it because that will
+// loose the event stream.
+const chat = page.data.chat || new ChatService();
+const notification = getNotificationContext();
 
-	$effect(() => {
-		if (!page.params.id) return;
-		chat.setChatId(page.params.id).catch((e) => {
-			console.error('Error setting chat ID:', e);
-			notification.error(e.message);
-		});
+$effect(() => {
+	if (!page.params.id) return;
+	chat.setChatId(page.params.id).catch((e) => {
+		console.error("Error setting chat ID:", e);
+		notification.error(e.message);
 	});
+});
 
-	onDestroy(() => {
-		chat.close();
-	});
+onDestroy(() => {
+	chat.close();
+});
 </script>
 
 <svelte:head>

--- a/packages/ui/src/routes/workspace-test/+page.svelte
+++ b/packages/ui/src/routes/workspace-test/+page.svelte
@@ -1,351 +1,353 @@
 <script lang="ts">
-  import '$lib/../app.css';
-  import {WorkspaceService, type WorkspaceInstance} from '$lib/workspace.svelte';
-  import {onMount} from 'svelte';
-  import {
-    AlertCircle,
-    RefreshCw,
-    Plus,
-    Edit,
-    Trash2,
-    X,
-    Save,
-    FileText,
-    Download,
-    MessageSquare,
-    Info,
-    List
-  } from '@lucide/svelte';
-  import type {SessionDetails} from "$lib/types";
-  import type {ChatService} from '$lib/chat.svelte';
-  import ThreadFromChat from "$lib/components/ThreadFromChat.svelte";
+import "$lib/../app.css";
+import { onMount } from "svelte";
+import type { ChatService } from "$lib/chat.svelte";
+import type { SessionDetails } from "$lib/types";
+import {
+	type WorkspaceInstance,
+	WorkspaceService,
+} from "$lib/workspace.svelte";
 
-  const workspaceService = new WorkspaceService();
+const workspaceService = new WorkspaceService();
 
-  let loading = $state(false);
-  let error = $state<string | null>(null);
-  let newWorkspaceName = $state('');
-  let newWorkspaceColor = $state('#3b82f6');
-  let newWorkspaceOrder = $state(0);
+let _loading = $state(false);
+let _error = $state<string | null>(null);
+let newWorkspaceName = $state("");
+let newWorkspaceColor = $state("#3b82f6");
+let newWorkspaceOrder = $state(0);
 
-  // Edit mode state
-  let editingWorkspaceId = $state<string | null>(null);
-  let editName = $state('');
-  let editColor = $state('');
-  let editOrder = $state(0);
+// Edit mode state
+let _editingWorkspaceId = $state<string | null>(null);
+let editName = $state("");
+let editColor = $state("");
+let editOrder = $state(0);
 
-  // File operations state
-  let selectedWorkspace = $state<WorkspaceInstance | null>(null);
-  let newFileName = $state('');
-  let newFileContent = $state('');
-  let editingFilePath = $state<string | null>(null);
-  let editFileContent = $state('');
-  let fileReadContent = $state<{ path: string; content: string; mimeType: string } | null>(null);
+// File operations state
+let selectedWorkspace = $state<WorkspaceInstance | null>(null);
+let newFileName = $state("");
+let newFileContent = $state("");
+let _editingFilePath = $state<string | null>(null);
+let editFileContent = $state("");
+let fileReadContent = $state<{
+	path: string;
+	content: string;
+	mimeType: string;
+} | null>(null);
 
-  // Session info state
-  let sessionInfo = $state<SessionDetails | null>(null);
+// Session info state
+let sessionInfo = $state<SessionDetails | null>(null);
 
-  // Active session state
-  let activeSession = $state<ChatService | null>(null);
+// Active session state
+let activeSession = $state<ChatService | null>(null);
 
-  onMount(() => {
-    loadWorkspaces();
-  });
+onMount(() => {
+	loadWorkspaces();
+});
 
-  async function loadWorkspaces() {
-    loading = true;
-    error = null;
-    try {
-      await workspaceService.load();
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-    } finally {
-      loading = false;
-    }
-  }
+async function loadWorkspaces() {
+	_loading = true;
+	_error = null;
+	try {
+		await workspaceService.load();
+	} catch (e) {
+		_error = e instanceof Error ? e.message : String(e);
+	} finally {
+		_loading = false;
+	}
+}
 
-  async function createWorkspace() {
-    if (!newWorkspaceName.trim()) {
-      error = 'Workspace name is required';
-      return;
-    }
+async function _createWorkspace() {
+	if (!newWorkspaceName.trim()) {
+		_error = "Workspace name is required";
+		return;
+	}
 
-    loading = true;
-    error = null;
-    try {
-      await workspaceService.createWorkspace({
-        name: newWorkspaceName,
-        color: newWorkspaceColor,
-        order: newWorkspaceOrder
-      });
+	_loading = true;
+	_error = null;
+	try {
+		await workspaceService.createWorkspace({
+			name: newWorkspaceName,
+			color: newWorkspaceColor,
+			order: newWorkspaceOrder,
+		});
 
-      // Reset form
-      newWorkspaceName = '';
-      newWorkspaceColor = '#3b82f6';
-      newWorkspaceOrder = 0;
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-    } finally {
-      loading = false;
-    }
-  }
+		// Reset form
+		newWorkspaceName = "";
+		newWorkspaceColor = "#3b82f6";
+		newWorkspaceOrder = 0;
+	} catch (e) {
+		_error = e instanceof Error ? e.message : String(e);
+	} finally {
+		_loading = false;
+	}
+}
 
-  function startEdit(workspaceId: string) {
-    const workspace = workspaceService.workspaces.find(w => w.id === workspaceId);
-    if (workspace) {
-      editingWorkspaceId = workspaceId;
-      editName = workspace.name;
-      editColor = workspace.color || '#3b82f6';
-      editOrder = workspace.order || 0;
-    }
-  }
+function _startEdit(workspaceId: string) {
+	const workspace = workspaceService.workspaces.find(
+		(w) => w.id === workspaceId,
+	);
+	if (workspace) {
+		_editingWorkspaceId = workspaceId;
+		editName = workspace.name;
+		editColor = workspace.color || "#3b82f6";
+		editOrder = workspace.order || 0;
+	}
+}
 
-  function cancelEdit() {
-    editingWorkspaceId = null;
-    editName = '';
-    editColor = '';
-    editOrder = 0;
-  }
+function cancelEdit() {
+	_editingWorkspaceId = null;
+	editName = "";
+	editColor = "";
+	editOrder = 0;
+}
 
-  async function saveEdit(workspaceId: string) {
-    if (!editName.trim()) {
-      error = 'Workspace name is required';
-      return;
-    }
+async function _saveEdit(workspaceId: string) {
+	if (!editName.trim()) {
+		_error = "Workspace name is required";
+		return;
+	}
 
-    const workspace = workspaceService.workspaces.find((w) => w.id === workspaceId);
-    if (!workspace) {
-      error = 'Workspace not found';
-      return;
-    }
+	const workspace = workspaceService.workspaces.find(
+		(w) => w.id === workspaceId,
+	);
+	if (!workspace) {
+		_error = "Workspace not found";
+		return;
+	}
 
-    loading = true;
-    error = null;
-    try {
-      await workspaceService.updateWorkspace({
-        ...workspace,
-        name: editName,
-        color: editColor,
-        order: editOrder
-      });
-      cancelEdit();
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-    } finally {
-      loading = false;
-    }
-  }
+	_loading = true;
+	_error = null;
+	try {
+		await workspaceService.updateWorkspace({
+			...workspace,
+			name: editName,
+			color: editColor,
+			order: editOrder,
+		});
+		cancelEdit();
+	} catch (e) {
+		_error = e instanceof Error ? e.message : String(e);
+	} finally {
+		_loading = false;
+	}
+}
 
-  async function deleteWorkspace(workspaceId: string) {
-    if (!confirm('Are you sure you want to delete this workspace?')) {
-      return;
-    }
+async function _deleteWorkspace(workspaceId: string) {
+	if (!confirm("Are you sure you want to delete this workspace?")) {
+		return;
+	}
 
-    loading = true;
-    error = null;
-    try {
-      await workspaceService.deleteWorkspace(workspaceId);
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-    } finally {
-      loading = false;
-    }
-  }
+	_loading = true;
+	_error = null;
+	try {
+		await workspaceService.deleteWorkspace(workspaceId);
+	} catch (e) {
+		_error = e instanceof Error ? e.message : String(e);
+	} finally {
+		_loading = false;
+	}
+}
 
-  // File Operations
-  function selectWorkspace(workspaceId: string) {
-    selectedWorkspace = workspaceService.getWorkspace(workspaceId) as WorkspaceInstance;
-    fileReadContent = null;
-    editingFilePath = null;
-    sessionInfo = null;
+// File Operations
+function _selectWorkspace(workspaceId: string) {
+	selectedWorkspace = workspaceService.getWorkspace(
+		workspaceId,
+	) as WorkspaceInstance;
+	fileReadContent = null;
+	_editingFilePath = null;
+	sessionInfo = null;
 
-    // Scroll to file operations section after a brief delay
-    setTimeout(() => {
-      document.getElementById('file-operations')?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'start'
-      });
-    }, 100);
-  }
+	// Scroll to file operations section after a brief delay
+	setTimeout(() => {
+		document.getElementById("file-operations")?.scrollIntoView({
+			behavior: "smooth",
+			block: "start",
+		});
+	}, 100);
+}
 
-  async function createFile() {
-    if (!selectedWorkspace || !newFileName.trim()) {
-      error = 'Workspace and filename are required';
-      return;
-    }
+async function _createFile() {
+	if (!selectedWorkspace || !newFileName.trim()) {
+		_error = "Workspace and filename are required";
+		return;
+	}
 
-    loading = true;
-    error = null;
-    try {
-      await selectedWorkspace.createFile(newFileName, newFileContent);
-      newFileName = '';
-      newFileContent = '';
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-    } finally {
-      loading = false;
-    }
-  }
+	_loading = true;
+	_error = null;
+	try {
+		await selectedWorkspace.createFile(newFileName, newFileContent);
+		newFileName = "";
+		newFileContent = "";
+	} catch (e) {
+		_error = e instanceof Error ? e.message : String(e);
+	} finally {
+		_loading = false;
+	}
+}
 
-  async function readFile(path: string) {
-    if (!selectedWorkspace) return;
+async function readFile(path: string) {
+	if (!selectedWorkspace) return;
 
-    loading = true;
-    error = null;
-    try {
-      const blob = await selectedWorkspace.readFile(path);
-      const content = await blob.text();
-      fileReadContent = {
-        path,
-        content,
-        mimeType: blob.type
-      };
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-    } finally {
-      loading = false;
-    }
-  }
+	_loading = true;
+	_error = null;
+	try {
+		const blob = await selectedWorkspace.readFile(path);
+		const content = await blob.text();
+		fileReadContent = {
+			path,
+			content,
+			mimeType: blob.type,
+		};
+	} catch (e) {
+		_error = e instanceof Error ? e.message : String(e);
+	} finally {
+		_loading = false;
+	}
+}
 
-  function startEditFile(path: string) {
-    editingFilePath = path;
-    // Load current content if available
-    if (fileReadContent && fileReadContent.path === path) {
-      editFileContent = fileReadContent.content;
-    } else {
-      editFileContent = '';
-    }
-  }
+function _startEditFile(path: string) {
+	_editingFilePath = path;
+	// Load current content if available
+	if (fileReadContent && fileReadContent.path === path) {
+		editFileContent = fileReadContent.content;
+	} else {
+		editFileContent = "";
+	}
+}
 
-  async function updateFile(path: string) {
-    if (!selectedWorkspace) return;
+async function _updateFile(path: string) {
+	if (!selectedWorkspace) return;
 
-    loading = true;
-    error = null;
-    try {
-      await selectedWorkspace.writeFile(path, editFileContent);
-      editingFilePath = null;
-      editFileContent = '';
-      // Refresh the file content if it was being viewed
-      if (fileReadContent && fileReadContent.path === path) {
-        await readFile(path);
-      }
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-    } finally {
-      loading = false;
-    }
-  }
+	_loading = true;
+	_error = null;
+	try {
+		await selectedWorkspace.writeFile(path, editFileContent);
+		_editingFilePath = null;
+		editFileContent = "";
+		// Refresh the file content if it was being viewed
+		if (fileReadContent && fileReadContent.path === path) {
+			await readFile(path);
+		}
+	} catch (e) {
+		_error = e instanceof Error ? e.message : String(e);
+	} finally {
+		_loading = false;
+	}
+}
 
-  function cancelEditFile() {
-    editingFilePath = null;
-    editFileContent = '';
-  }
+function _cancelEditFile() {
+	_editingFilePath = null;
+	editFileContent = "";
+}
 
-  async function deleteFile(path: string) {
-    if (!selectedWorkspace) return;
-    if (!confirm(`Are you sure you want to delete ${path}?`)) {
-      return;
-    }
+async function _deleteFile(path: string) {
+	if (!selectedWorkspace) return;
+	if (!confirm(`Are you sure you want to delete ${path}?`)) {
+		return;
+	}
 
-    loading = true;
-    error = null;
-    try {
-      await selectedWorkspace.deleteFile(path);
-      // Clear read content if the deleted file was being viewed
-      if (fileReadContent && fileReadContent.path === path) {
-        fileReadContent = null;
-      }
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-    } finally {
-      loading = false;
-    }
-  }
+	_loading = true;
+	_error = null;
+	try {
+		await selectedWorkspace.deleteFile(path);
+		// Clear read content if the deleted file was being viewed
+		if (fileReadContent && fileReadContent.path === path) {
+			fileReadContent = null;
+		}
+	} catch (e) {
+		_error = e instanceof Error ? e.message : String(e);
+	} finally {
+		_loading = false;
+	}
+}
 
-  async function refreshFiles() {
-    if (!selectedWorkspace) return;
+async function refreshFiles() {
+	if (!selectedWorkspace) return;
 
-    loading = true;
-    error = null;
-    try {
-      await selectedWorkspace.load();
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-    } finally {
-      loading = false;
-    }
-  }
+	_loading = true;
+	_error = null;
+	try {
+		await selectedWorkspace.load();
+	} catch (e) {
+		_error = e instanceof Error ? e.message : String(e);
+	} finally {
+		_loading = false;
+	}
+}
 
-  async function readSessionInfo(sessionId: string) {
-    if (!selectedWorkspace) return;
+async function _readSessionInfo(sessionId: string) {
+	if (!selectedWorkspace) return;
 
-    loading = true;
-    error = null;
-    try {
-      sessionInfo = await selectedWorkspace.getSessionDetails(sessionId);
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-    } finally {
-      loading = false;
-    }
-  }
+	_loading = true;
+	_error = null;
+	try {
+		sessionInfo = await selectedWorkspace.getSessionDetails(sessionId);
+	} catch (e) {
+		_error = e instanceof Error ? e.message : String(e);
+	} finally {
+		_loading = false;
+	}
+}
 
-  async function deleteSession(sessionId: string) {
-    if (!selectedWorkspace) return;
-    if (!confirm('Are you sure you want to delete this session? This action cannot be undone.')) {
-      return;
-    }
+async function _deleteSession(sessionId: string) {
+	if (!selectedWorkspace) return;
+	if (
+		!confirm(
+			"Are you sure you want to delete this session? This action cannot be undone.",
+		)
+	) {
+		return;
+	}
 
-    loading = true;
-    error = null;
-    try {
-      await selectedWorkspace.deleteSession(sessionId);
+	_loading = true;
+	_error = null;
+	try {
+		await selectedWorkspace.deleteSession(sessionId);
 
-      // Clear session info if the deleted session was being viewed
-      if (sessionInfo && sessionInfo.id === sessionId) {
-        sessionInfo = null;
-      }
+		// Clear session info if the deleted session was being viewed
+		if (sessionInfo && sessionInfo.id === sessionId) {
+			sessionInfo = null;
+		}
 
-      // Clear active session if it was deleted
-      if (activeSession && activeSession.chatId === sessionId) {
-        activeSession = null;
-      }
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-    } finally {
-      loading = false;
-    }
-  }
+		// Clear active session if it was deleted
+		if (activeSession && activeSession.chatId === sessionId) {
+			activeSession = null;
+		}
+	} catch (e) {
+		_error = e instanceof Error ? e.message : String(e);
+	} finally {
+		_loading = false;
+	}
+}
 
-  async function createNewSession() {
-    if (!selectedWorkspace) return;
+async function _createNewSession() {
+	if (!selectedWorkspace) return;
 
-    loading = true;
-    error = null;
-    try {
-      activeSession = await selectedWorkspace.newSession({ editor: false });
-      await refreshFiles(); // Refresh to show the new session
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-    } finally {
-      loading = false;
-    }
-  }
+	_loading = true;
+	_error = null;
+	try {
+		activeSession = await selectedWorkspace.newSession({ editor: false });
+		await refreshFiles(); // Refresh to show the new session
+	} catch (e) {
+		_error = e instanceof Error ? e.message : String(e);
+	} finally {
+		_loading = false;
+	}
+}
 
-  async function selectSession(sessionId: string) {
-    if (!selectedWorkspace) return;
+async function _selectSession(sessionId: string) {
+	if (!selectedWorkspace) return;
 
-    loading = true;
-    error = null;
-    try {
-      activeSession = await selectedWorkspace.getSession(sessionId);
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-    } finally {
-      loading = false;
-    }
-  }
+	_loading = true;
+	_error = null;
+	try {
+		activeSession = await selectedWorkspace.getSession(sessionId);
+	} catch (e) {
+		_error = e instanceof Error ? e.message : String(e);
+	} finally {
+		_loading = false;
+	}
+}
 </script>
 
 <svelte:head>

--- a/packages/ui/static/assets/theme.css
+++ b/packages/ui/static/assets/theme.css
@@ -1,65 +1,67 @@
 /* Obot Override Light Theme */
-:root:has(input.theme-controller[value=nanobotlight]:checked), [data-theme=nanobotlight] {
-    --color-base-100: hsl(0 0 100);
-    --color-base-200: hsl(0 0 95.5);
-    --color-base-300: hsl(0 0 92.5);
-    --color-base-content: hsl(0 0 0);
-    --color-primary: #4f7ef3;
-    --color-primary-content: hsl(0 0 100);
-    --color-secondary: hsl(0 0 82.5);
-    --color-secondary-content: hsl(0 0 0);
-    --color-accent: #95bcfb;
-    --color-accent-content: hsl(0 0 0);
-    --color-neutral: hsl(0 0 82.5);
-    --color-neutral-content: hsl(0 0 0);
-    --color-info: #4f7ef3;
-    --color-info-content: hsl(0 0 100);
-    --color-success: oklch(72.3% 0.219 149.579);
-    --color-success-content: hsl(0 0 0);
-    --color-warning: oklch(79.5% 0.184 86.047);
-    --color-warning-content: hsl(0 0 100);
-    --color-error: #ef4444;
-    --color-error-content: hsl(0 0 100);
-    --radius-selector: 1rem;
-    --radius-field: 0.25rem;
-    --radius-box: 0.5rem;
-    --size-selector: 0.25rem;
-    --size-field: 0.25rem;
-    --border: 1px;
-    --depth: 0;
-    --noise: 1;
-    --logo-url: /assets/obot-workflow-logo-blue-black-text.svg;
+:root:has(input.theme-controller[value='nanobotlight']:checked),
+[data-theme='nanobotlight'] {
+	--color-base-100: hsl(0 0 100);
+	--color-base-200: hsl(0 0 95.5);
+	--color-base-300: hsl(0 0 92.5);
+	--color-base-content: hsl(0 0 0);
+	--color-primary: #4f7ef3;
+	--color-primary-content: hsl(0 0 100);
+	--color-secondary: hsl(0 0 82.5);
+	--color-secondary-content: hsl(0 0 0);
+	--color-accent: #95bcfb;
+	--color-accent-content: hsl(0 0 0);
+	--color-neutral: hsl(0 0 82.5);
+	--color-neutral-content: hsl(0 0 0);
+	--color-info: #4f7ef3;
+	--color-info-content: hsl(0 0 100);
+	--color-success: oklch(72.3% 0.219 149.579);
+	--color-success-content: hsl(0 0 0);
+	--color-warning: oklch(79.5% 0.184 86.047);
+	--color-warning-content: hsl(0 0 100);
+	--color-error: #ef4444;
+	--color-error-content: hsl(0 0 100);
+	--radius-selector: 1rem;
+	--radius-field: 0.25rem;
+	--radius-box: 0.5rem;
+	--size-selector: 0.25rem;
+	--size-field: 0.25rem;
+	--border: 1px;
+	--depth: 0;
+	--noise: 1;
+	--logo-url: url('/assets/obot-workflow-logo-blue-black-text.svg');
 }
 
 /* Obot Override Dark Theme */
-:root:has(input.theme-controller[value=nanobotdark]:checked), [data-theme=nanobotdark] {
-    --color-base-100: hsl(0 0 0);
-    --color-base-200: hsl(0 0 5.5);
-    --color-base-300: hsl(0 0 12.5);
-    --color-base-content: hsl(0 0 97.5);
-    --color-primary: #4f7ef3;
-    --color-primary-content: hsl(0 0 97.5);
-    --color-secondary: hsl(0 0 22.5);
-    --color-secondary-content: hsl(0 0 97.5);
-    --color-accent: #203188;
-    --color-accent-content: hsl(0 0 97.5);
-    --color-neutral: hsl(0 0 22.5);
-    --color-neutral-content: hsl(0 0 97.5);
-    --color-info: #4f7ef3;
-    --color-info-content: hsl(0 0 97.5);
-    --color-success: oklch(72.3% 0.219 149.579);
-    --color-success-content: hsl(0 0 97.5);
-    --color-warning: oklch(79.5% 0.184 86.047);
-    --color-warning-content: hsl(0 0 97.5);
-    --color-error: #ef4444;
-    --color-error-content: hsl(0 0 97.5);
-    --radius-selector: 1rem;
-    --radius-field: 0.25rem;
-    --radius-box: 0.5rem;
-    --size-selector: 0.25rem;
-    --size-field: 0.25rem;
-    --border: 1px;
-    --depth: 0;
-    --noise: 1;
-    --logo-url: /assets/obot-workflow-logo-blue-white-text.svg;
+:root:has(input.theme-controller[value='nanobotdark']:checked),
+[data-theme='nanobotdark'] {
+	--color-base-100: hsl(0 0 0);
+	--color-base-200: hsl(0 0 5.5);
+	--color-base-300: hsl(0 0 12.5);
+	--color-base-content: hsl(0 0 97.5);
+	--color-primary: #4f7ef3;
+	--color-primary-content: hsl(0 0 97.5);
+	--color-secondary: hsl(0 0 22.5);
+	--color-secondary-content: hsl(0 0 97.5);
+	--color-accent: #203188;
+	--color-accent-content: hsl(0 0 97.5);
+	--color-neutral: hsl(0 0 22.5);
+	--color-neutral-content: hsl(0 0 97.5);
+	--color-info: #4f7ef3;
+	--color-info-content: hsl(0 0 97.5);
+	--color-success: oklch(72.3% 0.219 149.579);
+	--color-success-content: hsl(0 0 97.5);
+	--color-warning: oklch(79.5% 0.184 86.047);
+	--color-warning-content: hsl(0 0 97.5);
+	--color-error: #ef4444;
+	--color-error-content: hsl(0 0 97.5);
+	--radius-selector: 1rem;
+	--radius-field: 0.25rem;
+	--radius-box: 0.5rem;
+	--size-selector: 0.25rem;
+	--size-field: 0.25rem;
+	--border: 1px;
+	--depth: 0;
+	--noise: 1;
+	--logo-url: url('/assets/obot-workflow-logo-blue-white-text.svg');
 }

--- a/packages/ui/svelte.config.js
+++ b/packages/ui/svelte.config.js
@@ -1,5 +1,5 @@
-import adapter from '@sveltejs/adapter-static';
-import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import adapter from "@sveltejs/adapter-static";
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -12,9 +12,9 @@ const config = {
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
 		adapter: adapter({
-			fallback: 'fallback.html'
-		})
-	}
+			fallback: "fallback.html",
+		}),
+	},
 };
 
 export default config;

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,7 +1,7 @@
-import tailwindcss from '@tailwindcss/vite';
-import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { sveltekit } from "@sveltejs/kit/vite";
+import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "vite";
 
 export default defineConfig({
-	plugins: [tailwindcss(), sveltekit()]
+	plugins: [tailwindcss(), sveltekit()],
 });


### PR DESCRIPTION
## Summary

Apply biome auto-fixes across the codebase to fix formatting and minor lint issues.

## Changes

- **48 files** updated with biome formatting (indentation, trailing commas, quote style, etc.)
- **Import organization** applied via biome assist
- **JSON schema files** reformatted
- **Svelte components** cleaned up

## Remaining

51 warnings (mostly unused variables in Svelte components) — these require manual review and are out of scope for this formatting-only PR.

No errors remain after these fixes.