### PR TITLE
Improve ability to list workflows and add prompt/tool testing setup

### DIFF
--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -12,16 +12,7 @@ ANTHROPIC_API_KEY=... go test ./integration_test/ -runs 5
 
 ## Agent Configuration
 
-The harness loads the builtin `nanobot` agent via `config.Load(".nanobot/", true)`. If a `.nanobot/` directory exists in the working directory when the tests run, its config is merged in — allowing you to override the agent's model, instructions, or add MCP servers without changing test code.
-
-For example, to test against a specific model:
-
-```yaml
-# .nanobot/nanobot.yaml
-agents:
-  nanobot:
-    model: claude-haiku-4-5
-```
+The harness loads the builtin `nanobot` agent via `config.Load(".nanobot/", true)`. If a `.nanobot/` directory exists in the working directory when the tests run, its config is merged in — allowing you to override the agent's instructions, add MCP servers, or adjust other settings without changing test code.
 
 If no `.nanobot/` directory exists, the tests run against the default builtin agent.
 
@@ -29,8 +20,8 @@ If no `.nanobot/` directory exists, the tests run against the default builtin ag
 
 Tests use shared tooling:
 
-- **`newTestRuntime(t, completer, recorder)`** — creates a `Runtime` wired with a recording/intercepting system server and returns a context ready for agent execution.
-- **`runAgent(ctx, prompt)`** — runs the agent with the given user prompt.
+- **`newTestRuntime(t, completer, recorder)`** — creates a `Runtime` wired with a recording/intercepting system server and returns a context and agent service ready for execution.
+- **`runAgent(ctx, svc, prompt)`** — runs the agent with the given user prompt.
 - **`newRecorder(handlers)`** — creates a `toolCallRecorder` with custom `ToolHandler`s for specific tools. By default, `config` and `getSkill` always pass through to the real server; all other tools return an error unless a handler is registered.
 - **`recorder.find(name)`** — returns the first recorded call for a tool, or nil.
 - **`recorder.summary()`** — returns a formatted list of all tool calls with arguments, useful in failure messages.
@@ -58,8 +49,8 @@ func TestMySkillBehavior(t *testing.T) {
         },
     })
 
