### PR TITLE
feat: add passthrough headers

### DIFF
--- a/pkg/config/schema.yaml
+++ b/pkg/config/schema.yaml
@@ -349,6 +349,14 @@ definitions:
           A map of headers that will be sent with requests to the MCP Server.
           This is useful for authentication or other custom headers that the
           MCP Server requires.
+      passthroughHeaders:
+        type: array
+        items:
+          type: string
+        description: |
+          A list of incoming HTTP request headers that will be forwarded to the
+          MCP Server. Static headers configured in `headers` take precedence
+          when the same header is configured in both places.
       env:
         $ref: "#/definitions/StringMap"
         description: |

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -135,19 +135,20 @@ type Server struct {
 	ShortName   string `json:"shortName,omitempty"`
 	Description string `json:"description,omitempty"`
 
-	Image        string            `json:"image,omitempty"`
-	Dockerfile   string            `json:"dockerfile,omitempty"`
-	Source       ServerSource      `json:"source,omitzero"`
-	Sandboxed    bool              `json:"sandboxed,omitempty"`
-	Env          map[string]string `json:"env,omitempty"`
-	Command      string            `json:"command,omitempty"`
-	Args         []string          `json:"args,omitempty"`
-	BaseURL      string            `json:"url,omitempty"`
-	Ports        []string          `json:"ports,omitempty"`
-	ReversePorts []int             `json:"reversePorts,omitempty"`
-	Cwd          string            `json:"cwd,omitempty"`
-	Workdir      string            `json:"workdir,omitempty"`
-	Headers      map[string]string `json:"headers,omitempty"`
+	Image              string            `json:"image,omitempty"`
+	Dockerfile         string            `json:"dockerfile,omitempty"`
+	Source             ServerSource      `json:"source,omitzero"`
+	Sandboxed          bool              `json:"sandboxed,omitempty"`
+	Env                map[string]string `json:"env,omitempty"`
+	Command            string            `json:"command,omitempty"`
+	Args               []string          `json:"args,omitempty"`
+	BaseURL            string            `json:"url,omitempty"`
+	Ports              []string          `json:"ports,omitempty"`
+	ReversePorts       []int             `json:"reversePorts,omitempty"`
+	Cwd                string            `json:"cwd,omitempty"`
+	Workdir            string            `json:"workdir,omitempty"`
+	Headers            map[string]string `json:"headers,omitempty"`
+	PassthroughHeaders []string          `json:"passthroughHeaders,omitempty"`
 
 	// If providing tool overrides, any tools not included will be implicitly disabled.
 	// If providing no tool overrides, all tools will be enabled.

--- a/pkg/mcp/httpclient.go
+++ b/pkg/mcp/httpclient.go
@@ -12,6 +12,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -40,19 +41,20 @@ func isJWT(token string) bool {
 }
 
 type HTTPClient struct {
-	ctx          context.Context
-	cancel       context.CancelCauseFunc
-	clientLock   sync.RWMutex
-	httpClient   *http.Client
-	handler      WireHandler
-	oauthHandler *oauth
-	baseURL      string
-	messageURL   string
-	serverName   string
-	displayName  string
-	headers      map[string]string
-	waiter       *waiter
-	sse          bool
+	ctx                context.Context
+	cancel             context.CancelCauseFunc
+	clientLock         sync.RWMutex
+	httpClient         *http.Client
+	handler            WireHandler
+	oauthHandler       *oauth
+	baseURL            string
+	messageURL         string
+	serverName         string
+	displayName        string
+	headers            map[string]string
+	passthroughHeaders []string
+	waiter             *waiter
+	sse                bool
 
 	tokenExchangeEndpoint     string
 	tokenExchangeClientID     string
@@ -95,17 +97,18 @@ func newHTTPClient(serverName string, config Server, opts HTTPClientOptions, ses
 	}
 
 	return &HTTPClient{
-		httpClient:        instrumentHTTPClient(http.DefaultClient),
-		oauthHandler:      newOAuth(opts.CallbackHandler, opts.ClientCredLookup, opts.TokenStorage, opts.OAuthClientName, opts.OAuthRedirectURL),
-		baseURL:           config.BaseURL,
-		messageURL:        config.BaseURL,
-		serverName:        serverName,
-		displayName:       complete.First(config.Name, config.ShortName, serverName),
-		headers:           maps.Clone(headers),
-		waiter:            newWaiter(),
-		needReconnect:     watchesEvents,
-		sessionID:         sessionID,
-		initializeRequest: initializeRequest,
+		httpClient:         instrumentHTTPClient(http.DefaultClient),
+		oauthHandler:       newOAuth(opts.CallbackHandler, opts.ClientCredLookup, opts.TokenStorage, opts.OAuthClientName, opts.OAuthRedirectURL),
+		baseURL:            config.BaseURL,
+		messageURL:         config.BaseURL,
+		serverName:         serverName,
+		displayName:        complete.First(config.Name, config.ShortName, serverName),
+		headers:            maps.Clone(headers),
+		passthroughHeaders: slices.Clone(config.PassthroughHeaders),
+		waiter:             newWaiter(),
+		needReconnect:      watchesEvents,
+		sessionID:          sessionID,
+		initializeRequest:  initializeRequest,
 
 		tokenExchangeClientID:     opts.TokenExchangeClientID,
 		tokenExchangeClientSecret: opts.TokenExchangeClientSecret,
@@ -217,6 +220,7 @@ func (s *HTTPClient) newRequest(ctx context.Context, method string, in any) (*ht
 	for k, v := range s.headers {
 		req.Header.Set(k, v)
 	}
+	s.addPassthroughHeaders(ctx, req)
 
 	// Perform token exchange if configured and a token was parsed
 	// Check for a token on the context
@@ -250,6 +254,29 @@ func (s *HTTPClient) newRequest(ctx context.Context, method string, in any) (*ht
 	}
 
 	return req, nil
+}
+
+func (s *HTTPClient) addPassthroughHeaders(ctx context.Context, req *http.Request) {
+	incoming := RequestFromContext(ctx)
+	if incoming == nil {
+		return
+	}
+
+	for _, header := range s.passthroughHeaders {
+		header = strings.TrimSpace(header)
+		if header == "" {
+			continue
+		}
+
+		canonicalHeader := http.CanonicalHeaderKey(header)
+		if _, exists := req.Header[canonicalHeader]; exists {
+			continue
+		}
+
+		if values := incoming.Header.Values(header); len(values) != 0 {
+			req.Header[canonicalHeader] = values
+		}
+	}
 }
 
 func (s *HTTPClient) ensureSSE(ctx context.Context, msg *Message, lastEventID string) error {

--- a/pkg/mcp/httpclient_test.go
+++ b/pkg/mcp/httpclient_test.go
@@ -1,0 +1,45 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHTTPClientPassthroughHeaders(t *testing.T) {
+	incoming := httptest.NewRequest(http.MethodPost, "http://nanobot.example/mcp", nil)
+	incoming.Header.Set("X-Passthrough", "from-request")
+	incoming.Header.Add("X-Passthrough", "from-request-1")
+	incoming.Header.Set("X-Static", "from-request")
+	incoming.Header.Set("X-Not-Allowed", "from-request")
+
+	client, err := newHTTPClient("test", Server{
+		BaseURL: "http://mcp.example/mcp",
+		Headers: map[string]string{
+			"X-Static": "from-config",
+		},
+		PassthroughHeaders: []string{"X-Passthrough", "X-Static", "X-Not-Present"},
+	}, HTTPClientOptions{}, nil, map[string]string{
+		"X-Static": "from-config",
+	}, false)
+	if err != nil {
+		t.Fatalf("newHTTPClient failed: %v", err)
+	}
+
+	outgoing, err := client.newRequest(WithRequest(context.Background(), incoming), http.MethodPost, nil)
+	if err != nil {
+		t.Fatalf("newRequest failed: %v", err)
+	}
+
+	passthrough := outgoing.Header.Values("X-Passthrough")
+	if len(passthrough) != 2 || passthrough[0] != "from-request" || passthrough[1] != "from-request-1" {
+		t.Fatalf("X-Passthrough = %v, want %q", passthrough, []string{"from-request", "from-request-1"})
+	}
+	if got := outgoing.Header.Get("X-Static"); got != "from-config" {
+		t.Fatalf("X-Static = %q, want static config value", got)
+	}
+	if got := outgoing.Header.Get("X-Not-Allowed"); got != "" {
+		t.Fatalf("X-Not-Allowed = %q, want empty", got)
+	}
+}

--- a/pkg/mcp/httpserver.go
+++ b/pkg/mcp/httpserver.go
@@ -247,8 +247,8 @@ func (h *HTTPServer) streamEvents(rw http.ResponseWriter, req *http.Request, aud
 
 type requestKey struct{}
 
-func withRequest(req *http.Request) context.Context {
-	return context.WithValue(req.Context(), requestKey{}, req)
+func WithRequest(ctx context.Context, req *http.Request) context.Context {
+	return context.WithValue(ctx, requestKey{}, req)
 }
 
 func RequestFromContext(ctx context.Context) *http.Request {
@@ -275,7 +275,7 @@ func (h *HTTPServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (h *HTTPServer) serveHTTP(rw http.ResponseWriter, req *http.Request) {
-	req = req.WithContext(withRequest(req))
+	req = req.WithContext(WithRequest(req.Context(), req))
 	start := time.Now()
 	// Determine audit log method and session ID based on HTTP method
 	sessionID := h.sessions.ExtractID(req)

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -549,6 +549,9 @@ func (s *Service) newClient(ctx context.Context, name string, state *mcp.Session
 	}
 
 	sessionCtx := session.Context()
+	if req := mcp.RequestFromContext(ctx); req != nil {
+		sessionCtx = mcp.WithRequest(sessionCtx, req)
+	}
 	token := mcp.TokenFromContext(ctx)
 	if token != "" {
 		sessionCtx = mcp.WithToken(sessionCtx, token)


### PR DESCRIPTION
This change adds configuration for headers that should be passed from the client request through to the actual MCP server. If a static header is configured with the same name as a passthrough header, then the static header takes precidence.

Issue: https://github.com/obot-platform/obot/issues/6275