### PR TITLE
Fix supervise process cleanup

### DIFF
--- a/pkg/supervise/daemon.go
+++ b/pkg/supervise/daemon.go
@@ -14,14 +14,10 @@ func Daemon() error {
 	cmd := exec.CommandContext(ctx, os.Args[2], os.Args[3:]...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
+	configureDaemonCommand(cmd)
 
-	// Inherit the process group from parent (don't create new one)
-	// The parent already set up the process group in Cmd()
 	cmd.Cancel = func() error {
-		if cmd.Process != nil {
-			return cmd.Process.Kill()
-		}
-		return nil
+		return cancelDaemonCommand(cmd)
 	}
 
 	processIn, err := cmd.StdinPipe()
@@ -30,6 +26,8 @@ func Daemon() error {
 	}
 
 	go func() {
+		defer processIn.Close()
+
 		var buf [4096]byte
 		for {
 			n, err := os.Stdin.Read(buf[:])
@@ -42,6 +40,8 @@ func Daemon() error {
 				}
 			}
 		}
+		// Give the wrapped command a short grace period to exit on stdin EOF before
+		// canceling and escalating to process-group termination.
 		time.Sleep(5 * time.Second)
 		cancel()
 	}()

--- a/pkg/supervise/daemon_unix.go
+++ b/pkg/supervise/daemon_unix.go
@@ -1,0 +1,49 @@
+//go:build !windows
+
+package supervise
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func configureDaemonCommand(cmd *exec.Cmd) {
+	wrapperPGID, err := syscall.Getpgid(0)
+	if err != nil || wrapperPGID != os.Getpid() {
+		// There are two regimes here:
+		//   1. If _exec is already the leader of its own process group, keep the wrapped
+		//      command in that same group so an external kill of the wrapper group
+		//      naturally reaps the whole subtree.
+		//   2. Otherwise, put the wrapped command in its own group so Cancel can still
+		//      signal the entire child subtree without depending on the parent's group.
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Setpgid: true,
+		}
+	}
+}
+
+func cancelDaemonCommand(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+
+	targetPGID, err := daemonTargetPGID(cmd)
+	if err != nil || targetPGID <= 0 {
+		return err
+	}
+
+	err = syscall.Kill(-targetPGID, syscall.SIGKILL)
+	if errors.Is(err, syscall.ESRCH) {
+		return nil
+	}
+	return err
+}
+
+func daemonTargetPGID(cmd *exec.Cmd) (int, error) {
+	if cmd.SysProcAttr != nil && cmd.SysProcAttr.Setpgid {
+		return cmd.Process.Pid, nil
+	}
+	return syscall.Getpgid(0)
+}

--- a/pkg/supervise/daemon_windows.go
+++ b/pkg/supervise/daemon_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package supervise
+
+import "os/exec"
+
+func configureDaemonCommand(*exec.Cmd) {
+}
+
+func cancelDaemonCommand(cmd *exec.Cmd) error {
+	if cmd.Process != nil {
+		return cmd.Process.Kill()
+	}
+	return nil
+}

