### PR TITLE
enhance: show mutated request and original response in audit logs

### DIFF
--- a/pkg/fswatch/subscriptions.go
+++ b/pkg/fswatch/subscriptions.go
@@ -107,7 +107,7 @@ func (sm *SubscriptionManager) SendResourceUpdatedNotification(uri string) {
 	}
 	sm.mu.RUnlock()
 
-	notification := mcp.Message{
+	notification := &mcp.Message{
 		JSONRPC: "2.0",
 		Method:  "notifications/resources/updated",
 	}
@@ -134,7 +134,7 @@ func (sm *SubscriptionManager) SendResourceUpdatedNotification(uri string) {
 
 // SendListChangedNotification sends a notifications/resources/list_changed message to all sessions.
 func (sm *SubscriptionManager) SendListChangedNotification() {
-	notification := mcp.Message{
+	notification := &mcp.Message{
 		JSONRPC: "2.0",
 		Method:  "notifications/resources/list_changed",
 	}

--- a/pkg/mcp/auditlogs/auditlog.go
+++ b/pkg/mcp/auditlogs/auditlog.go
@@ -10,22 +10,24 @@ import (
 type MCPAuditLog struct {
 	// Metadata is additional information about this server that a user can provide for audit log tracking purposes.
 	// For example Obot uses this to track catalog information.
-	Metadata         map[string]string  `json:"metadata,omitempty"`
-	CreatedAt        time.Time          `json:"createdAt"`
-	Subject          string             `json:"subject"`
-	APIKey           string             `json:"apiKey,omitempty"`
-	ClientName       string             `json:"clientName"`
-	ClientVersion    string             `json:"clientVersion"`
-	ClientIP         string             `json:"clientIP"`
-	CallType         string             `json:"callType"`
-	CallIdentifier   string             `json:"callIdentifier,omitempty"`
-	RequestBody      json.RawMessage    `json:"requestBody,omitempty"`
-	ResponseBody     json.RawMessage    `json:"responseBody,omitempty"`
-	ResponseStatus   int                `json:"responseStatus"`
-	Error            string             `json:"error,omitempty"`
-	ProcessingTimeMs int64              `json:"processingTimeMs"`
-	SessionID        string             `json:"sessionID,omitempty"`
-	WebhookStatuses  []MCPWebhookStatus `json:"webhookStatuses,omitempty"`
+	Metadata             map[string]string  `json:"metadata,omitempty"`
+	CreatedAt            time.Time          `json:"createdAt"`
+	Subject              string             `json:"subject"`
+	APIKey               string             `json:"apiKey,omitempty"`
+	ClientName           string             `json:"clientName"`
+	ClientVersion        string             `json:"clientVersion"`
+	ClientIP             string             `json:"clientIP"`
+	CallType             string             `json:"callType"`
+	CallIdentifier       string             `json:"callIdentifier,omitempty"`
+	RequestBody          json.RawMessage    `json:"requestBody,omitempty"`
+	MutatedRequestBody   json.RawMessage    `json:"mutatedRequestBody,omitempty"`
+	ResponseBody         json.RawMessage    `json:"responseBody,omitempty"`
+	OriginalResponseBody json.RawMessage    `json:"originalResponseBody,omitempty"`
+	ResponseStatus       int                `json:"responseStatus"`
+	Error                string             `json:"error,omitempty"`
+	ProcessingTimeMs     int64              `json:"processingTimeMs"`
+	SessionID            string             `json:"sessionID,omitempty"`
+	WebhookStatuses      []MCPWebhookStatus `json:"webhookStatuses,omitempty"`
 
 	// Additional metadata
 	RequestID       string          `json:"requestID,omitempty"`

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -427,7 +427,7 @@ func (c *Client) Initialize(ctx context.Context, param InitializeRequest) (resul
 
 	err = c.Session.Exchange(ctx, "initialize", param, &result)
 	if err == nil {
-		err = c.Session.Send(ctx, Message{
+		err = c.Session.Send(ctx, &Message{
 			Method: "notifications/initialized",
 		})
 	}

--- a/pkg/mcp/message.go
+++ b/pkg/mcp/message.go
@@ -135,7 +135,7 @@ func (r *Message) SendError(ctx context.Context, err error) {
 		data = ErrRPCInternal.WithError(err)
 	}
 
-	resp := Message{
+	resp := &Message{
 		JSONRPC: r.JSONRPC,
 		ID:      r.ID,
 		Error:   data,
@@ -151,7 +151,7 @@ func (r *Message) Reply(ctx context.Context, result any) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal result: %w", err)
 	}
-	return r.Session.Send(ctx, Message{
+	return r.Session.Send(ctx, &Message{
 		JSONRPC: r.JSONRPC,
 		ID:      r.ID,
 		Result:  data,

--- a/pkg/mcp/session.go
+++ b/pkg/mcp/session.go
@@ -517,15 +517,18 @@ func (s *Session) SendPayload(ctx context.Context, method string, payload any) e
 	if err != nil {
 		return fmt.Errorf("failed to marshal payload: %w", err)
 	}
-	return s.Send(ctx, Message{
+	return s.Send(ctx, &Message{
 		Method: method,
 		Params: data,
 	})
 }
 
-func (s *Session) Send(ctx context.Context, req Message) error {
+func (s *Session) Send(ctx context.Context, req *Message) error {
 	if s.wire == nil {
 		return fmt.Errorf("empty session: wire is not initialized")
+	}
+	if req == nil {
+		return fmt.Errorf("request is nil")
 	}
 
 	s.lock.Lock()
@@ -533,21 +536,21 @@ func (s *Session) Send(ctx context.Context, req Message) error {
 	s.lock.Unlock()
 
 	for _, filter := range f {
-		newReq, err := filter.filter(ctx, &req)
+		newReq, err := filter.filter(ctx, req)
 		if err != nil || newReq == nil {
 			return err
 		}
-		req = *newReq
+		*req = *newReq
 	}
 
-	newReq, err := s.callAllHooks(ctx, &req, "request")
+	newReq, err := s.callAllHooks(ctx, req, "request")
 	if err != nil {
 		return fmt.Errorf("failed to call \"request\" hooks: %w", err)
 	}
 
-	req = *newReq
+	*req = *newReq
 	req.JSONRPC = "2.0"
-	if err := s.wire.Send(ctx, req); err != nil {
+	if err := s.wire.Send(ctx, *req); err != nil {
 		return err
 	}
 	return nil
@@ -712,14 +715,28 @@ func (s *Session) callAllHooks(ctx context.Context, req *Message, direction stri
 		}
 
 		// Use the hook response message if set, otherwise use the last value we have
-		if hookResponse.Mutated {
-			req = hookResponse.Message
-			if string(req.Result) == "null" {
-				req.Result = nil
+		if hookResponse.Mutated && hookResponse.Message != nil {
+			if string(hookResponse.Message.Result) == "null" {
+				hookResponse.Message.Result = nil
 			}
-			if string(req.Params) == "null" {
-				req.Params = nil
+			if string(hookResponse.Message.Params) == "null" {
+				hookResponse.Message.Params = nil
 			}
+
+			if auditLog != nil {
+				switch direction {
+				case "request":
+					mutatedMessage, _ := json.Marshal(hookResponse.Message)
+					auditLog.MutatedRequestBody = mutatedMessage
+				case "response":
+					if auditLog.OriginalResponseBody == nil {
+						originalMessage, _ := json.Marshal(req)
+						auditLog.OriginalResponseBody = originalMessage
+					}
+				}
+			}
+
+			*req = *hookResponse.Message
 		} else {
 			hookResponse.Message = req
 		}
@@ -772,7 +789,7 @@ func (s *Session) Exchange(ctx context.Context, method string, in, out any, opts
 	go func() {
 		defer close(errChan)
 
-		if err := s.Send(ctx, *req); err != nil {
+		if err := s.Send(ctx, req); err != nil {
 			errChan <- fmt.Errorf("failed to send request: %w", err)
 		}
 	}()

--- a/pkg/mcp/session_test.go
+++ b/pkg/mcp/session_test.go
@@ -1,0 +1,113 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/nanobot-ai/nanobot/pkg/mcp/auditlogs"
+)
+
+type staticHookRunner struct {
+	response SessionMessageHook
+}
+
+func (r staticHookRunner) RunHook(_ context.Context, _, out any, _ string) (bool, error) {
+	*(out.(*SessionMessageHook)) = r.response
+	return true, nil
+}
+
+func TestCallAllHooksRecordsMutatedToolRequestBody(t *testing.T) {
+	mutated := &Message{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"test","arguments":{"value":"mutated"}}`),
+	}
+	auditLog := &auditlogs.MCPAuditLog{}
+	s := &Session{
+		HookRunner: staticHookRunner{response: SessionMessageHook{
+			Accept:  true,
+			Mutated: true,
+			Message: mutated,
+		}},
+		hooks: Hooks{{Name: "tools/call", Targets: []HookTarget{{Target: "test-hook"}}}},
+	}
+
+	_, err := s.callAllHooks(WithAuditLog(context.Background(), auditLog), &Message{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"test","arguments":{"value":"original"}}`),
+	}, "request")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertJSONEqual(t, auditLog.MutatedRequestBody, mutated)
+	if len(auditLog.OriginalResponseBody) != 0 {
+		t.Fatalf("original response body was recorded for request mutation: %s", auditLog.OriginalResponseBody)
+	}
+}
+
+func TestCallAllHooksRecordsOriginalToolResponseBody(t *testing.T) {
+	mutated := &Message{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "tools/call",
+		Result:  json.RawMessage(`{"content":[{"type":"text","text":"mutated"}]}`),
+	}
+	original := &Message{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "tools/call",
+		Result:  json.RawMessage(`{"content":[{"type":"text","text":"original"}]}`),
+	}
+	originalBytes, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	auditLog := &auditlogs.MCPAuditLog{}
+	s := &Session{
+		HookRunner: staticHookRunner{response: SessionMessageHook{
+			Accept:  true,
+			Mutated: true,
+			Message: mutated,
+		}},
+		hooks: Hooks{{Name: "tools/call", Targets: []HookTarget{{Target: "test-hook"}}}},
+	}
+
+	_, err = s.callAllHooks(WithAuditLog(context.Background(), auditLog), original, "response")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertJSONEqual(t, auditLog.OriginalResponseBody, json.RawMessage(originalBytes))
+	if len(auditLog.MutatedRequestBody) != 0 {
+		t.Fatalf("mutated request body was recorded for response mutation: %s", auditLog.MutatedRequestBody)
+	}
+}
+
+func assertJSONEqual(t *testing.T, actual json.RawMessage, expected any) {
+	t.Helper()
+
+	expectedBytes, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var actualValue any
+	if err := json.Unmarshal(actual, &actualValue); err != nil {
+		t.Fatalf("failed to unmarshal actual JSON: %v", err)
+	}
+	var expectedValue any
+	if err := json.Unmarshal(expectedBytes, &expectedValue); err != nil {
+		t.Fatalf("failed to unmarshal expected JSON: %v", err)
+	}
+
+	actualBytes, _ := json.Marshal(actualValue)
+	expectedBytes, _ = json.Marshal(expectedValue)
+	if string(actualBytes) != string(expectedBytes) {
+		t.Fatalf("JSON mismatch\nactual:   %s\nexpected: %s", actualBytes, expectedBytes)
+	}
+}

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -413,7 +413,7 @@ func (s *Service) newClient(ctx context.Context, name string, state *mcp.Session
 				s.collectAuditLog(auditLog)
 			}()
 
-			return session.Send(mcp.WithMCPServerConfig(mcp.WithAuditLog(ctx, auditLog), mcpConfig), msg)
+			return session.Send(mcp.WithMCPServerConfig(mcp.WithAuditLog(ctx, auditLog), mcpConfig), &msg)
 		},
 		OnLogging: func(ctx context.Context, logMsg mcp.LoggingMessage) (err error) {
 			data, err := json.Marshal(mcp.LoggingMessage{
@@ -448,7 +448,7 @@ func (s *Service) newClient(ctx context.Context, name string, state *mcp.Session
 				s.collectAuditLog(auditLog)
 			}()
 
-			return session.Send(mcp.WithMCPServerConfig(mcp.WithAuditLog(ctx, auditLog), mcpConfig), msg)
+			return session.Send(mcp.WithMCPServerConfig(mcp.WithAuditLog(ctx, auditLog), mcpConfig), &msg)
 		},
 		Runner: &s.runner,
 		HTTPClientOptions: mcp.HTTPClientOptions{


### PR DESCRIPTION
Before this change, the audit logs would show the original request body and the mutated response body. Both the mutated request and the original response body would not be shown so it would be difficult to see what changed and why.

After this change, all such request and response bodies will be saved to the audit logs if they exist.

One other thing that was fixed here during the investigation: if the request was mutated, then that mutated request would be sent to the MCP server. However, the original request would be used when we send the result to the filter for response processing. This change will use the mutated request for this.

Part of https://github.com/obot-platform/obot/issues/6426