### PR TITLE
fix: separate real audit log from secondary requests

### DIFF
--- a/pkg/mcp/session.go
+++ b/pkg/mcp/session.go
@@ -729,12 +729,10 @@ func (s *Session) callAllHooks(ctx context.Context, req *Message, direction stri
 			if auditLog != nil {
 				switch direction {
 				case "request":
-					mutatedMessage, _ := json.Marshal(hookResponse.Message)
-					auditLog.MutatedRequestBody = mutatedMessage
+					auditLog.MutatedRequestBody, _ = json.Marshal(hookResponse.Message)
 				case "response":
 					if auditLog.OriginalResponseBody == nil {
-						originalMessage, _ := json.Marshal(req)
-						auditLog.OriginalResponseBody = originalMessage
+						auditLog.OriginalResponseBody, _ = json.Marshal(req)
 					}
 				}
 			}

--- a/pkg/sessiondata/sessiondata.go
+++ b/pkg/sessiondata/sessiondata.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"maps"
 	"net/http"
 	"slices"
@@ -13,9 +14,9 @@ import (
 
 	"github.com/nanobot-ai/nanobot/pkg/complete"
 	"github.com/nanobot-ai/nanobot/pkg/mcp"
+	"github.com/nanobot-ai/nanobot/pkg/mcp/auditlogs"
 	"github.com/nanobot-ai/nanobot/pkg/schema"
 	"github.com/nanobot-ai/nanobot/pkg/types"
-	"log/slog"
 )
 
 const (
@@ -723,7 +724,9 @@ func (d *Data) BuildResourceMappings(ctx context.Context, refs []string) (types.
 			slog.Error("failed to get client while building resource mappings, skipping", "server", toolRef.Server, "error", err)
 			continue
 		}
-		resources, err := c.ListResources(ctx)
+
+		// Separate the audit log from the context so that the audit log only reflects the operations for this specific call.
+		resources, err := c.ListResources(mcp.WithAuditLog(ctx, new(auditlogs.MCPAuditLog)))
 		if err != nil {
 			slog.Error("failed to get resources while building resource mappings, skipping", "server", toolRef.Server, "error", err)
 			continue
@@ -754,7 +757,9 @@ func (d *Data) BuildResourceTemplateMappings(ctx context.Context, refs []string)
 			slog.Error("failed to get client while building resource template mappings, skipping", "server", toolRef.Server, "error", err)
 			continue
 		}
-		resources, err := c.ListResourceTemplates(ctx)
+
+		// Separate the audit log from the context so that the audit log only reflects the operations for this specific call.
+		resources, err := c.ListResourceTemplates(mcp.WithAuditLog(ctx, new(auditlogs.MCPAuditLog)))
 		if err != nil {
 			slog.Error("failed to get resource templates while building resource template mappings, skipping", "server", toolRef.Server, "error", err)
 		}

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -958,7 +958,8 @@ func (s *Service) listToolsForReferences(ctx context.Context, toolList []string)
 }
 
 func (s *Service) BuildToolMappings(ctx context.Context, toolList []string, opts ...types.BuildToolMappingsOptions) (types.ToolMappings, error) {
-	tools, err := s.listToolsForReferences(ctx, toolList)
+	// Separate the audit log from the context so that the audit log only reflects the operations for this specific call.
+	tools, err := s.listToolsForReferences(mcp.WithAuditLog(ctx, new(auditlogs.MCPAuditLog)), toolList)
 	if err != nil {
 		return nil, err
 	}
@@ -978,10 +979,6 @@ func hasOnlySampleKeys(args map[string]any) bool {
 		}
 	}
 	return true
-}
-
-func fileAttachmentPath(uri string) (string, error) {
-	return fileuri.Decode(uri)
 }
 
 func attachmentPreview(attachment types.Attachment, decodedPath string) mcp.Content {


### PR DESCRIPTION
If a new session is created and an immediate tool cal is made, then nanobot will list tools to ensure that the tool call can be made. Before this change, those requests would interfere with the audit log for the real request.

This change separates the audit logs to ensure no interference and the real audit log is persisted.

Issue: https://github.com/obot-platform/obot/issues/6454