### PR TITLE
fix: ensure null fields are nil after calling hooks

### DIFF
--- a/pkg/mcp/session.go
+++ b/pkg/mcp/session.go
@@ -704,6 +704,12 @@ func (s *Session) callAllHooks(ctx context.Context, req *Message, direction stri
 			hookResponse.Message = req
 		} else {
 			req = hookResponse.Message
+			if string(req.Result) == "null" {
+				req.Result = nil
+			}
+			if string(req.Params) == "null" {
+				req.Params = nil
+			}
 		}
 		return hookResponse
 	})


### PR DESCRIPTION
Depending on the hook, it could return `null` for JSON objects. This change ensures that they are `nil`, which is the expected behavior in that case.