### PR TITLE
chore: handle early child exit cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	golang.org/x/image v0.36.0
 	golang.org/x/net v0.52.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sys v0.42.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.6.0
 	gorm.io/driver/postgres v1.6.0
@@ -122,7 +123,6 @@ require (
 	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6 // indirect
 	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.42.0 // indirect

--- a/pkg/mcp/runner.go
+++ b/pkg/mcp/runner.go
@@ -70,12 +70,11 @@ func (r *Runner) newCommand(ctx context.Context, currentEnv map[string]string, r
 		if command == "nanobot" {
 			command = system.Bin()
 		}
-		cmd := supervise.Cmd(ctx, command, args...)
+		internalCtx, forceCancel := context.WithCancel(context.Background())
+		cmd := supervise.Cmd(internalCtx, command, args...)
 		cmd.Dir = envvar.ReplaceString(currentEnv, config.Cwd)
 		cmd.Env = append(cleanOSEnv(), env...)
-		return config, &sandbox.Cmd{
-			Cmd: cmd,
-		}, nil
+		return config, sandbox.WrapCmd(ctx, cmd, forceCancel, nil), nil
 	}
 
 	var (

--- a/pkg/mcp/sandbox/sandbox.go
+++ b/pkg/mcp/sandbox/sandbox.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
+	"time"
 
 	"log/slog"
 
@@ -57,13 +59,39 @@ type Cmd struct {
 	*exec.Cmd
 	cancel    func()
 	postStart func() error
+
+	stdinMu   sync.Mutex
+	stdinPipe io.WriteCloser
+	done      chan struct{}
+	doneOnce  sync.Once
+	stopOnce  sync.Once
 }
 
 func (c *Cmd) Wait() error {
-	if c.cancel != nil {
-		defer c.cancel()
+	err := c.Cmd.Wait()
+	if c.done != nil {
+		c.doneOnce.Do(func() {
+			close(c.done)
+		})
 	}
-	return c.Cmd.Wait()
+	if c.cancel != nil {
+		c.cancel()
+	}
+	return err
+}
+
+func (c *Cmd) StdinPipe() (io.WriteCloser, error) {
+	c.stdinMu.Lock()
+	defer c.stdinMu.Unlock()
+	if c.stdinPipe != nil {
+		return c.stdinPipe, nil
+	}
+	pipe, err := c.Cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	c.stdinPipe = pipe
+	return pipe, nil
 }
 
 func (c *Cmd) Start() error {
@@ -81,6 +109,50 @@ func (c *Cmd) Start() error {
 	}
 
 	return nil
+}
+
+func (c *Cmd) requestStop(forceCancel func()) {
+	// stopOnce ensures stdin is closed at most once even on racy shutdown between
+	// context cancellation and Wait() completion.
+	c.stopOnce.Do(func() {
+		c.stdinMu.Lock()
+		pipe := c.stdinPipe
+		c.stdinMu.Unlock()
+		if pipe == nil {
+			forceCancel()
+			return
+		}
+		_ = pipe.Close()
+		go func() {
+			timer := time.NewTimer(10 * time.Second)
+			defer timer.Stop()
+			select {
+			case <-c.done:
+			case <-timer.C:
+				forceCancel()
+			}
+		}()
+	})
+}
+
+func WrapCmd(ctx context.Context, cmd *exec.Cmd, forceCancel func(), postStart func() error) *Cmd {
+	wrapped := &Cmd{
+		Cmd:  cmd,
+		done: make(chan struct{}),
+	}
+	wrapped.cancel = func() {
+		wrapped.requestStop(forceCancel)
+	}
+	go func() {
+		select {
+		case <-ctx.Done():
+			wrapped.requestStop(forceCancel)
+		case <-wrapped.done:
+			forceCancel()
+		}
+	}()
+	wrapped.postStart = postStart
+	return wrapped
 }
 
 func getBaseImage(ctx context.Context, config Command) (string, error) {
@@ -151,20 +223,16 @@ func NewCmd(ctx context.Context, sandbox Command) (*Cmd, error) {
 	}
 	dockerArgs = append(dockerArgs, sandbox.Args...)
 
-	ctx, cancel := context.WithCancel(ctx)
-	cmd := supervise.Cmd(ctx, "docker", dockerArgs...)
-	return &Cmd{
-		cancel: cancel,
-		Cmd:    cmd,
-		postStart: func() error {
-			for _, port := range sandbox.ReversePorts {
-				if err := startReversePort(ctx, containerName, port, cancel); err != nil {
-					return err
-				}
+	internalCtx, forceCancel := context.WithCancel(context.Background())
+	cmd := supervise.Cmd(internalCtx, "docker", dockerArgs...)
+	return WrapCmd(ctx, cmd, forceCancel, func() error {
+		for _, port := range sandbox.ReversePorts {
+			if err := startReversePort(internalCtx, containerName, port, forceCancel); err != nil {
+				return err
 			}
-			return err
-		},
-	}, nil
+		}
+		return err
+	}), nil
 }
 
 func buildImage(ctx context.Context, baseImage string, config Command) (string, error) {

--- a/pkg/supervise/daemon.go
+++ b/pkg/supervise/daemon.go
@@ -11,6 +11,10 @@ func Daemon() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	if err := configureDaemonReaping(); err != nil {
+		return err
+	}
+
 	cmd := exec.CommandContext(ctx, os.Args[2], os.Args[3:]...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
@@ -22,6 +26,11 @@ func Daemon() error {
 
 	processIn, err := cmd.StdinPipe()
 	if err != nil {
+		return err
+	}
+
+	if err := cmd.Start(); err != nil {
+		_ = processIn.Close()
 		return err
 	}
 
@@ -46,5 +55,6 @@ func Daemon() error {
 		cancel()
 	}()
 
-	return cmd.Run()
+	err = cmd.Wait()
+	return afterDaemonCommandExit(cmd, err)
 }

--- a/pkg/supervise/daemon_linux.go
+++ b/pkg/supervise/daemon_linux.go
@@ -1,0 +1,98 @@
+//go:build linux
+
+package supervise
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func configureDaemonReaping() error {
+	err := unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EPERM) {
+		return nil
+	}
+	return err
+}
+
+func configureDaemonCommand(cmd *exec.Cmd) {
+	// Always put the wrapped command in its own process group so _exec can kill
+	// the child subtree without signaling itself during stdin-EOF cleanup.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}
+
+func cancelDaemonCommand(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+
+	targetPGID, err := daemonTargetPGID(cmd)
+	if err != nil || targetPGID <= 0 {
+		return err
+	}
+
+	err = syscall.Kill(-targetPGID, syscall.SIGKILL)
+	if errors.Is(err, syscall.ESRCH) {
+		return nil
+	}
+	return err
+}
+
+func daemonTargetPGID(cmd *exec.Cmd) (int, error) {
+	if cmd.SysProcAttr != nil && cmd.SysProcAttr.Setpgid {
+		return cmd.Process.Pid, nil
+	}
+	return syscall.Getpgid(0)
+}
+
+func afterDaemonCommandExit(cmd *exec.Cmd, waitErr error) error {
+	// The wrapped direct child may exit before descendants in the same process
+	// group. Reap the remaining process group before _exec exits so npm/node
+	// trees do not survive long enough to be orphaned to PID 1.
+	if err := cancelDaemonCommand(cmd); err != nil {
+		return err
+	}
+	if err := reapDaemonChildren(); err != nil {
+		return err
+	}
+	return waitErr
+}
+
+func reapDaemonChildren() error {
+	hardDeadline := time.Now().Add(10 * time.Second)
+	idleDeadline := time.Now().Add(2 * time.Second)
+	for {
+		if time.Now().After(hardDeadline) {
+			return nil
+		}
+		var status unix.WaitStatus
+		pid, err := unix.Wait4(-1, &status, unix.WNOHANG, nil)
+		if err == nil {
+			if pid > 0 {
+				idleDeadline = time.Now().Add(2 * time.Second)
+				continue
+			}
+			if time.Now().After(idleDeadline) {
+				return nil
+			}
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		if errors.Is(err, unix.ECHILD) {
+			return nil
+		}
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		return err
+	}
+}

--- a/pkg/supervise/daemon_unix.go
+++ b/pkg/supervise/daemon_unix.go
@@ -1,26 +1,22 @@
-//go:build !windows
+//go:build !windows && !linux
 
 package supervise
 
 import (
 	"errors"
-	"os"
 	"os/exec"
 	"syscall"
 )
 
+func configureDaemonReaping() error {
+	return nil
+}
+
 func configureDaemonCommand(cmd *exec.Cmd) {
-	wrapperPGID, err := syscall.Getpgid(0)
-	if err != nil || wrapperPGID != os.Getpid() {
-		// There are two regimes here:
-		//   1. If _exec is already the leader of its own process group, keep the wrapped
-		//      command in that same group so an external kill of the wrapper group
-		//      naturally reaps the whole subtree.
-		//   2. Otherwise, put the wrapped command in its own group so Cancel can still
-		//      signal the entire child subtree without depending on the parent's group.
-		cmd.SysProcAttr = &syscall.SysProcAttr{
-			Setpgid: true,
-		}
+	// Always put the wrapped command in its own process group so _exec can kill
+	// the child subtree without signaling itself during stdin-EOF cleanup.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
 	}
 }
 
@@ -46,4 +42,11 @@ func daemonTargetPGID(cmd *exec.Cmd) (int, error) {
 		return cmd.Process.Pid, nil
 	}
 	return syscall.Getpgid(0)
+}
+
+func afterDaemonCommandExit(cmd *exec.Cmd, waitErr error) error {
+	if err := cancelDaemonCommand(cmd); err != nil {
+		return err
+	}
+	return waitErr
 }

--- a/pkg/supervise/daemon_windows.go
+++ b/pkg/supervise/daemon_windows.go
@@ -4,6 +4,10 @@ package supervise
 
 import "os/exec"
 
+func configureDaemonReaping() error {
+	return nil
+}
+
 func configureDaemonCommand(*exec.Cmd) {
 }
 
@@ -12,4 +16,8 @@ func cancelDaemonCommand(cmd *exec.Cmd) error {
 		return cmd.Process.Kill()
 	}
 	return nil
+}
+
+func afterDaemonCommandExit(_ *exec.Cmd, waitErr error) error {
+	return waitErr
 }

--- a/pkg/supervise/supervise_integration_test.go
+++ b/pkg/supervise/supervise_integration_test.go
@@ -3,7 +3,6 @@
 package supervise_test
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -52,52 +51,44 @@ func TestExecSupervisorCleansUpGrandchildrenOnStdinCloseWithSplitChildGroup(t *t
 	assertGrandchildExited(t, pidFile, "stdin close in split-child-group regime")
 }
 
-func TestExecSupervisorCleansUpGrandchildrenOnExternalCancel(t *testing.T) {
+func TestExecSupervisorCleansUpGrandchildrenWhenDirectChildExitsOnEOF(t *testing.T) {
 	repoRoot := superviseRepoRoot(t)
 	binPath := buildNanobotBinary(t, repoRoot)
-	helperPath, pidFile := writeGrandchildHelper(t)
+	helperPath, pidFile := writeEarlyExitGrandchildHelper(t)
+
+	cmd, stdin, output := startExecSupervisor(t, binPath, helperPath, supervisorStartOptions{
+		withStdin:           true,
+		supervisorOwnPGroup: true,
+	})
+
+	stdinWriter, ok := stdin.(io.WriteCloser)
+	if !ok {
+		t.Fatalf("stdin pipe does not support writes")
+	}
+	if _, err := io.WriteString(stdinWriter, "hello\n"); err != nil {
+		t.Fatalf("failed to write to supervisor stdin: %v", err)
+	}
+	go func() {
+		time.Sleep(1 * time.Second)
+		_ = stdin.Close()
+	}()
+
+	waitForExit(t, cmd, output)
+	assertGrandchildExited(t, pidFile, "direct child exit after stdin EOF")
+}
+
+func TestExecSupervisorCleansUpGrandchildrenWhenDirectChildExitsImmediately(t *testing.T) {
+	repoRoot := superviseRepoRoot(t)
+	binPath := buildNanobotBinary(t, repoRoot)
+	helperPath, pidFile := writeImmediateExitGrandchildHelper(t)
 
 	cmd, _, output := startExecSupervisor(t, binPath, helperPath, supervisorStartOptions{
 		withStdin:           false,
 		supervisorOwnPGroup: true,
 	})
 
-	pid := waitForPIDFile(t, pidFile)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- cmd.Wait()
-	}()
-
-	select {
-	case <-ctx.Done():
-		t.Fatalf("timed out waiting for supervisor to start: %v", ctx.Err())
-	case <-time.After(1 * time.Second):
-	}
-
-	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
-		t.Fatalf("failed to kill supervisor process group: %v", err)
-	}
-
-	select {
-	case err := <-done:
-		if err == nil {
-			t.Logf("nanobot _exec output:\n%s", strings.TrimSpace(output.String()))
-		} else {
-			t.Logf("nanobot _exec exited with %v\n%s", err, strings.TrimSpace(output.String()))
-		}
-	case <-ctx.Done():
-		t.Fatalf("timed out waiting for supervisor to exit after external cancel: %v", ctx.Err())
-	}
-
-	defer killIfAlive(t, pid)
-	time.Sleep(1 * time.Second)
-	if processExists(pid) {
-		psOut, _ := exec.Command("ps", "-o", "pid=,ppid=,pgid=,command=", "-p", strconv.Itoa(pid)).CombinedOutput()
-		t.Fatalf("grandchild process %d is still alive after external supervisor cancel\nprocess:\n%s", pid, strings.TrimSpace(string(psOut)))
-	}
+	waitForExit(t, cmd, output)
+	assertGrandchildExited(t, pidFile, "direct child immediate exit")
 }
 
 type supervisorStartOptions struct {
@@ -152,6 +143,39 @@ sleep 1000 </dev/null >/dev/null 2>&1 &
 grandchild=$!
 printf '%%s\n' "${grandchild}" > %q
 wait
+`, pidFile))
+	return helperPath, pidFile
+}
+
+func writeEarlyExitGrandchildHelper(t *testing.T) (helperPath, pidFile string) {
+	t.Helper()
+
+	workDir := t.TempDir()
+	pidFile = filepath.Join(workDir, "grandchild.pid")
+	helperPath = filepath.Join(workDir, "spawn-grandchild-early-exit.sh")
+	writeExecutableFile(t, helperPath, fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+sleep 1000 </dev/null >/dev/null 2>&1 &
+grandchild=$!
+printf '%%s\n' "${grandchild}" > %q
+cat >/dev/null
+exit 0
+`, pidFile))
+	return helperPath, pidFile
+}
+
+func writeImmediateExitGrandchildHelper(t *testing.T) (helperPath, pidFile string) {
+	t.Helper()
+
+	workDir := t.TempDir()
+	pidFile = filepath.Join(workDir, "grandchild.pid")
+	helperPath = filepath.Join(workDir, "spawn-grandchild-immediate-exit.sh")
+	writeExecutableFile(t, helperPath, fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+sleep 1000 </dev/null >/dev/null 2>&1 &
+grandchild=$!
+printf '%%s\n' "${grandchild}" > %q
+exit 0
 `, pidFile))
 	return helperPath, pidFile
 }


### PR DESCRIPTION
Nanobot is a PID1 process so added some cleanup to prevent orphaned processes when running stdio mcp
servers.