### PR TITLE
fix(mcp/stdio): log.Fatal on child EOF crashes the supervisor

### DIFF
--- a/pkg/mcp/stdio.go
+++ b/pkg/mcp/stdio.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	log2 "log"
 	"log/slog"
 	"os/exec"
 	"strings"
@@ -96,9 +95,8 @@ func (s *Stdio) Start(ctx context.Context, handler WireHandler) error {
 		s.Close(false)
 	})
 	go func() {
-		err := s.start(ctx, handler)
-		if err != nil {
-			log2.Fatal(err)
+		if err := s.start(ctx, handler); err != nil {
+			slog.Error("mcp stdio reader exited", "server", s.server, "error", err)
 		}
 	}()
 	return nil


### PR DESCRIPTION
Replace log2.Fatal with slog.Error in the Stdio.Start goroutine. When the MCP child process closes its stdout (normal shutdown, crash, token rotation), buf.Err() returns a non-nil error. Escalating that to log.Fatal killed the entire nanobot process, breaking long-running supervisor deployments (e.g. obot Kubernetes pods where nanobot runs as PID 1). Now logs the error and returns, allowing Close() (already deferred by start()) to signal shutdown gracefully. Fixes #301.