### PR TITLE
enhance: provide denial of hook mutation

### DIFF
--- a/pkg/agents/run.go
+++ b/pkg/agents/run.go
@@ -527,9 +527,9 @@ func (a *Agents) configHook(ctx context.Context, baseConfig types.Config, agentN
 
 	agent := baseConfig.Agents[agentName]
 	if !slices.ContainsFunc(agent.Hooks, func(hook mcp.HookMapping) bool {
-		return hook.Name == "config" && slices.Contains(hook.Targets, "nanobot.system/config")
+		return hook.Name == "config" && slices.Contains(hook.Targets, mcp.HookTarget{Target: "nanobot.system/config"})
 	}) {
-		agent.Hooks = append(agent.Hooks, mcp.HookMapping{Name: "config", Targets: []string{"nanobot.system/config"}})
+		agent.Hooks = append(agent.Hooks, mcp.HookMapping{Name: "config", Targets: []mcp.HookTarget{{Target: "nanobot.system/config"}}})
 	}
 	hookResult, err := mcp.InvokeHooks(ctx, a.registry, agent.Hooks, &types.AgentConfigHook{
 		Agent:     &agent.HookAgent,

--- a/pkg/mcp/hooks.go
+++ b/pkg/mcp/hooks.go
@@ -18,7 +18,7 @@ type HookRunner interface {
 type Hooks []HookMapping
 
 func (h *Hooks) UnmarshalJSON(data []byte) error {
-	var m map[string]stringList
+	var m map[string][]HookTarget
 	if err := json.Unmarshal(data, &m); err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func (h Hooks) MarshalJSON() ([]byte, error) {
 		return nil, nil
 	}
 
-	m := make(map[string][]string, len(h))
+	m := make(map[string][]HookTarget, len(h))
 	for _, mapping := range h {
 		m[mapping.String()] = mapping.Targets
 	}
@@ -54,30 +54,7 @@ func (h Hooks) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
-type stringList []string
-
-func (s *stringList) UnmarshalJSON(data []byte) error {
-	if data[0] == '[' && data[len(data)-1] == ']' {
-		var raw []string
-		if err := json.Unmarshal(data, &raw); err != nil {
-			return err
-		}
-		*s = raw
-	} else {
-		var raw string
-		if err := json.Unmarshal(data, &raw); err != nil {
-			return err
-		}
-		var list []string
-		for item := range strings.SplitSeq(raw, ",") {
-			list = append(list, strings.TrimSpace(item))
-		}
-		*s = list
-	}
-	return nil
-}
-
-type HookResponseCallback[T any] = func(hook HookMapping, resp T, err error) T
+type HookResponseCallback[T any] = func(hook HookMapping, target HookTarget, resp T, err error) T
 
 func InvokeHooks[T any](ctx context.Context, r HookRunner, hooks Hooks, in *T, name string, params map[string]string, callbacks ...HookResponseCallback[T]) (T, error) {
 	var (
@@ -90,10 +67,10 @@ func InvokeHooks[T any](ctx context.Context, r HookRunner, hooks Hooks, in *T, n
 		if mapping.Matches(name, params) {
 			for _, target := range mapping.Targets {
 				matched = true
-				hasOutput, err := r.RunHook(ctx, current, &out, target)
+				hasOutput, err := r.RunHook(ctx, current, &out, target.Target)
 				if hasOutput || err != nil {
 					for _, cb := range callbacks {
-						out = cb(mapping, out, err)
+						out = cb(mapping, target, out, err)
 					}
 				}
 				if err != nil {
@@ -115,7 +92,30 @@ func InvokeHooks[T any](ctx context.Context, r HookRunner, hooks Hooks, in *T, n
 type HookMapping struct {
 	Name    string
 	Params  map[string]string
-	Targets []string
+	Targets []HookTarget
+}
+
+type HookTarget struct {
+	Target           string
+	MutateDisallowed bool
+}
+
+func (h *HookTarget) UnmarshalJSON(data []byte) error {
+	var target string
+	if err := json.Unmarshal(data, &target); err != nil {
+		return err
+	}
+
+	h.Target, h.MutateDisallowed = strings.CutPrefix(target, "!mutate:")
+	return nil
+}
+
+func (h *HookTarget) MarshalJSON() ([]byte, error) {
+	target := h.Target
+	if h.MutateDisallowed {
+		target = "!mutate:" + target
+	}
+	return json.Marshal(target)
 }
 
 func parseHookDefinition(data string) (result HookMapping, _ error) {
@@ -127,12 +127,8 @@ func parseHookDefinition(data string) (result HookMapping, _ error) {
 		}
 		result.Params = make(map[string]string, len(query))
 		for k, v := range query {
-			if len(v) == 0 {
-				continue
-			} else if len(v) > 1 {
+			if len(v) > 0 {
 				result.Params[k] = strings.Join(v, ",")
-			} else {
-				result.Params[k] = v[0]
 			}
 		}
 	}

--- a/pkg/mcp/session.go
+++ b/pkg/mcp/session.go
@@ -675,16 +675,28 @@ func (s *Session) callAllHooks(ctx context.Context, req *Message, direction stri
 	hookResponse, _ := InvokeHooks(ctx, s.HookRunner, hooks, &SessionMessageHook{
 		Accept:  true,
 		Message: req,
-	}, req.Method, params, func(hook HookMapping, hookResponse SessionMessageHook, err error) SessionMessageHook {
+	}, req.Method, params, func(hook HookMapping, target HookTarget, hookResponse SessionMessageHook, err error) SessionMessageHook {
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to run hook %s: %w", hook.Name, err))
 			return hookResponse
+		}
+
+		if hookResponse.Mutated && target.MutateDisallowed {
+			if hookResponse.Reason != "" {
+				hookResponse.Reason += "; "
+			}
+
+			hookResponse.Reason += "mutation not allowed by hook configuration, implicit rejection"
+			hookResponse.Accept = false
+			hookResponse.Mutated = false
 		}
 
 		if auditLog != nil {
 			status := "ok"
 			if !hookResponse.Accept {
 				status = "rejected"
+			} else if hookResponse.Mutated {
+				status = "mutated"
 			}
 			auditLog.WebhookStatuses = append(auditLog.WebhookStatuses, auditlogs.MCPWebhookStatus{
 				Type:    direction,
@@ -700,9 +712,7 @@ func (s *Session) callAllHooks(ctx context.Context, req *Message, direction stri
 		}
 
 		// Use the hook response message if set, otherwise use the last value we have
-		if hookResponse.Message == nil {
-			hookResponse.Message = req
-		} else {
+		if hookResponse.Mutated {
 			req = hookResponse.Message
 			if string(req.Result) == "null" {
 				req.Result = nil
@@ -710,6 +720,8 @@ func (s *Session) callAllHooks(ctx context.Context, req *Message, direction stri
 			if string(req.Params) == "null" {
 				req.Params = nil
 			}
+		} else {
+			hookResponse.Message = req
 		}
 		return hookResponse
 	})

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -488,6 +488,7 @@ type SetLogLevelResult struct{}
 
 type SessionMessageHook struct {
 	Accept  bool     `json:"accept"`
+	Mutated bool     `json:"mutated"`
 	Message *Message `json:"message"`
 	Reason  string   `json:"reason"`
 }


### PR DESCRIPTION
This change makes it possible to forbid a hook from mutating the output. If a hook is not allowed to mutate the output, then it is treated as a rejection.