### PR TITLE
fix(httpclient): treat HTML responses as AuthRequiredErr in readResponse

### DIFF
--- a/pkg/mcp/httpclient.go
+++ b/pkg/mcp/httpclient.go
@@ -789,6 +789,17 @@ func (s *HTTPClient) readResponse(resp *http.Response) (bool, error) {
 		}
 	}
 
+	// If the server returned HTML (e.g. an OAuth login redirect that was followed),
+	// treat it as an authentication-required error so the OAuth flow can restart
+	// rather than surfacing a confusing JSON parse error.
+	if ct := resp.Header.Get("Content-Type"); strings.Contains(ct, "text/html") {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return false, AuthRequiredErr{
+			ProtectedResourceValue: resp.Header.Get("WWW-Authenticate"),
+			Err:                    fmt.Errorf("server returned HTML instead of JSON (status %d)", resp.StatusCode),
+		}
+	}
+
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return seen, fmt.Errorf("failed to read response body: %w", err)
@@ -799,6 +810,13 @@ func (s *HTTPClient) readResponse(resp *http.Response) (bool, error) {
 	}
 
 	if data[0] != '{' {
+		// If the body starts with '<' it is almost certainly HTML from an auth redirect.
+		if data[0] == '<' {
+			return false, AuthRequiredErr{
+				ProtectedResourceValue: resp.Header.Get("WWW-Authenticate"),
+				Err:                    fmt.Errorf("server returned HTML instead of JSON (status %d)", resp.StatusCode),
+			}
+		}
 		return false, fmt.Errorf("invalid response format, expected JSON object, got: %s", data)
 	}
 


### PR DESCRIPTION
## Problem

When an upstream MCP server's OAuth access token expires, the server may return an HTML login-redirect page (HTTP 200 after following a 3xx, or the redirect body itself) instead of a JSON response.

`readResponse` currently returns a generic `"invalid response format"` error for any non-`{` body. This error is **not** caught by either the `AuthRequiredErr` or `oauth2:` handlers in `Send()`, so instead of triggering the OAuth re-authentication flow, the error surfaces to the caller as:

```
failed to decode response: invalid character '<' looking for beginning of value
```

### Root cause

`Send()` has two recovery paths for auth failures:
1. `errors.AsType[AuthRequiredErr](err)` — deletes the stored token and re-runs the OAuth flow  
2. `strings.HasPrefix(err, "oauth2:")` — resets to `http.DefaultClient` and retries (which triggers path 1)

Neither matches the plain `"invalid response format"` string returned by `readResponse` for HTML bodies, so both paths are skipped and the error propagates as-is.

## Fix

Before reading the body:
- Check `Content-Type: text/html` → return `AuthRequiredErr` immediately (discarding the body)

After `ReadAll`:
- If the first byte is `<`, the body is almost certainly HTML from an auth redirect → return `AuthRequiredErr`

This makes `Send()` correctly trigger the OAuth re-authentication flow when a stored upstream token expires.

## Reproduction

Observed with **Amplitude MCP** (`https://mcp.amplitude.com/mcp`) used as a remote server behind the Obot gateway. After the initial OAuth connection, the stored Amplitude access token expires. On the next MCP request, Amplitude responds with an HTML redirect to its login page. With this fix, `readResponse` returns `AuthRequiredErr`, `Send()` deletes the stale token and re-runs the OAuth flow transparently.

## Testing

- `go build ./pkg/mcp/...` passes
- Manually verified the error path by inspecting the Obot gateway logs showing `"failed to decode response: invalid character '<' looking for beginning of value"` disappears after applying the fix

Made with [Cursor](https://cursor.com)