### PR TITLE
fix: provide server id/catalog entry id in elicitation meta

### DIFF
--- a/pkg/confirm/confirm.go
+++ b/pkg/confirm/confirm.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/nanobot-ai/nanobot/pkg/mcp"
+	"github.com/nanobot-ai/nanobot/pkg/servers/obotmcp"
 	"github.com/nanobot-ai/nanobot/pkg/types"
 )
 
@@ -19,7 +21,7 @@ func New() *Service {
 	return &Service{}
 }
 
-func (*Service) HandleAuthURL(ctx context.Context, mcpServerName, url string) (bool, error) {
+func (*Service) HandleAuthURL(ctx context.Context, req mcp.AuthURLRequest) (bool, error) {
 	session := mcp.SessionFromContext(ctx)
 	if session == nil {
 		return false, fmt.Errorf("no session found in context")
@@ -29,14 +31,37 @@ func (*Service) HandleAuthURL(ctx context.Context, mcpServerName, url string) (b
 		session = session.Parent
 	}
 
+	lookupCtx := mcp.WithSession(ctx, session)
+	var candidates []string
+	if u := strings.TrimSpace(req.ConnectURL); u != "" {
+		candidates = append(candidates, u)
+	}
+	if u := obotmcp.ResourceURLFromAuthorizeURL(req.URL); u != "" {
+		candidates = append(candidates, u)
+	}
+	var displayNames []string
+	for _, s := range []string{req.DisplayName, req.ServerKey} {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			displayNames = append(displayNames, s)
+		}
+	}
+	mcpID, catalogID := obotmcp.LookupObotConnectedServerIDs(lookupCtx, candidates, displayNames)
+
 	meta := map[string]any{
-		types.MetaPrefix + "oauth-url":   url,
-		types.MetaPrefix + "server-name": mcpServerName,
+		types.MetaPrefix + "oauth-url":   req.URL,
+		types.MetaPrefix + "server-name": req.DisplayName,
+	}
+	if mcpID != "" {
+		meta[types.MetaPrefix+"mcp-server-id"] = mcpID
+	}
+	if catalogID != "" {
+		meta[types.MetaPrefix+"catalog-entry-id"] = catalogID
 	}
 	metaStr, _ := json.Marshal(meta)
 
 	elicit := mcp.ElicitRequest{
-		Message: fmt.Sprintf("MCP server %s requires authorization, please visit the following URL to continue: %s", mcpServerName, url),
+		Message: fmt.Sprintf("MCP server %s requires authorization, please visit the following URL to continue: %s", req.DisplayName, req.URL),
 		RequestedSchema: mcp.PrimitiveSchema{
 			Type:       "object",
 			Properties: map[string]mcp.PrimitiveProperty{},
@@ -54,8 +79,8 @@ func (*Service) HandleAuthURL(ctx context.Context, mcpServerName, url string) (b
 	case "accept":
 		return true, nil
 	case "reject":
-		return false, fmt.Errorf("user has rejected authorization for server %s", mcpServerName)
+		return false, fmt.Errorf("user has rejected authorization for server %s", req.DisplayName)
 	default:
-		return false, fmt.Errorf("user has canceled authorization for server %s", mcpServerName)
+		return false, fmt.Errorf("user has canceled authorization for server %s", req.DisplayName)
 	}
 }

--- a/pkg/mcp/callback.go
+++ b/pkg/mcp/callback.go
@@ -12,8 +12,16 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// AuthURLRequest carries context for the OAuth authorization URL prompt.
+type AuthURLRequest struct {
+	DisplayName string
+	URL         string // authorization (browser) URL
+	ConnectURL  string // MCP server base URL used to match obot_list_connected_mcp_servers entries
+	ServerKey   string // Nanobot mcpServers map key (e.g. "gmail") for Obot name matching when URLs differ
+}
+
 type AuthURLHandler interface {
-	HandleAuthURL(context.Context, string, string) (bool, error)
+	HandleAuthURL(context.Context, AuthURLRequest) (bool, error)
 }
 
 type CallbackHandler interface {

--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -228,7 +228,12 @@ func (o *oauth) oauthClient(ctx context.Context, c *HTTPClient, connectURL, auth
 	}
 
 	slog.Info("handing oauth authorization url to callback handler", "server", c.serverName, "auth_url", authorizationServerMetadata.AuthorizationEndpoint)
-	handled, err := o.callbackHandler.HandleAuthURL(ctx, c.displayName, authURL)
+	handled, err := o.callbackHandler.HandleAuthURL(ctx, AuthURLRequest{
+		DisplayName: c.displayName,
+		URL:         authURL,
+		ConnectURL:  c.baseURL,
+		ServerKey:   c.serverName,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to handle auth url %s: %w", authURL, err)
 	} else if !handled {

--- a/pkg/mcp/tracecontext.go
+++ b/pkg/mcp/tracecontext.go
@@ -6,13 +6,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
-)
-
-var mcpTracePropagator = propagation.NewCompositeTextMapPropagator(
-	propagation.TraceContext{},
-	propagation.Baggage{},
 )
 
 func startOutboundSpan(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {

--- a/pkg/servers/obotmcp/authorize_parse.go
+++ b/pkg/servers/obotmcp/authorize_parse.go
@@ -1,0 +1,16 @@
+package obotmcp
+
+import (
+	"net/url"
+	"strings"
+)
+
+// ResourceURLFromAuthorizeURL returns the RFC 8707-style resource URL from an OAuth
+// authorize URL's query parameter (often the MCP HTTPS endpoint).
+func ResourceURLFromAuthorizeURL(authorizeURL string) string {
+	u, err := url.Parse(strings.TrimSpace(authorizeURL))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(u.Query().Get("resource"))
+}

--- a/pkg/servers/obotmcp/lookup.go
+++ b/pkg/servers/obotmcp/lookup.go
@@ -1,0 +1,216 @@
+package obotmcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/nanobot-ai/nanobot/pkg/complete"
+	"github.com/nanobot-ai/nanobot/pkg/mcp"
+)
+
+// LookupObotConnectedServerIDs resolves mcp_server_id and catalog_entry_id from obot_list_connected_mcp_servers.
+// It first tries to match any normalized connect URL from connectURLs to Obot's connect_url; if none match,
+// it matches by display name or alias against displayNames (e.g. config key "gmail", name "Gmail", or shortName).
+// Obot often exposes a different connect_url (proxy) than Nanobot's configured MCP url, so the name pass is required.
+func LookupObotConnectedServerIDs(ctx context.Context, connectURLs []string, displayNames []string) (mcpServerID, catalogEntryID string) {
+	servers, err := (obotConnectedServerLister{}).ConnectedMCPServers(ctx)
+	if err != nil || len(servers) == 0 {
+		return "", ""
+	}
+
+	normTargets := normalizeURLList(connectURLs)
+	names := dedupeNonEmpty(displayNames)
+
+	// Pass 1: exact normalized URL match
+	for _, cs := range servers {
+		cu, err := normalizeConnectURL(cs.ConnectURL)
+		if err != nil || cu == "" {
+			continue
+		}
+		for _, t := range normTargets {
+			if t != "" && cu == t {
+				return mcpServerIDFromConnected(cs), catalogEntryIDFromConnected(cs)
+			}
+		}
+	}
+
+	// Pass 1b: same host (and port) as connect URL — scheme/path may differ between Obot and the client.
+	candidateHosts := connectURLHostList(connectURLs)
+	for _, cs := range servers {
+		obHost, ok := connectURLHostKey(cs.ConnectURL)
+		if !ok || obHost == "" {
+			continue
+		}
+		for _, h := range candidateHosts {
+			if h != "" && h == obHost {
+				return mcpServerIDFromConnected(cs), catalogEntryIDFromConnected(cs)
+			}
+		}
+	}
+
+	// Pass 2: name / alias (and config key) match — Obot connect_url often differs from client BaseURL
+	for _, cs := range servers {
+		if matchDisplayNames(cs, names) {
+			return mcpServerIDFromConnected(cs), catalogEntryIDFromConnected(cs)
+		}
+	}
+
+	return "", ""
+}
+
+func normalizeURLList(urls []string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, raw := range urls {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		u, err := normalizeConnectURL(raw)
+		if err != nil || u == "" {
+			continue
+		}
+		if _, dup := seen[u]; dup {
+			continue
+		}
+		seen[u] = struct{}{}
+		out = append(out, u)
+	}
+	return out
+}
+
+func dedupeNonEmpty(names []string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if n == "" {
+			continue
+		}
+		if _, dup := seen[n]; dup {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+	}
+	return out
+}
+
+func matchDisplayNames(cs ConnectedServer, displayNames []string) bool {
+	for _, dn := range displayNames {
+		if strings.EqualFold(strings.TrimSpace(cs.Name), dn) {
+			return true
+		}
+		if a := strings.TrimSpace(cs.Alias); a != "" && strings.EqualFold(a, dn) {
+			return true
+		}
+	}
+	return false
+}
+
+// mcpServerIDFromConnected prefers explicit mcp_server_id; otherwise uses Obot's top-level id field.
+func mcpServerIDFromConnected(cs ConnectedServer) string {
+	s := idToString(cs.MCPServerID)
+	if s != "" {
+		return s
+	}
+	return strings.TrimSpace(cs.ID)
+}
+
+func catalogEntryIDFromConnected(cs ConnectedServer) string {
+	return idToString(cs.CatalogEntryID)
+}
+
+// LookupConnectedServerIDs matches a single connect URL and display name (legacy helper).
+func LookupConnectedServerIDs(ctx context.Context, connectURL, displayName string) (mcpServerID, catalogEntryID string) {
+	connectURL = strings.TrimSpace(connectURL)
+	var urls []string
+	if connectURL != "" {
+		urls = []string{connectURL}
+	}
+	dn := strings.TrimSpace(displayName)
+	var names []string
+	if dn != "" {
+		names = []string{dn}
+	}
+	return LookupObotConnectedServerIDs(ctx, urls, names)
+}
+
+func idToString(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch x := v.(type) {
+	case string:
+		return strings.TrimSpace(x)
+	case float64:
+		return strconv.FormatInt(int64(x), 10)
+	default:
+		return strings.TrimSpace(fmt.Sprint(x))
+	}
+}
+
+func normalizeConnectURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", errors.New("empty MCP base URL")
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return "", err
+	}
+	u.Fragment = ""
+	u.RawQuery = ""
+	return strings.TrimSuffix(strings.ToLower(u.String()), "/"), nil
+}
+
+// connectURLHostKey returns host[:port] lowercased for comparing MCP endpoints when full URLs differ.
+func connectURLHostKey(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", false
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return "", false
+	}
+	return strings.ToLower(u.Host), true
+}
+
+func connectURLHostList(urls []string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, raw := range urls {
+		h, ok := connectURLHostKey(raw)
+		if !ok || h == "" {
+			continue
+		}
+		if _, dup := seen[h]; dup {
+			continue
+		}
+		seen[h] = struct{}{}
+		out = append(out, h)
+	}
+	return out
+}
+
+// LookupConnectedServerIDsForServer resolves IDs using mcp.Server BaseURL and display name
+// (name, shortName, then empty).
+func LookupConnectedServerIDsForServer(ctx context.Context, srv mcp.Server) (mcpServerID, catalogEntryID string) {
+	name := strings.TrimSpace(complete.First(srv.Name, srv.ShortName, ""))
+	return LookupConnectedServerIDs(ctx, srv.BaseURL, name)
+}
+
+// LookupConnectedServerIDsFromCandidates tries each connect URL with a single display name (legacy).
+func LookupConnectedServerIDsFromCandidates(ctx context.Context, connectURLs []string, displayName string) (mcpServerID, catalogEntryID string) {
+	displayName = strings.TrimSpace(displayName)
+	var names []string
+	if displayName != "" {
+		names = []string{displayName}
+	}
+	return LookupObotConnectedServerIDs(ctx, connectURLs, names)
+}

--- a/pkg/servers/obotmcp/mcpcli_config.go
+++ b/pkg/servers/obotmcp/mcpcli_config.go
@@ -32,6 +32,9 @@ type ConnectedServer struct {
 	Alias       string `json:"alias,omitempty"`
 	Description string `json:"description,omitempty"`
 	ConnectURL  string `json:"connect_url"`
+	// Obot structured content may use numeric or string IDs; use any for JSON decoding.
+	MCPServerID    any `json:"mcp_server_id,omitempty"`
+	CatalogEntryID any `json:"catalog_entry_id,omitempty"`
 }
 
 type inventoryEntry struct {

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -22,6 +23,7 @@ import (
 	"github.com/nanobot-ai/nanobot/pkg/mcp"
 	"github.com/nanobot-ai/nanobot/pkg/mcp/auditlogs"
 	"github.com/nanobot-ai/nanobot/pkg/sampling"
+	"github.com/nanobot-ai/nanobot/pkg/servers/obotmcp"
 	"github.com/nanobot-ai/nanobot/pkg/types"
 	"github.com/nanobot-ai/nanobot/pkg/uuid"
 )
@@ -106,6 +108,171 @@ func (s *Service) AddServer(name string, factory func(name string) mcp.MessageHa
 
 func (s *Service) SetSampler(sampler Sampler) {
 	s.sampler = sampler
+}
+
+func connectURLCandidatesForObot(srv mcp.Server, elicit mcp.ElicitRequest) []string {
+	var out []string
+	seen := map[string]struct{}{}
+	add := func(s string) {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	add(srv.BaseURL)
+	add(obotmcp.ResourceURLFromAuthorizeURL(elicit.URL))
+	if len(elicit.Meta) > 0 {
+		s := strings.TrimSpace(string(elicit.Meta))
+		if s != "" && s != "null" {
+			var meta map[string]any
+			if err := json.Unmarshal(elicit.Meta, &meta); err == nil && meta != nil {
+				if ou, ok := meta[types.MetaPrefix+"oauth-url"].(string); ok {
+					add(obotmcp.ResourceURLFromAuthorizeURL(ou))
+				}
+			}
+		}
+	}
+	return out
+}
+
+func displayNameCandidatesForObot(srv mcp.Server, serverKey string, elicit mcp.ElicitRequest) []string {
+	var out []string
+	seen := map[string]struct{}{}
+	add := func(s string) {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	add(complete.First(srv.Name, srv.ShortName, ""))
+	add(serverKey)
+	if len(elicit.Meta) > 0 {
+		s := strings.TrimSpace(string(elicit.Meta))
+		if s != "" && s != "null" {
+			var meta map[string]any
+			if err := json.Unmarshal(elicit.Meta, &meta); err == nil && meta != nil {
+				// Downstream MCP (e.g. Gmail) often sets this; Obot lists connected servers by that name, not the Obot bridge name.
+				if v, ok := meta[types.MetaPrefix+"server-name"].(string); ok {
+					add(v)
+				}
+			}
+		}
+	}
+	return out
+}
+
+func stashObotConnectServerIDInSession(session *mcp.Session, tool string, args any) {
+	if session == nil || tool != "obot_connect_to_mcp_server" {
+		return
+	}
+	sid := extractObotConnectServerIDFromArgs(args)
+	if sid == "" {
+		return
+	}
+	session.Set(types.ObotLastConnectServerIDSessionKey, mcp.SavedString(sid))
+}
+
+func extractObotConnectServerIDFromArgs(args any) string {
+	if args == nil {
+		return ""
+	}
+	m, ok := args.(map[string]any)
+	if !ok {
+		b, err := json.Marshal(args)
+		if err != nil {
+			return ""
+		}
+		if err := json.Unmarshal(b, &m); err != nil {
+			return ""
+		}
+	}
+	v, ok := m["server_id"]
+	if !ok {
+		return ""
+	}
+	switch x := v.(type) {
+	case string:
+		return strings.TrimSpace(x)
+	case float64:
+		return strconv.FormatInt(int64(x), 10)
+	default:
+		return strings.TrimSpace(fmt.Sprint(x))
+	}
+}
+
+// applyStashedObotConnectServerIDs fills missing IDs from the last obot_connect_to_mcp_server server_id
+// (catalog entry or multi-user id per Obot). Catalog-style ids typically use the "default-" prefix.
+func applyStashedObotConnectServerIDs(session *mcp.Session, mcpID, catalogID *string) {
+	var stashed string
+	if session == nil || !session.Get(types.ObotLastConnectServerIDSessionKey, &stashed) {
+		return
+	}
+	stashed = strings.TrimSpace(stashed)
+	if stashed == "" {
+		return
+	}
+	isCatalogish := strings.HasPrefix(stashed, "default-")
+	if *catalogID == "" && isCatalogish {
+		*catalogID = stashed
+	}
+	if *mcpID == "" && !isCatalogish {
+		*mcpID = stashed
+	}
+}
+
+// augmentElicitationMetaWithObotServerIDs adds ai.nanobot.meta/mcp-server-id and catalog-entry-id
+// when forwarding elicitation/create from a remote MCP server (e.g. OAuth URL mode), using
+// obot_list_connected_mcp_servers data matched to this client's MCP config.
+func augmentElicitationMetaWithObotServerIDs(ctx context.Context, session *mcp.Session, elicit *mcp.ElicitRequest, srv mcp.Server, serverKey string) error {
+	lookupCtx := mcp.WithSession(ctx, session)
+	// Subclient elicitation callbacks may not carry session in ctx; Obot fetch requires it.
+	candidates := connectURLCandidatesForObot(srv, *elicit)
+	displayNames := displayNameCandidatesForObot(srv, serverKey, *elicit)
+	mcpID, catalogID := obotmcp.LookupObotConnectedServerIDs(lookupCtx, candidates, displayNames)
+	applyStashedObotConnectServerIDs(session, &mcpID, &catalogID)
+	if mcpID == "" && catalogID == "" {
+		return nil
+	}
+
+	meta := map[string]any{}
+	if len(elicit.Meta) > 0 {
+		s := strings.TrimSpace(string(elicit.Meta))
+		if s != "" && s != "null" {
+			if err := json.Unmarshal(elicit.Meta, &meta); err != nil {
+				return fmt.Errorf("unmarshal elicitation _meta: %w", err)
+			}
+		}
+	}
+	if meta == nil {
+		meta = map[string]any{}
+	}
+	p := types.MetaPrefix
+	if mcpID != "" {
+		if _, exists := meta[p+"mcp-server-id"]; !exists {
+			meta[p+"mcp-server-id"] = mcpID
+		}
+	}
+	if catalogID != "" {
+		if _, exists := meta[p+"catalog-entry-id"]; !exists {
+			meta[p+"catalog-entry-id"] = catalogID
+		}
+	}
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	elicit.Meta = data
+	return nil
 }
 
 // buildAuditLog creates a new audit log entry for internal service calls
@@ -486,6 +653,11 @@ func (s *Service) newClient(ctx context.Context, name string, state *mcp.Session
 				s.collectAuditLog(auditLog)
 			}()
 
+			elicit := elicitation
+			if augErr := augmentElicitationMetaWithObotServerIDs(ctx, session, &elicit, mcpConfig, name); augErr == nil {
+				elicitation = elicit
+			}
+
 			if err = session.Exchange(mcp.WithMCPServerConfig(mcp.WithAuditLog(ctx, auditLog), mcpConfig), "elicitation/create", elicitation, &result); err != nil {
 				auditLog.Error = err.Error()
 			} else {
@@ -756,6 +928,7 @@ func (s *Service) Call(ctx context.Context, server, tool string, args any, opts 
 		// For tools, use the user context so that tool calls can be cancelled by the user.
 		ctx = mcp.UserContext(ctx)
 	}
+	stashObotConnectServerIDInSession(session, tool, args)
 	mcpCallResult, err := c.Call(ctx, tool, args, mcp.CallOption{
 		ProgressToken: opt.ProgressToken,
 		Meta:          opt.Meta,

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -26,6 +26,9 @@ const (
 	TaskURISessionKey               = "taskURI"
 	ResourceSubscriptionsSessionKey = "resourceSubscriptions"
 	PublicURLSessionKey             = "publicURL"
+	// ObotLastConnectServerIDSessionKey holds the server_id argument from the last obot_connect_to_mcp_server
+	// tool call (catalog entry or multi-user id) for elicitation meta when MCP_SERVER_SEARCH_URL is unset.
+	ObotLastConnectServerIDSessionKey = "obotLastConnectServerID"
 )
 
 type configContextKey struct{}


### PR DESCRIPTION
These changes are to address https://github.com/obot-platform/obot/issues/5836
Not 100% this is the ideal way to get the information needed so leaving up for review!

* add mcp server id/catalog entry id in elicitation meta
* frontend has data of catalog entries/user configured servers so can use that to get the icon to display rather than try to throw the icon_url in the elicitation meta

```
{
   "jsonrpc":"2.0",
   // ... 
      "elicitationId":"4b88beae-64a9-47b8-8585-956acb981c6d",
      "_meta":{
         "ai.nanobot.meta/catalog-entry-id":"default-gmail-8a99d8be",
         "ai.nanobot.meta/mcp-server-id":"ms1zmbgv",
         "ai.nanobot.meta/oauth-url":"https://gmail-mcp.obot.ai/authorize?access_type=offline\u0026client_id=0YN74fBlydIIooDH\u0026code_challenge=pJW56e4tQPoOC_58YcKuMPAEIEsN6R1tfYbuz-D4z4Y\u0026code_challenge_method=S256\u0026redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Foauth%2Fmcp%2Fcallback\u0026resource=https%3A%2F%2Fgmail-mcp.obot.ai%2Fmcp\u0026response_type=code\u0026state=d2gufodfywuaboyqvvfe2ajy2d",
         "ai.nanobot.meta/server-name":"Gmail"
      }
   }
}
```

<img width="466" height="262" alt="Screenshot 2026-04-16 at 10 37 53 AM" src="https://github.com/user-attachments/assets/baea8f1f-c3b7-4770-ab8d-c31d29711bda" />