-    ctx := newTestRuntime(t, completer, recorder)
-    if err := runAgent(ctx, "my prompt"); err != nil {
+    ctx, svc := newTestRuntime(t, completer, recorder)
+    if err := runAgent(ctx, svc, "my prompt"); err != nil {
         t.Fatalf("Complete() failed: %v", err)
     }
 

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -1,0 +1,72 @@
+# Integration Tests
+
+End-to-end tests that run against a real LLM. Skipped automatically when `ANTHROPIC_API_KEY` is not set.
+
+## Running
+
+```bash
+ANTHROPIC_API_KEY=... go test ./integration_test/ -runs 5
+```
+
+`-runs` controls how many times each prompt is run per test (default: 5).
+
+## Agent Configuration
+
+The harness loads the builtin `nanobot` agent via `config.Load(".nanobot/", true)`. If a `.nanobot/` directory exists in the working directory when the tests run, its config is merged in — allowing you to override the agent's model, instructions, or add MCP servers without changing test code.
+
+For example, to test against a specific model:
+
+```yaml
+# .nanobot/nanobot.yaml
+agents:
+  nanobot:
+    model: claude-haiku-4-5
+```
+
+If no `.nanobot/` directory exists, the tests run against the default builtin agent.
+
+## Adding a Test
+
+Tests use shared tooling:
+
+- **`newTestRuntime(t, completer, recorder)`** — creates a `Runtime` wired with a recording/intercepting system server and returns a context ready for agent execution.
+- **`runAgent(ctx, prompt)`** — runs the agent with the given user prompt.
+- **`newRecorder(handlers)`** — creates a `toolCallRecorder` with custom `ToolHandler`s for specific tools. By default, `config` and `getSkill` always pass through to the real server; all other tools return an error unless a handler is registered.
+- **`recorder.find(name)`** — returns the first recorded call for a tool, or nil.
+- **`recorder.summary()`** — returns a formatted list of all tool calls with arguments, useful in failure messages.
+
+### Example
+
+```go
+func TestMySkillBehavior(t *testing.T) {
+    apiKey := os.Getenv("ANTHROPIC_API_KEY")
+    if apiKey == "" {
+        t.Skip("ANTHROPIC_API_KEY not set")
+    }
+
+    completer := llm.NewClient(llm.Config{
+        DefaultModel: "claude-sonnet-4-6",
+        Anthropic:    anthropic.Config{APIKey: apiKey},
+    })
+
+    recorder := newRecorder(map[string]ToolHandler{
+        // Register tools the agent is expected to call with mock responses.
+        "bash": func(req mcp.CallToolRequest) *mcp.CallToolResult {
+            return &mcp.CallToolResult{
+                Content: []mcp.Content{{Type: "text", Text: "mock output"}},
+            }
+        },
+    })
+
+    ctx := newTestRuntime(t, completer, recorder)
+    if err := runAgent(ctx, "my prompt"); err != nil {
+        t.Fatalf("Complete() failed: %v", err)
+    }
+
+    call := recorder.find("bash")
+    if call == nil {
+        t.Fatalf("expected bash call\nall tool calls:\n%s", recorder.summary())
+    }
+    // assert call.Arguments as needed
+}
+```

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -1,14 +1,15 @@
 # Integration Tests
 
-End-to-end tests that run against a real LLM. Skipped automatically when `ANTHROPIC_API_KEY` is not set.
+End-to-end tests that run against a real LLM. Skipped by default — you must pass `-integration` to opt in.
 
 ## Running
 
 ```bash
-ANTHROPIC_API_KEY=... go test ./integration_test/ -runs 5
+ANTHROPIC_API_KEY=... go test ./integration_test/ -integration -runs 5
 ```
 
-`-runs` controls how many times each prompt is run per test (default: 5).
+- `-integration` enables the tests (required; without it all tests are skipped).
+- `-runs` controls how many times each prompt is run per test (default: 5).
 
 ## Agent Configuration
 
@@ -32,7 +33,7 @@ Tests use shared tooling:
 func TestMySkillBehavior(t *testing.T) {
     apiKey := os.Getenv("ANTHROPIC_API_KEY")
     if apiKey == "" {
-        t.Skip("ANTHROPIC_API_KEY not set")
+        t.Fatal("ANTHROPIC_API_KEY must be set when running integration tests")
     }
 
     completer := llm.NewClient(llm.Config{

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -1,14 +1,14 @@
 # Integration Tests
 
-End-to-end tests that run against a real LLM. Skipped by default — you must pass `-integration` to opt in.
+End-to-end tests that run against a real LLM. Excluded from `go test ./...` by default via the `//go:build integration` build tag.
 
 ## Running
 
 ```bash
-ANTHROPIC_API_KEY=... go test ./integration_test/ -integration -runs 5
+ANTHROPIC_API_KEY=... go test -tags integration ./integration_test/ -runs 5
 ```
 
-- `-integration` enables the tests (required; without it all tests are skipped).
+- `-tags integration` enables compilation of the tests (required; without it they are completely skipped).
 - `-runs` controls how many times each prompt is run per test (default: 5).
 
 ## Agent Configuration

--- a/integration_test/main_test.go
+++ b/integration_test/main_test.go
@@ -50,7 +50,10 @@ func (r *toolCallRecorder) wrap(inner mcp.MessageHandler) mcp.MessageHandler {
 		}
 
 		var call mcp.CallToolRequest
-		_ = json.Unmarshal(msg.Params, &call)
+		if err := json.Unmarshal(msg.Params, &call); err != nil {
+			msg.SendError(ctx, mcp.ErrRPCInvalidParams.WithMessage("unmarshal tools/call params: %v", err))
+			return
+		}
 		r.mu.Lock()
 		r.calls = append(r.calls, call)
 		r.mu.Unlock()
@@ -81,7 +84,8 @@ func (r *toolCallRecorder) find(name string) *mcp.CallToolRequest {
 	defer r.mu.Unlock()
 	for i := range r.calls {
 		if r.calls[i].Name == name {
-			return &r.calls[i]
+			c := r.calls[i]
+			return &c
 		}
 	}
 	return nil

--- a/integration_test/main_test.go
+++ b/integration_test/main_test.go
@@ -26,7 +26,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// toolCallRecorder wraps an MCP handler, records every tools/call invocation, and
 // ToolHandler is a function that handles a mocked tool call and returns a result.
 type ToolHandler func(mcp.CallToolRequest) *mcp.CallToolResult
 
@@ -132,7 +131,7 @@ func stubMCPHandler() mcp.MessageHandler {
 // newTestRuntime creates a Runtime and installs a toolCallRecorder on nanobot.system.
 // The agent has no pre-loaded instructions; it discovers the workflows skill naturally
 // via the getSkill tool that the config hook injects.
-func newTestRuntime(t *testing.T, completer types.Completer, recorder *toolCallRecorder) context.Context {
+func newTestRuntime(t *testing.T, completer types.Completer, recorder *toolCallRecorder) (context.Context, *agents.Agents) {
 	t.Helper()
 
 	rt, err := runtime.NewRuntime(context.Background(), llm.Config{})
@@ -157,13 +156,10 @@ func newTestRuntime(t *testing.T, completer types.Completer, recorder *toolCallR
 
 	agentSvc := agents.New(completer, rt.Service)
 	ctx := rt.WithTempSession(context.Background(), cfg)
-	return context.WithValue(ctx, agentSvcKey{}, agentSvc)
+	return ctx, agentSvc
 }
 
-type agentSvcKey struct{}
-
-func runAgent(ctx context.Context, prompt string) error {
-	svc := ctx.Value(agentSvcKey{}).(*agents.Agents)
+func runAgent(ctx context.Context, svc *agents.Agents, prompt string) error {
 	_, err := svc.Complete(ctx, types.CompletionRequest{
 		Agent: "nanobot",
 		Input: []types.Message{{

--- a/integration_test/main_test.go
+++ b/integration_test/main_test.go
@@ -19,10 +19,18 @@ import (
 	"github.com/nanobot-ai/nanobot/pkg/types"
 )
 
-var numRuns = flag.Int("runs", 5, "number of times to run each prompt")
+var (
+	numRuns        = flag.Int("runs", 5, "number of times to run each prompt")
+	integrationRun = flag.Bool("integration", false, "enable integration tests (requires ANTHROPIC_API_KEY)")
+)
 
 func TestMain(m *testing.M) {
 	flag.Parse()
+
+	if !*integrationRun {
+		return
+	}
+
 	os.Exit(m.Run())
 }
 

--- a/integration_test/main_test.go
+++ b/integration_test/main_test.go
@@ -1,3 +1,7 @@
+//go:build integration
+
+// Package integration_test contains integration tests that require a real LLM.
+// Build with -tags integration to include them.
 package integration_test
 
 import (
@@ -5,8 +9,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -20,21 +22,7 @@ import (
 	"github.com/nanobot-ai/nanobot/pkg/types"
 )
 
-var (
-	numRuns        = flag.Int("runs", 5, "number of times to run each prompt")
-	integrationRun = flag.Bool("integration", false, "enable integration tests (requires ANTHROPIC_API_KEY)")
-)
-
-func TestMain(m *testing.M) {
-	flag.Parse()
-
-	if !*integrationRun {
-		log.Println("use -integration to run the integration tests")
-		return
-	}
-
-	os.Exit(m.Run())
-}
+var numRuns = flag.Int("runs", 5, "number of times to run each prompt")
 
 // ToolHandler is a function that handles a mocked tool call and returns a result.
 type ToolHandler func(mcp.CallToolRequest) *mcp.CallToolResult

--- a/integration_test/main_test.go
+++ b/integration_test/main_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"sync"
@@ -28,6 +29,7 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 
 	if !*integrationRun {
+		log.Println("use -integration to run the integration tests")
 		return
 	}
 

--- a/integration_test/main_test.go
+++ b/integration_test/main_test.go
@@ -1,0 +1,177 @@
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/nanobot-ai/nanobot/pkg/agents"
+	"github.com/nanobot-ai/nanobot/pkg/config"
+	"github.com/nanobot-ai/nanobot/pkg/llm"
+	"github.com/nanobot-ai/nanobot/pkg/mcp"
+	"github.com/nanobot-ai/nanobot/pkg/runtime"
+	"github.com/nanobot-ai/nanobot/pkg/servers/system"
+	"github.com/nanobot-ai/nanobot/pkg/types"
+)
+
+var numRuns = flag.Int("runs", 5, "number of times to run each prompt")
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(m.Run())
+}
+
+// toolCallRecorder wraps an MCP handler, records every tools/call invocation, and
+// ToolHandler is a function that handles a mocked tool call and returns a result.
+type ToolHandler func(mcp.CallToolRequest) *mcp.CallToolResult
+
+// toolCallRecorder wraps an MCP handler and records every tools/call invocation.
+// By default, "config" and "getSkill" pass through to the real server; all other
+// tools return an error unless a custom ToolHandler is registered.
+type toolCallRecorder struct {
+	mu       sync.Mutex
+	calls    []mcp.CallToolRequest
+	handlers map[string]ToolHandler
+}
+
+func newRecorder(handlers map[string]ToolHandler) *toolCallRecorder {
+	return &toolCallRecorder{handlers: handlers}
+}
+
+func (r *toolCallRecorder) wrap(inner mcp.MessageHandler) mcp.MessageHandler {
+	return mcp.MessageHandlerFunc(func(ctx context.Context, msg mcp.Message) {
+		if msg.Method != "tools/call" {
+			inner.OnMessage(ctx, msg)
+			return
+		}
+
+		var call mcp.CallToolRequest
+		_ = json.Unmarshal(msg.Params, &call)
+		r.mu.Lock()
+		r.calls = append(r.calls, call)
+		r.mu.Unlock()
+
+		switch call.Name {
+		case "config", "getSkill":
+			// Always pass through: config drives agent setup, getSkill loads skills.
+			inner.OnMessage(ctx, msg)
+		default:
+			if handler, ok := r.handlers[call.Name]; ok {
+				mcp.Invoke(ctx, msg, func(_ context.Context, _ mcp.Message, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return handler(req), nil
+				})
+			} else {
+				mcp.Invoke(ctx, msg, func(_ context.Context, _ mcp.Message, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return &mcp.CallToolResult{
+						IsError: true,
+						Content: []mcp.Content{{Type: "text", Text: fmt.Sprintf("tool %q is not available in the test environment", call.Name)}},
+					}, nil
+				})
+			}
+		}
+	})
+}
+
+func (r *toolCallRecorder) find(name string) *mcp.CallToolRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i := range r.calls {
+		if r.calls[i].Name == name {
+			return &r.calls[i]
+		}
+	}
+	return nil
+}
+
+// summary returns a multi-line description of all recorded tool calls with their
+// arguments, for use in test failure output.
+func (r *toolCallRecorder) summary() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.calls) == 0 {
+		return "  (no tool calls recorded)"
+	}
+	var sb strings.Builder
+	for i, c := range r.calls {
+		args, _ := json.MarshalIndent(c.Arguments, "    ", "  ")
+		fmt.Fprintf(&sb, "  [%d] %s\n    args: %s\n", i+1, c.Name, args)
+	}
+	return sb.String()
+}
+
+// stubMCPHandler returns a minimal, no-tool MCP server used as a placeholder for
+// servers that aren't needed in the test but are referenced by the config hook.
+func stubMCPHandler() mcp.MessageHandler {
+	stubTools := mcp.NewServerTools()
+	return mcp.MessageHandlerFunc(func(ctx context.Context, msg mcp.Message) {
+		switch msg.Method {
+		case "initialize":
+			mcp.Invoke(ctx, msg, func(ctx context.Context, _ mcp.Message, params mcp.InitializeRequest) (*mcp.InitializeResult, error) {
+				return &mcp.InitializeResult{
+					ProtocolVersion: params.ProtocolVersion,
+					Capabilities:    mcp.ServerCapabilities{Tools: &mcp.ToolsServerCapability{}},
+					ServerInfo:      mcp.ServerInfo{Name: "stub", Version: "0"},
+				}, nil
+			})
+		case "notifications/initialized", "notifications/cancelled":
+		case "tools/list":
+			mcp.Invoke(ctx, msg, stubTools.List)
+		case "tools/call":
+			mcp.Invoke(ctx, msg, stubTools.Call)
+		default:
+			msg.SendError(ctx, mcp.ErrRPCMethodNotFound.WithMessage("%s", msg.Method))
+		}
+	})
+}
+
+// newTestRuntime creates a Runtime and installs a toolCallRecorder on nanobot.system.
+// The agent has no pre-loaded instructions; it discovers the workflows skill naturally
+// via the getSkill tool that the config hook injects.
+func newTestRuntime(t *testing.T, completer types.Completer, recorder *toolCallRecorder) context.Context {
+	t.Helper()
+
+	rt, err := runtime.NewRuntime(context.Background(), llm.Config{})
+	if err != nil {
+		t.Fatalf("NewRuntime failed: %v", err)
+	}
+
+	// Wrap the real system server so we can record and intercept tool calls.
+	rt.AddServer("nanobot.system", func(string) mcp.MessageHandler {
+		return recorder.wrap(system.NewServer("", ""))
+	})
+	// nanobot.tasks is only registered when LoopbackURL+Store are set; stub it so
+	// the config hook doesn't fail when it adds the server to MCPServers.
+	rt.AddServer("nanobot.tasks", func(string) mcp.MessageHandler { return stubMCPHandler() })
+
+	// Load the production config (builtin nanobot agent) from the standard location.
+	// config.Load handles a missing .nanobot/ directory gracefully.
+	cfg, _, err := config.Load(context.Background(), ".nanobot/", true)
+	if err != nil {
+		t.Fatalf("config.Load failed: %v", err)
+	}
+
+	agentSvc := agents.New(completer, rt.Service)
+	ctx := rt.WithTempSession(context.Background(), cfg)
+	return context.WithValue(ctx, agentSvcKey{}, agentSvc)
+}
+
+type agentSvcKey struct{}
+
+func runAgent(ctx context.Context, prompt string) error {
+	svc := ctx.Value(agentSvcKey{}).(*agents.Agents)
+	_, err := svc.Complete(ctx, types.CompletionRequest{
+		Agent: "nanobot",
+		Input: []types.Message{{
+			Role: "user",
+			Items: []types.CompletionItem{{
+				Content: &mcp.Content{Type: "text", Text: prompt},
+			}},
+		}},
+	})
+	return err
+}

--- a/integration_test/workflow_skill_test.go
+++ b/integration_test/workflow_skill_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration_test
 
 import (

--- a/integration_test/workflow_skill_test.go
+++ b/integration_test/workflow_skill_test.go
@@ -107,6 +107,10 @@ func TestWorkflowListingGlobPattern(t *testing.T) {
 					}
 
 					assertCorrectGlobCall(t, recorder)
+
+					if call := recorder.find("searchArtifacts"); call != nil {
+						t.Errorf("model should not call searchArtifacts for local listing prompts\nall tool calls:\n%s", recorder.summary())
+					}
 				})
 			}
 		})

--- a/integration_test/workflow_skill_test.go
+++ b/integration_test/workflow_skill_test.go
@@ -77,7 +77,7 @@ func assertCorrectGlobCall(t *testing.T, recorder *toolCallRecorder) {
 func TestWorkflowListingGlobPattern(t *testing.T) {
 	apiKey := os.Getenv("ANTHROPIC_API_KEY")
 	if apiKey == "" {
-		t.Skip("ANTHROPIC_API_KEY not set")
+		t.Fatal("ANTHROPIC_API_KEY must be set when running integration tests")
 	}
 
 	completer := llm.NewClient(llm.Config{

--- a/integration_test/workflow_skill_test.go
+++ b/integration_test/workflow_skill_test.go
@@ -1,0 +1,112 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/nanobot-ai/nanobot/pkg/llm"
+	"github.com/nanobot-ai/nanobot/pkg/llm/anthropic"
+	"github.com/nanobot-ai/nanobot/pkg/mcp"
+	"github.com/nanobot-ai/nanobot/pkg/types"
+)
+
+// setupWorkflowListing creates a recorder that mocks the glob tool with a pair of
+// fake workflow files, and a runtime context ready for agent execution.
+func setupWorkflowListing(t *testing.T, completer types.Completer) (context.Context, *toolCallRecorder) {
+	t.Helper()
+	recorder := newRecorder(map[string]ToolHandler{
+		"glob": func(_ mcp.CallToolRequest) *mcp.CallToolResult {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{{Type: "text", Text: "workflows/code-review/SKILL.md\nworkflows/deploy/SKILL.md\n"}},
+			}
+		},
+	})
+	return newTestRuntime(t, completer, recorder), recorder
+}
+
+// getSkillDiagnostic returns a string describing whether the model called getSkill,
+// used as additional context in glob assertion failures.
+func getSkillDiagnostic(recorder *toolCallRecorder) string {
+	call := recorder.find("getSkill")
+	if call == nil {
+		return "model did not call getSkill"
+	}
+	name, _ := call.Arguments["name"].(string)
+	return fmt.Sprintf("model called getSkill(%q)", name)
+}
+
+// assertCorrectGlobCall verifies that the recorder captured a glob call with valid
+// workflow-discovery parameters. Two forms are accepted:
+//
+//	pattern="**/SKILL.md"           path ends with "workflows"
+//	pattern="workflows/**/SKILL.md" path does NOT contain "workflows" (already in pattern)
+func assertCorrectGlobCall(t *testing.T, recorder *toolCallRecorder) {
+	t.Helper()
+
+	globCall := recorder.find("glob")
+	if globCall == nil {
+		t.Fatalf("LLM did not call glob (%s)\nall tool calls:\n%s",
+			getSkillDiagnostic(recorder), recorder.summary())
+	}
+
+	pattern, _ := globCall.Arguments["pattern"].(string)
+	path, _ := globCall.Arguments["path"].(string)
+	cleanPath := strings.TrimRight(path, "/")
+
+	patternWithPath := pattern == "**/SKILL.md" &&
+		(cleanPath == "workflows" || strings.HasSuffix(cleanPath, "/workflows"))
+	patternOnly := pattern == "workflows/**/SKILL.md" &&
+		cleanPath != "workflows" && !strings.HasSuffix(cleanPath, "/workflows")
+
+	if !patternWithPath && !patternOnly {
+		t.Errorf("unexpected glob call: pattern=%q path=%q\n  want: pattern=\"**/SKILL.md\" with path ending in \"workflows\"\n     or: pattern=\"workflows/**/SKILL.md\" with path NOT containing \"workflows\" (would double-nest)\n  (%s)\nall tool calls:\n%s",
+			pattern, path, getSkillDiagnostic(recorder), recorder.summary())
+	}
+}
+
+// TestWorkflowListingGlobPattern runs the agent against a real LLM and asserts that
+// the model calls glob with the correct pattern (**/SKILL.md) and path (workflows/).
+// The glob tool is intercepted and not actually executed.
+//
+// Requires ANTHROPIC_API_KEY; skipped otherwise.
+func TestWorkflowListingGlobPattern(t *testing.T) {
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		t.Skip("ANTHROPIC_API_KEY not set")
+	}
+
+	completer := llm.NewClient(llm.Config{
+		DefaultModel: "claude-sonnet-4-6",
+		Anthropic:    anthropic.Config{APIKey: apiKey},
+	})
+
+	prompts := []string{
+		"list all workflows",
+		"show my workflows",
+		"what workflows do I have?",
+		"show me my available workflows",
+		"display all workflows",
+	}
+
+	for _, prompt := range prompts {
+		t.Run(prompt, func(t *testing.T) {
+			t.Parallel()
+			for i := range *numRuns {
+				t.Run(fmt.Sprintf("run%d", i+1), func(t *testing.T) {
+					t.Parallel()
+					ctx, recorder := setupWorkflowListing(t, completer)
+
+					err := runAgent(ctx, prompt)
+					if err != nil {
+						t.Fatalf("Complete() failed: %v", err)
+					}
+
+					assertCorrectGlobCall(t, recorder)
+				})
+			}
+		})
+	}
+}

--- a/integration_test/workflow_skill_test.go
+++ b/integration_test/workflow_skill_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nanobot-ai/nanobot/pkg/agents"
 	"github.com/nanobot-ai/nanobot/pkg/llm"
 	"github.com/nanobot-ai/nanobot/pkg/llm/anthropic"
 	"github.com/nanobot-ai/nanobot/pkg/mcp"
@@ -15,7 +16,7 @@ import (
 
 // setupWorkflowListing creates a recorder that mocks the glob tool with a pair of
 // fake workflow files, and a runtime context ready for agent execution.
-func setupWorkflowListing(t *testing.T, completer types.Completer) (context.Context, *toolCallRecorder) {
+func setupWorkflowListing(t *testing.T, completer types.Completer) (context.Context, *agents.Agents, *toolCallRecorder) {
 	t.Helper()
 	recorder := newRecorder(map[string]ToolHandler{
 		"glob": func(_ mcp.CallToolRequest) *mcp.CallToolResult {
@@ -24,7 +25,8 @@ func setupWorkflowListing(t *testing.T, completer types.Completer) (context.Cont
 			}
 		},
 	})
-	return newTestRuntime(t, completer, recorder), recorder
+	ctx, svc := newTestRuntime(t, completer, recorder)
+	return ctx, svc, recorder
 }
 
 // getSkillDiagnostic returns a string describing whether the model called getSkill,
@@ -97,9 +99,9 @@ func TestWorkflowListingGlobPattern(t *testing.T) {
 			for i := range *numRuns {
 				t.Run(fmt.Sprintf("run%d", i+1), func(t *testing.T) {
 					t.Parallel()
-					ctx, recorder := setupWorkflowListing(t, completer)
+					ctx, svc, recorder := setupWorkflowListing(t, completer)
 
-					err := runAgent(ctx, prompt)
+					err := runAgent(ctx, svc, prompt)
 					if err != nil {
 						t.Fatalf("Complete() failed: %v", err)
 					}

--- a/pkg/servers/system/skills/workflows.md
+++ b/pkg/servers/system/skills/workflows.md
@@ -16,7 +16,7 @@ There are two places workflows can exist:
 
 **When the user asks about "shared workflows", "public workflows", workflows from other users, or wants to discover/find/browse available workflows they haven't installed yet, ALWAYS use `searchArtifacts` to search the remote registry.** Do not just list the local `workflows/` directory — that only shows what is already installed locally.
 
-If the user asks to "list all workflows", "show my workflows", "which workflows are installed" or similar without specifying shared/public, find workflows by using the Glob tool (never Bash with find or ls) with pattern `**/SKILL.md` in the `workflows/` directory (do NOT set path to `workflows/` and pattern to `workflows/**/SKILL.md` — that double-nests the path). If they ask to "list shared workflows" or "find workflows", use `searchArtifacts`.
+If the user asks to "list all workflows", "show my workflows", "which workflows are installed" or similar without specifying shared/public, find workflows by using the Glob tool (never Bash with find or ls) with pattern `**/SKILL.md` in the `workflows/` directory (do NOT include `workflows/` in both the path and the pattern — that double-nests). If they ask to "list shared workflows" or "find workflows", use `searchArtifacts`.
 
 ## When to Use Workflows
 

--- a/pkg/servers/system/skills/workflows.md
+++ b/pkg/servers/system/skills/workflows.md
@@ -16,7 +16,7 @@ There are two places workflows can exist:
 
 **When the user asks about "shared workflows", "public workflows", workflows from other users, or wants to discover/find/browse available workflows they haven't installed yet, ALWAYS use `searchArtifacts` to search the remote registry.** Do not just list the local `workflows/` directory — that only shows what is already installed locally.
 
-If the user asks to "list all workflows" or "show my workflows" without specifying shared/public, list the local `workflows/` directory. If they ask to "list shared workflows" or "find workflows", use `searchArtifacts`.
+If the user asks to "list all workflows", "show my workflows", "which workflows are installed" or similar without specifying shared/public, find workflows by using the Glob tool (never Bash with find or ls) with pattern `**/SKILL.md` in the `workflows/` directory (do NOT set path to `workflows/` and pattern to `workflows/**/SKILL.md` — that double-nests the path). If they ask to "list shared workflows" or "find workflows", use `searchArtifacts`.
 
 ## When to Use Workflows
 
@@ -209,7 +209,7 @@ Users may ask to run a workflow at any time — not just immediately after desig
 
 When the user asks you to run a workflow:
 
-1. Load the workflow from `workflows/<name>/SKILL.md`. If you're unsure which workflows are available, list the `workflows/` directory.
+1. Load the workflow from `workflows/<name>/SKILL.md`. If you're unsure which workflows are available, use glob pattern `**/SKILL.md` with path `workflows/` to find them.
 2. Use TodoWrite to create a todo for each workflow step before you begin. This is your execution plan — the user will follow along.
 3. **Present the execution plan to the user.** After creating the todos, present a brief summary of what will be executed and ask the user to confirm before proceeding. For example: "I've planned the following steps: [list steps]. Does this look good to proceed?"
 4. **Wait for user approval.** Do not begin execution until the user confirms.


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/6256

- Update the skill definition to have more clear guidance on how workflows can be discovered.
- In order to improve testability and ensure consistency across different prompts and repeated use, I also added an `integration_test` directory with some tools for testing prompts and intercepting tool calls to record/count