--- a/pkg/supervise/supervise_integration_test.go
+++ b/pkg/supervise/supervise_integration_test.go
@@ -1,0 +1,247 @@
+//go:build integration && !windows
+
+package supervise_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestExecSupervisorCleansUpGrandchildrenOnStdinClose(t *testing.T) {
+	repoRoot := superviseRepoRoot(t)
+	binPath := buildNanobotBinary(t, repoRoot)
+	helperPath, pidFile := writeGrandchildHelper(t)
+
+	cmd, stdin, output := startExecSupervisor(t, binPath, helperPath, supervisorStartOptions{
+		withStdin:           true,
+		supervisorOwnPGroup: true,
+	})
+	go func() {
+		time.Sleep(1 * time.Second)
+		_ = stdin.Close()
+	}()
+	waitForExit(t, cmd, output)
+
+	assertGrandchildExited(t, pidFile, "stdin close in shared-group regime")
+}
+
+func TestExecSupervisorCleansUpGrandchildrenOnStdinCloseWithSplitChildGroup(t *testing.T) {
+	repoRoot := superviseRepoRoot(t)
+	binPath := buildNanobotBinary(t, repoRoot)
+	helperPath, pidFile := writeGrandchildHelper(t)
+
+	cmd, stdin, output := startExecSupervisor(t, binPath, helperPath, supervisorStartOptions{
+		withStdin:           true,
+		supervisorOwnPGroup: false,
+	})
+	go func() {
+		time.Sleep(1 * time.Second)
+		_ = stdin.Close()
+	}()
+	waitForExit(t, cmd, output)
+
+	assertGrandchildExited(t, pidFile, "stdin close in split-child-group regime")
+}
+
+func TestExecSupervisorCleansUpGrandchildrenOnExternalCancel(t *testing.T) {
+	repoRoot := superviseRepoRoot(t)
+	binPath := buildNanobotBinary(t, repoRoot)
+	helperPath, pidFile := writeGrandchildHelper(t)
+
+	cmd, _, output := startExecSupervisor(t, binPath, helperPath, supervisorStartOptions{
+		withStdin:           false,
+		supervisorOwnPGroup: true,
+	})
+
+	pid := waitForPIDFile(t, pidFile)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for supervisor to start: %v", ctx.Err())
+	case <-time.After(1 * time.Second):
+	}
+
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		t.Fatalf("failed to kill supervisor process group: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Logf("nanobot _exec output:\n%s", strings.TrimSpace(output.String()))
+		} else {
+			t.Logf("nanobot _exec exited with %v\n%s", err, strings.TrimSpace(output.String()))
+		}
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for supervisor to exit after external cancel: %v", ctx.Err())
+	}
+
+	defer killIfAlive(t, pid)
+	time.Sleep(1 * time.Second)
+	if processExists(pid) {
+		psOut, _ := exec.Command("ps", "-o", "pid=,ppid=,pgid=,command=", "-p", strconv.Itoa(pid)).CombinedOutput()
+		t.Fatalf("grandchild process %d is still alive after external supervisor cancel\nprocess:\n%s", pid, strings.TrimSpace(string(psOut)))
+	}
+}
+
+type supervisorStartOptions struct {
+	withStdin           bool
+	supervisorOwnPGroup bool
+}
+
+func startExecSupervisor(t *testing.T, binPath, helperPath string, opts supervisorStartOptions) (*exec.Cmd, io.Closer, *strings.Builder) {
+	t.Helper()
+
+	cmd := exec.Command(binPath, "_exec", helperPath)
+	if opts.supervisorOwnPGroup {
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	}
+	var output strings.Builder
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	var stdin io.Closer
+	if opts.withStdin {
+		var err error
+		stdin, err = cmd.StdinPipe()
+		if err != nil {
+			t.Fatalf("failed to create stdin pipe: %v", err)
+		}
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start nanobot _exec: %v", err)
+	}
+	return cmd, stdin, &output
+}
+
+func waitForExit(t *testing.T, cmd *exec.Cmd, output *strings.Builder) {
+	t.Helper()
+
+	err := cmd.Wait()
+	if err == nil {
+		t.Logf("nanobot _exec output:\n%s", strings.TrimSpace(output.String()))
+	} else {
+		t.Logf("nanobot _exec exited with %v\n%s", err, strings.TrimSpace(output.String()))
+	}
+}
+
+func writeGrandchildHelper(t *testing.T) (helperPath, pidFile string) {
+	t.Helper()
+
+	workDir := t.TempDir()
+	pidFile = filepath.Join(workDir, "grandchild.pid")
+	helperPath = filepath.Join(workDir, "spawn-grandchild.sh")
+	writeExecutableFile(t, helperPath, fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+sleep 1000 </dev/null >/dev/null 2>&1 &
+grandchild=$!
+printf '%%s\n' "${grandchild}" > %q
+wait
+`, pidFile))
+	return helperPath, pidFile
+}
+
+func waitForPIDFile(t *testing.T, pidFile string) int {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		pidBytes, err := os.ReadFile(pidFile)
+		if err == nil && strings.TrimSpace(string(pidBytes)) != "" {
+			pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+			if err != nil {
+				t.Fatalf("failed to parse pid from %s: %v", pidFile, err)
+			}
+			return pid
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	pidBytes, err := os.ReadFile(pidFile)
+	if err != nil {
+		t.Fatalf("failed to read pid file %s: %v", pidFile, err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		t.Fatalf("failed to parse pid from %s: %v", pidFile, err)
+	}
+	return pid
+}
+
+func assertGrandchildExited(t *testing.T, pidFile string, reason string) {
+	t.Helper()
+
+	pid := waitForPIDFile(t, pidFile)
+	defer killIfAlive(t, pid)
+
+	time.Sleep(1 * time.Second)
+
+	if processExists(pid) {
+		psOut, _ := exec.Command("ps", "-o", "pid=,ppid=,pgid=,command=", "-p", strconv.Itoa(pid)).CombinedOutput()
+		t.Fatalf("grandchild process %d is still alive after %s\nprocess:\n%s", pid, reason, strings.TrimSpace(string(psOut)))
+	}
+}
+
+func superviseRepoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	return filepath.Clean(filepath.Join(wd, "..", ".."))
+}
+
+func buildNanobotBinary(t *testing.T, repoRoot string) string {
+	t.Helper()
+	binPath := filepath.Join(t.TempDir(), "nanobot-test-bin")
+	cmd := exec.Command("go", "build", "-o", binPath, ".")
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to build nanobot binary: %v\n%s", err, strings.TrimSpace(string(output)))
+	}
+	return binPath
+}
+
+func writeExecutableFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}
+
+func processExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil
+}
+
+func killIfAlive(t *testing.T, pid int) {
+	t.Helper()
+	if !processExists(pid) {
+		return
+	}
+	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		t.Logf("failed to kill leaked process %d: %v", pid, err)
+	}
+}


### PR DESCRIPTION
Refactor supervise daemon helpers
Added test cases.

Addresses obot-platform/obot#6404

Here is a simple shell script to reproduce the orphaned path with the existing code base.

```bash
#!/usr/bin/env bash
set -euo pipefail

ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
BIN="${ROOT_DIR}/bin/nanobot"
WORK_DIR="$(mktemp -d)"
HELPER="${WORK_DIR}/spawn-grandchild.sh"
PID_FILE="${WORK_DIR}/grandchild.pid"
LOG_FILE="${WORK_DIR}/supervisor.log"

cleanup() {
        if [[ -f "${PID_FILE}" ]]; then
                pid="$(cat "${PID_FILE}" 2>/dev/null || true)"
                if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
                        echo "Cleaning up leaked grandchild ${pid}" >&2
                        kill "${pid}" 2>/dev/null || true
                        wait "${pid}" 2>/dev/null || true
                fi
        fi
        rm -rf "${WORK_DIR}"
}
trap cleanup EXIT

if [[ ! -x "${BIN}" ]]; then
        echo "Missing ${BIN}. Build it first with: make" >&2
        exit 1
fi

cat > "${HELPER}" <<EOF
#!/usr/bin/env bash
set -euo pipefail
sleep 1000 &
grandchild=\$!
printf '%s\n' "\${grandchild}" > "${PID_FILE}"
wait
EOF
chmod +x "${HELPER}"

echo "Running narrow orphan-process reproduction via nanobot _exec"
echo "helper: ${HELPER}"
echo "pid file: ${PID_FILE}"
echo

echo "Starting supervisor; stdin will close after 1 second"
set +e
( sleep 1 ) | "${BIN}" _exec "${HELPER}" >"${LOG_FILE}" 2>&1
status=$?
set -e

echo "nanobot _exec exited with status: ${status}"

if [[ ! -s "${PID_FILE}" ]]; then
        echo "FAIL: helper never recorded a grandchild pid" >&2
        echo "supervisor log:" >&2
        sed -n '1,120p' "${LOG_FILE}" >&2
        exit 1
fi

pid="$(cat "${PID_FILE}")"
echo "Recorded grandchild pid: ${pid}"

sleep 1

if kill -0 "${pid}" 2>/dev/null; then
        echo
        echo "REPRODUCED: grandchild i still alive after nanobot _exec exited"
        ps -o pid=,ppid=,pgid=,command= -p "${pid}"
        exit 0
fi

echo
echo "NOT REPRODUCED: grandchild is no longer running"
echo "supervisor log:"
sed -n '1,120p' "${LOG_FILE}"
exit 2
```
