### PR TITLE
enhance: allow specifying the config flag multiple times

### DIFF
--- a/integration_test/main_test.go
+++ b/integration_test/main_test.go
@@ -151,7 +151,7 @@ func newTestRuntime(t *testing.T, completer types.Completer, recorder *toolCallR
 
 	// Load the production config (builtin nanobot agent) from the standard location.
 	// config.Load handles a missing .nanobot/ directory gracefully.
-	cfg, _, err := config.Load(context.Background(), ".nanobot/", true)
+	cfg, _, err := config.Load(context.Background(), config.DefaultConfigPath, true)
 	if err != nil {
 		t.Fatalf("config.Load failed: %v", err)
 	}

--- a/pkg/cli/call.go
+++ b/pkg/cli/call.go
@@ -39,7 +39,12 @@ func (e *Call) Customize(cmd *cobra.Command) {
 }
 
 func (e *Call) Run(cmd *cobra.Command, args []string) error {
-	cfg, err := e.n.ReadConfig(cmd.Context(), e.n.ConfigPath, !e.n.ExcludeBuiltInAgents)
+	configDir, err := e.n.RuntimeConfigDir()
+	if err != nil {
+		return err
+	}
+
+	cfg, err := e.n.ReadConfig(cmd.Context(), e.n.ConfigPaths(), !e.n.ExcludeBuiltInAgents)
 	if err != nil {
 		return err
 	}
@@ -47,7 +52,7 @@ func (e *Call) Run(cmd *cobra.Command, args []string) error {
 		MaxConcurrency: e.n.MaxConcurrency,
 		DSN:            e.n.DSN(),
 		DefaultModel:   e.n.DefaultModel,
-		ConfigDir:      e.n.ConfigPath,
+		ConfigDir:      configDir,
 	})
 	if err != nil {
 		return err

--- a/pkg/cli/call.go
+++ b/pkg/cli/call.go
@@ -39,11 +39,6 @@ func (e *Call) Customize(cmd *cobra.Command) {
 }
 
 func (e *Call) Run(cmd *cobra.Command, args []string) error {
-	configDir, err := e.n.RuntimeConfigDir()
-	if err != nil {
-		return err
-	}
-
 	cfg, err := e.n.ReadConfig(cmd.Context(), e.n.ConfigPaths(), !e.n.ExcludeBuiltInAgents)
 	if err != nil {
 		return err
@@ -52,7 +47,7 @@ func (e *Call) Run(cmd *cobra.Command, args []string) error {
 		MaxConcurrency: e.n.MaxConcurrency,
 		DSN:            e.n.DSN(),
 		DefaultModel:   e.n.DefaultModel,
-		ConfigDir:      configDir,
+		ConfigDir:      e.n.RuntimeConfigDir(),
 	})
 	if err != nil {
 		return err

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -55,7 +55,7 @@ type Nanobot struct {
 	MaxConcurrency       int      `usage:"The maximum number of concurrent tasks in a parallel loop" default:"10" hidden:"true"`
 	Chdir                string   `usage:"Change directory to this path before running the nanobot" default:"." short:"C"`
 	State                string   `usage:"Path to the state file" default:"./nanobot.db"`
-	ConfigPath           string   `usage:"Path to nanobot configuration file or directory" default:".nanobot/" name:"config" short:"c"`
+	ConfigPath           []string `usage:"Configuration file, directory, URL, or repo ref. Repeat to merge multiple configs; later entries override earlier ones" name:"config" short:"c"`
 	ExcludeBuiltInAgents bool     `usage:"Exclude built-in agents from the configuration"`
 
 	otel *telemetry.Otel
@@ -224,9 +224,37 @@ func (n *Nanobot) loadEnv() (map[string]string, error) {
 	return env, nil
 }
 
-func (n *Nanobot) ReadConfig(ctx context.Context, cfgPath string, includeDefaultAgents bool, opts ...runtime.Options) (*types.Config, error) {
-	cfg, _, err := config.Load(ctx, cfgPath, includeDefaultAgents, complete.Complete(opts...).Profiles...)
+func (n *Nanobot) ReadConfig(ctx context.Context, cfgPaths []string, includeDefaultAgents bool, opts ...runtime.Options) (*types.Config, error) {
+	cfg, _, err := config.LoadMany(ctx, cfgPaths, includeDefaultAgents, complete.Complete(opts...).Profiles...)
 	return cfg, err
+}
+
+func (n *Nanobot) ConfigPaths() []string {
+	if len(n.ConfigPath) == 0 {
+		return []string{".nanobot/"}
+	}
+	return n.ConfigPath
+}
+
+func (n *Nanobot) RuntimeConfigDir() (string, error) {
+	configPath := n.ConfigPaths()[0]
+	if strings.Contains(configPath, "://") {
+		return "", fmt.Errorf("first config path %q must be a local directory, not a URL", configPath)
+	}
+
+	info, err := os.Stat(configPath)
+	if err == nil {
+		if !info.IsDir() {
+			return "", fmt.Errorf("first config path %q must be a directory, not a file", configPath)
+		}
+		return configPath, nil
+	}
+
+	if strings.Count(configPath, "/") == 1 && !strings.HasPrefix(configPath, "/") && !strings.HasPrefix(configPath, "./") && !strings.HasPrefix(configPath, "../") {
+		return "", fmt.Errorf("first config path %q must be a local directory, not a GitHub repository", configPath)
+	}
+
+	return "", fmt.Errorf("failed to stat first config path %q: %w", configPath, err)
 }
 
 func (n *Nanobot) GetRuntime(ctx context.Context, opts ...runtime.Options) (*runtime.Runtime, error) {

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -231,30 +231,32 @@ func (n *Nanobot) ReadConfig(ctx context.Context, cfgPaths []string, includeDefa
 
 func (n *Nanobot) ConfigPaths() []string {
 	if len(n.ConfigPath) == 0 {
-		return []string{".nanobot/"}
+		return []string{config.DefaultConfigPath}
 	}
 	return n.ConfigPath
 }
 
-func (n *Nanobot) RuntimeConfigDir() (string, error) {
-	configPath := n.ConfigPaths()[0]
-	if strings.Contains(configPath, "://") {
-		return "", fmt.Errorf("first config path %q must be a local directory, not a URL", configPath)
-	}
+func (n *Nanobot) RuntimeConfigDir() string {
+	return runtimeConfigDir(n.ConfigPath)
+}
 
-	info, err := os.Stat(configPath)
-	if err == nil {
-		if !info.IsDir() {
-			return "", fmt.Errorf("first config path %q must be a directory, not a file", configPath)
+func runtimeConfigDir(configPaths []string) string {
+	configPath := config.DefaultConfigPath
+	for _, p := range configPaths {
+		if strings.Contains(configPath, "://") {
+			continue
 		}
-		return configPath, nil
+
+		info, err := os.Stat(p)
+		if err == nil {
+			if !info.IsDir() {
+				configPath = filepath.Dir(p)
+			}
+			return configPath
+		}
 	}
 
-	if strings.Count(configPath, "/") == 1 && !strings.HasPrefix(configPath, "/") && !strings.HasPrefix(configPath, "./") && !strings.HasPrefix(configPath, "../") {
-		return "", fmt.Errorf("first config path %q must be a local directory, not a GitHub repository", configPath)
-	}
-
-	return "", fmt.Errorf("failed to stat first config path %q: %w", configPath, err)
+	return configPath
 }
 
 func (n *Nanobot) GetRuntime(ctx context.Context, opts ...runtime.Options) (*runtime.Runtime, error) {

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNanobotConfigPathsDefault(t *testing.T) {
+	n := &Nanobot{}
+
+	paths := n.ConfigPaths()
+	if len(paths) != 1 || paths[0] != ".nanobot/" {
+		t.Fatalf("expected default config path [.nanobot/], got %v", paths)
+	}
+}
+
+func TestNanobotRuntimeConfigDirDirectory(t *testing.T) {
+	dir := t.TempDir()
+	n := &Nanobot{ConfigPath: []string{dir, "./overlay.yaml"}}
+
+	configDir, err := n.RuntimeConfigDir()
+	if err != nil {
+		t.Fatalf("expected directory config path to succeed, got %v", err)
+	}
+	if configDir != dir {
+		t.Fatalf("expected config dir %q, got %q", dir, configDir)
+	}
+}
+
+func TestNanobotRuntimeConfigDirFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nanobot.yaml")
+	if err := os.WriteFile(path, []byte("agents: {}\n"), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	n := &Nanobot{ConfigPath: []string{path}}
+	_, err := n.RuntimeConfigDir()
+	if err == nil || !strings.Contains(err.Error(), "must be a directory, not a file") {
+		t.Fatalf("expected file config path error, got %v", err)
+	}
+}
+
+func TestNanobotRuntimeConfigDirURL(t *testing.T) {
+	n := &Nanobot{ConfigPath: []string{"https://example.com/nanobot.yaml"}}
+	_, err := n.RuntimeConfigDir()
+	if err == nil || !strings.Contains(err.Error(), "must be a local directory, not a URL") {
+		t.Fatalf("expected URL config path error, got %v", err)
+	}
+}
+
+func TestNanobotRuntimeConfigDirGitHubRepo(t *testing.T) {
+	n := &Nanobot{ConfigPath: []string{"owner/repo"}}
+	_, err := n.RuntimeConfigDir()
+	if err == nil || !strings.Contains(err.Error(), "must be a local directory, not a GitHub repository") {
+		t.Fatalf("expected GitHub repo config path error, got %v", err)
+	}
+}

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -3,58 +3,45 @@ package cli
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
+
+	"github.com/nanobot-ai/nanobot/pkg/config"
 )
 
 func TestNanobotConfigPathsDefault(t *testing.T) {
 	n := &Nanobot{}
 
 	paths := n.ConfigPaths()
-	if len(paths) != 1 || paths[0] != ".nanobot/" {
+	if len(paths) != 1 || paths[0] != config.DefaultConfigPath {
 		t.Fatalf("expected default config path [.nanobot/], got %v", paths)
 	}
 }
 
-func TestNanobotRuntimeConfigDirDirectory(t *testing.T) {
-	dir := t.TempDir()
-	n := &Nanobot{ConfigPath: []string{dir, "./overlay.yaml"}}
-
-	configDir, err := n.RuntimeConfigDir()
-	if err != nil {
-		t.Fatalf("expected directory config path to succeed, got %v", err)
-	}
-	if configDir != dir {
-		t.Fatalf("expected config dir %q, got %q", dir, configDir)
+func TestRuntimeConfigDirDefaultsWhenNoPathsExist(t *testing.T) {
+	configDir := runtimeConfigDir([]string{"./missing", "https://example.com/nanobot.yaml"})
+	if configDir != config.DefaultConfigPath {
+		t.Fatalf("expected default config dir %q, got %q", config.DefaultConfigPath, configDir)
 	}
 }
 
-func TestNanobotRuntimeConfigDirFile(t *testing.T) {
+func TestRuntimeConfigDirKeepsDefaultForExistingDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	configDir := runtimeConfigDir([]string{"./missing", dir})
+	if configDir != config.DefaultConfigPath {
+		t.Fatalf("expected default config dir %q, got %q", config.DefaultConfigPath, configDir)
+	}
+}
+
+func TestRuntimeConfigDirReturnsFileParentDirectory(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "nanobot.yaml")
 	if err := os.WriteFile(path, []byte("agents: {}\n"), 0o644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
 	}
 
-	n := &Nanobot{ConfigPath: []string{path}}
-	_, err := n.RuntimeConfigDir()
-	if err == nil || !strings.Contains(err.Error(), "must be a directory, not a file") {
-		t.Fatalf("expected file config path error, got %v", err)
-	}
-}
-
-func TestNanobotRuntimeConfigDirURL(t *testing.T) {
-	n := &Nanobot{ConfigPath: []string{"https://example.com/nanobot.yaml"}}
-	_, err := n.RuntimeConfigDir()
-	if err == nil || !strings.Contains(err.Error(), "must be a local directory, not a URL") {
-		t.Fatalf("expected URL config path error, got %v", err)
-	}
-}
-
-func TestNanobotRuntimeConfigDirGitHubRepo(t *testing.T) {
-	n := &Nanobot{ConfigPath: []string{"owner/repo"}}
-	_, err := n.RuntimeConfigDir()
-	if err == nil || !strings.Contains(err.Error(), "must be a local directory, not a GitHub repository") {
-		t.Fatalf("expected GitHub repo config path error, got %v", err)
+	configDir := runtimeConfigDir([]string{path})
+	if configDir != dir {
+		t.Fatalf("expected config dir %q, got %q", dir, configDir)
 	}
 }

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -128,10 +128,6 @@ func (r *Run) Run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	callbackHandler := mcp.NewCallbackServer(confirm.New())
-	configDir, err := r.n.RuntimeConfigDir()
-	if err != nil {
-		return err
-	}
 	configPaths := r.n.ConfigPaths()
 	runtimeOpt := runtime.Options{
 		Roots:                     roots,
@@ -141,7 +137,7 @@ func (r *Run) Run(cmd *cobra.Command, args []string) (err error) {
 		TokenExchangeClientID:     r.Auth.OAuthClientID,
 		TokenExchangeClientSecret: r.Auth.OAuthClientSecret,
 		DefaultModel:              r.n.DefaultModel,
-		ConfigDir:                 configDir,
+		ConfigDir:                 r.n.RuntimeConfigDir(),
 		LoopbackURL:               "http://" + r.ListenAddress + "/mcp/chat",
 	}
 

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -50,7 +50,7 @@ func (r *Run) Customize(cmd *cobra.Command) {
 	cmd.Short = "Run the nanobot"
 	cmd.Long = `Run the nanobot using the specified configuration.
 
-If a configuration is not specified with the --config, the nanobot.yaml in the .nanobot/ directory
+If a configuration is not specified with the --config flag, the nanobot.yaml in the .nanobot/ directory
 will be used if it exists. Otherwise, the markdown files in the .nanobot/agents/ subdirectory
 will be used as the configuration.
 
@@ -59,6 +59,10 @@ To change the configuration location, use the --config flag. The same rules appl
 - If --config is a directory, then:
 	- If a nanobot.yaml file is found at the specified location, it will be used.
 	- If no nanobot.yaml file is found, the markdown files in the agents/ subdirectory will be used.
+
+The --config flag may be repeated to merge multiple configurations. Later --config values override
+earlier ones. The first config path is also used as the local config workspace for things like skills
+and local MCP CLI state, so it must be a local directory.
 
 The configuration location can also be a URL, in which case the contents will be treated as a nanobot.yaml file.
 
@@ -75,6 +79,9 @@ only supports YAML configuration files (i.e., nanobot.yaml) and not a directory 
 
   # Run the nanobot.yaml at the URL
   nanobot run --config https://....
+
+  # Merge multiple configs, with later values overriding earlier ones
+  nanobot run -c .nanobot/ -c ./team.yaml -c ./local.yaml
 `
 }
 
@@ -121,6 +128,11 @@ func (r *Run) Run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	callbackHandler := mcp.NewCallbackServer(confirm.New())
+	configDir, err := r.n.RuntimeConfigDir()
+	if err != nil {
+		return err
+	}
+	configPaths := r.n.ConfigPaths()
 	runtimeOpt := runtime.Options{
 		Roots:                     roots,
 		MaxConcurrency:            r.n.MaxConcurrency,
@@ -129,7 +141,7 @@ func (r *Run) Run(cmd *cobra.Command, args []string) (err error) {
 		TokenExchangeClientID:     r.Auth.OAuthClientID,
 		TokenExchangeClientSecret: r.Auth.OAuthClientSecret,
 		DefaultModel:              r.n.DefaultModel,
-		ConfigDir:                 r.n.ConfigPath,
+		ConfigDir:                 configDir,
 		LoopbackURL:               "http://" + r.ListenAddress + "/mcp/chat",
 	}
 
@@ -138,7 +150,7 @@ func (r *Run) Run(cmd *cobra.Command, args []string) (err error) {
 		if profiles != "" {
 			optCopy.Profiles = append(optCopy.Profiles, strings.Split(profiles, ",")...)
 		}
-		cfg, err := r.n.ReadConfig(cmd.Context(), r.n.ConfigPath, !r.n.ExcludeBuiltInAgents, optCopy)
+		cfg, err := r.n.ReadConfig(cmd.Context(), configPaths, !r.n.ExcludeBuiltInAgents, optCopy)
 		if err != nil {
 			return types.Config{}, err
 		}
@@ -162,7 +174,7 @@ func (r *Run) Run(cmd *cobra.Command, args []string) (err error) {
 
 	once, err := cfgFactory(cmd.Context(), "")
 	if err != nil {
-		return fmt.Errorf("failed to read config from %q: %w", r.n.ConfigPath, err)
+		return fmt.Errorf("failed to read config from %q: %w", strings.Join(configPaths, ", "), err)
 	}
 
 	slog.Info("config", "json", once.Redacted())

--- a/pkg/cli/targets.go
+++ b/pkg/cli/targets.go
@@ -40,7 +40,7 @@ func (t *Targets) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	c, err := t.n.ReadConfig(cmd.Context(), t.n.ConfigPath, !t.n.ExcludeBuiltInAgents)
+	c, err := t.n.ReadConfig(cmd.Context(), t.n.ConfigPaths(), !t.n.ExcludeBuiltInAgents)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/builtin_test.go
+++ b/pkg/config/builtin_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -113,5 +114,56 @@ func TestLoad_WithoutBuiltinAgents(t *testing.T) {
 	// Verify nanobot does NOT exist
 	if _, exists := cfg.Agents["nanobot"]; exists {
 		t.Errorf("did not expect builtin agent 'nanobot' when includeDefaultAgents=false")
+	}
+}
+
+func TestLoadMany_MergesInOrder(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	basePath := dir + "/base.yaml"
+	overlayPath := dir + "/overlay.yaml"
+
+	base := []byte(`agents:
+  assistant:
+    name: Base Assistant
+    instructions: Base instructions
+publish:
+  entrypoint:
+    - assistant
+`)
+	overlay := []byte(`agents:
+  assistant:
+    name: Overlay Assistant
+  helper:
+    name: Helper
+    instructions: Helper instructions
+publish:
+  entrypoint:
+    - helper
+`)
+
+	if err := os.WriteFile(basePath, base, 0o644); err != nil {
+		t.Fatalf("failed to write base config: %v", err)
+	}
+	if err := os.WriteFile(overlayPath, overlay, 0o644); err != nil {
+		t.Fatalf("failed to write overlay config: %v", err)
+	}
+
+	cfg, _, err := LoadMany(ctx, []string{basePath, overlayPath}, false)
+	if err != nil {
+		t.Fatalf("unexpected error loading merged configs: %v", err)
+	}
+
+	if got := cfg.Agents["assistant"].Name; got != "Overlay Assistant" {
+		t.Fatalf("expected later config to override assistant name, got %q", got)
+	}
+	if got := cfg.Agents["assistant"].Instructions.Instructions; got != "Base instructions" {
+		t.Fatalf("expected overlay merge to preserve existing instructions, got %q", got)
+	}
+	if _, ok := cfg.Agents["helper"]; !ok {
+		t.Fatalf("expected helper agent from overlay config to be present")
+	}
+	if got := cfg.Publish.Entrypoint; len(got) != 2 || got[0] != "assistant" || got[1] != "helper" {
+		t.Fatalf("expected entrypoint arrays to concatenate in order, got %v", got)
 	}
 }

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -20,6 +20,49 @@ import (
 )
 
 func Load(ctx context.Context, path string, includeDefaultAgents bool, profiles ...string) (cfg *types.Config, cwd string, err error) {
+	return LoadMany(ctx, []string{path}, includeDefaultAgents, profiles...)
+}
+
+func LoadMany(ctx context.Context, paths []string, includeDefaultAgents bool, profiles ...string) (cfg *types.Config, cwd string, err error) {
+	if len(paths) == 0 {
+		paths = []string{".nanobot/"}
+	}
+
+	var merged *types.Config
+	for _, path := range paths {
+		current, currentCwd, err := loadSingle(ctx, path, includeDefaultAgents, profiles...)
+		if err != nil {
+			return nil, "", err
+		}
+		if cwd == "" {
+			cwd = currentCwd
+		}
+		if merged == nil {
+			merged = current
+			continue
+		}
+
+		combined, err := Merge(*merged, *current)
+		if err != nil {
+			return nil, "", fmt.Errorf("error merging config path %s: %w", path, err)
+		}
+		merged = &combined
+	}
+
+	if merged == nil {
+		merged = new(types.Config)
+	}
+
+	if includeDefaultAgents {
+		if err := loadBuiltinAgents(merged); err != nil {
+			return nil, "", err
+		}
+	}
+
+	return merged, cwd, nil
+}
+
+func loadSingle(ctx context.Context, path string, includeDefaultAgents bool, profiles ...string) (cfg *types.Config, cwd string, err error) {
 	defer func() {
 		if err != nil {
 			if _, fErr := os.Stat(path); fErr == nil && !strings.HasPrefix(path, "/") && !strings.HasPrefix(path, ".") {
@@ -39,13 +82,6 @@ func Load(ctx context.Context, path string, includeDefaultAgents bool, profiles 
 		}
 	} else if !includeDefaultAgents {
 		return cfg, cwd, nil
-	}
-
-	if cfg == nil {
-		cfg = new(types.Config)
-	}
-	if err := loadBuiltinAgents(cfg); err != nil {
-		return nil, "", err
 	}
 
 	return cfg, cwd, nil

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -19,13 +19,15 @@ import (
 	"github.com/nanobot-ai/nanobot/pkg/types"
 )
 
+const DefaultConfigPath = ".nanobot/"
+
 func Load(ctx context.Context, path string, includeDefaultAgents bool, profiles ...string) (cfg *types.Config, cwd string, err error) {
 	return LoadMany(ctx, []string{path}, includeDefaultAgents, profiles...)
 }
 
 func LoadMany(ctx context.Context, paths []string, includeDefaultAgents bool, profiles ...string) (cfg *types.Config, cwd string, err error) {
 	if len(paths) == 0 {
-		paths = []string{".nanobot/"}
+		paths = []string{DefaultConfigPath}
 	}
 
 	var merged *types.Config
@@ -77,7 +79,7 @@ func loadSingle(ctx context.Context, path string, includeDefaultAgents bool, pro
 
 	cfg, cwd, err = loadResource(ctx, configResource, profiles...)
 	if err != nil {
-		if !includeDefaultAgents || !errors.Is(err, NoConfigFoundErr) && !errors.Is(err, fs.ErrNotExist) || path != ".nanobot/" {
+		if !includeDefaultAgents || !errors.Is(err, NoConfigFoundErr) && !errors.Is(err, fs.ErrNotExist) || path != DefaultConfigPath {
 			return cfg, cwd, err
 		}
 	} else if !includeDefaultAgents {

--- a/pkg/servers/obotmcp/mcpcli_config.go
+++ b/pkg/servers/obotmcp/mcpcli_config.go
@@ -67,13 +67,6 @@ func storageRoot(configDir string) string {
 		}
 	}
 
-	if info, err := os.Stat(base); err == nil {
-		if info.IsDir() {
-			return base
-		}
-		return filepath.Dir(base)
-	}
-
 	return base
 }
 


### PR DESCRIPTION
The configuration will be merged together. The first config flag specified will determine the "config directory" where we store mcp-cli config and skills.

Issue: https://github.com/obot-platform/obot/issues/6400