### PR TITLE
fix: remove temperature and always use reasoning for Responses client

### DIFF
--- a/pkg/llm/responses/client.go
+++ b/pkg/llm/responses/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -100,6 +101,9 @@ func (c *Client) complete(ctx context.Context, agentName string, req Request, op
 
 	if httpResp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResp.Body)
+		if err := unsupportedNonReasoningModelError(body); err != nil {
+			return nil, "", "", err
+		}
 		return nil, "", "", fmt.Errorf("failed to get response from OpenAI Responses API: %s %q", httpResp.Status, string(body))
 	}
 
@@ -117,4 +121,25 @@ func (c *Client) complete(ctx context.Context, agentName string, req Request, op
 	}
 
 	return &response, inputReplacement, toolCallPolicyViolation, nil
+}
+
+func unsupportedNonReasoningModelError(body []byte) error {
+	var resp struct {
+		Error *ResponseError `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil || resp.Error == nil {
+		return nil
+	}
+	if !isUnsupportedNonReasoningModelError(resp.Error) {
+		return nil
+	}
+
+	return errors.New("non-reasoning models are currently unsupported")
+}
+
+func isUnsupportedNonReasoningModelError(err *ResponseError) bool {
+	if err.Code == "unsupported_parameter" && err.Param == "reasoning.effort" {
+		return true
+	}
+	return err.Param == "include" && strings.Contains(err.Message, "Encrypted content is not supported with this model")
 }

--- a/pkg/llm/responses/client_test.go
+++ b/pkg/llm/responses/client_test.go
@@ -1,0 +1,65 @@
+package responses
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/obot-platform/nanobot/pkg/types"
+)
+
+func TestCompleteUnsupportedReasoningEffortError(t *testing.T) {
+	client := newErrorClient(t, `{
+		"error": {
+			"message": "Unsupported parameter: 'reasoning.effort' is not supported with this model.",
+			"type": "invalid_request_error",
+			"param": "reasoning.effort",
+			"code": "unsupported_parameter"
+		}
+	}`)
+
+	_, err := client.Complete(context.Background(), types.CompletionRequest{Model: "gpt-4.1"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "non-reasoning models are currently unsupported") {
+		t.Fatalf("expected non-reasoning model error, got %v", err)
+	}
+}
+
+func TestCompleteUnsupportedEncryptedContentError(t *testing.T) {
+	client := newErrorClient(t, `{
+		"error": {
+			"message": "Encrypted content is not supported with this model.",
+			"type": "invalid_request_error",
+			"param": "include",
+			"code": null
+		}
+	}`)
+
+	_, err := client.Complete(context.Background(), types.CompletionRequest{Model: "gpt-4.1"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "non-reasoning models are currently unsupported") {
+		t.Fatalf("expected non-reasoning model error, got %v", err)
+	}
+}
+
+func newErrorClient(t *testing.T, body string) *Client {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+
+	return NewClient(Config{BaseURL: server.URL})
+}

--- a/pkg/llm/responses/translate.go
+++ b/pkg/llm/responses/translate.go
@@ -93,35 +93,27 @@ func toSamplingMessageFromOutputMessage(output *Message) (result []types.Complet
 
 func toRequest(completion *types.CompletionRequest) (req Request, _ error) {
 	req = Request{
-		Model: completion.Model,
-		Store: new(false),
+		Model:     completion.Model,
+		Store:     new(false),
+		Reasoning: &ResponseReasoning{},
 	}
 
-	if reasoningPrefix.MatchString(req.Model) {
-		req.Include = append(req.Include, "reasoning.encrypted_content")
-		req.Reasoning = &ResponseReasoning{}
-		if completion.Reasoning != nil && completion.Reasoning.Summary != "" {
-			req.Reasoning.Summary = &completion.Reasoning.Summary
-		} else {
-			req.Reasoning.Summary = new("auto")
-		}
-		if completion.Reasoning != nil && completion.Reasoning.Effort != "" {
-			req.Reasoning.Effort = &completion.Reasoning.Effort
-		} else {
-			req.Reasoning.Effort = new("medium")
-		}
+	req.Include = append(req.Include, "reasoning.encrypted_content")
+	if completion.Reasoning != nil && completion.Reasoning.Summary != "" {
+		req.Reasoning.Summary = &completion.Reasoning.Summary
+	} else {
+		summary := "auto"
+		req.Reasoning.Summary = &summary
+	}
+	if completion.Reasoning != nil && completion.Reasoning.Effort != "" {
+		req.Reasoning.Effort = &completion.Reasoning.Effort
+	} else {
+		effort := "medium"
+		req.Reasoning.Effort = &effort
 	}
 
 	if completion.Truncation != "" {
 		req.Truncation = &completion.Truncation
-	}
-
-	if completion.Temperature != nil && !reasoningPrefix.MatchString(req.Model) {
-		req.Temperature = completion.Temperature
-	}
-
-	if completion.TopP != nil && !reasoningPrefix.MatchString(req.Model) {
-		req.TopP = completion.TopP
 	}
 
 	if len(completion.Metadata) > 0 {

--- a/pkg/llm/responses/translate.go
+++ b/pkg/llm/responses/translate.go
@@ -102,14 +102,12 @@ func toRequest(completion *types.CompletionRequest) (req Request, _ error) {
 	if completion.Reasoning != nil && completion.Reasoning.Summary != "" {
 		req.Reasoning.Summary = &completion.Reasoning.Summary
 	} else {
-		summary := "auto"
-		req.Reasoning.Summary = &summary
+		req.Reasoning.Summary = new("auto")
 	}
 	if completion.Reasoning != nil && completion.Reasoning.Effort != "" {
 		req.Reasoning.Effort = &completion.Reasoning.Effort
 	} else {
-		effort := "medium"
-		req.Reasoning.Effort = &effort
+		req.Reasoning.Effort = new("medium")
 	}
 
 	if completion.Truncation != "" {

--- a/pkg/llm/responses/translate_test.go
+++ b/pkg/llm/responses/translate_test.go
@@ -1,0 +1,90 @@
+package responses
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/obot-platform/nanobot/pkg/types"
+)
+
+func TestToRequestOmitsSamplingControls(t *testing.T) {
+	temperature := json.Number("0.7")
+	topP := json.Number("0.9")
+
+	req, err := toRequest(&types.CompletionRequest{
+		Model:       "gpt-4.1",
+		Temperature: &temperature,
+		TopP:        &topP,
+	})
+	if err != nil {
+		t.Fatalf("toRequest failed: %v", err)
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if _, ok := raw["temperature"]; ok {
+		t.Fatalf("request includes temperature: %s", data)
+	}
+	if _, ok := raw["top_p"]; ok {
+		t.Fatalf("request includes top_p: %s", data)
+	}
+}
+
+func TestToRequestAlwaysIncludesReasoningDefaults(t *testing.T) {
+	for _, model := range []string{"gpt-4.1", "gpt-5", "o1", "o3-mini"} {
+		t.Run(model, func(t *testing.T) {
+			req, err := toRequest(&types.CompletionRequest{
+				Model: model,
+			})
+			if err != nil {
+				t.Fatalf("toRequest failed: %v", err)
+			}
+
+			if req.Reasoning == nil {
+				t.Fatal("expected reasoning")
+			}
+			if req.Reasoning.Summary == nil || *req.Reasoning.Summary != "auto" {
+				t.Fatalf("expected summary auto, got %#v", req.Reasoning.Summary)
+			}
+			if req.Reasoning.Effort == nil || *req.Reasoning.Effort != "medium" {
+				t.Fatalf("expected effort medium, got %#v", req.Reasoning.Effort)
+			}
+			if len(req.Include) != 1 || req.Include[0] != "reasoning.encrypted_content" {
+				t.Fatalf("expected reasoning include, got %v", req.Include)
+			}
+		})
+	}
+}
+
+func TestToRequestUsesExplicitReasoningValues(t *testing.T) {
+	req, err := toRequest(&types.CompletionRequest{
+		Model: "gpt-5",
+		Reasoning: &types.AgentReasoning{
+			Summary: "detailed",
+			Effort:  "high",
+		},
+	})
+	if err != nil {
+		t.Fatalf("toRequest failed: %v", err)
+	}
+
+	if req.Reasoning == nil {
+		t.Fatal("expected reasoning")
+	}
+	if req.Reasoning.Summary == nil || *req.Reasoning.Summary != "detailed" {
+		t.Fatalf("expected summary detailed, got %#v", req.Reasoning.Summary)
+	}
+	if req.Reasoning.Effort == nil || *req.Reasoning.Effort != "high" {
+		t.Fatalf("expected effort high, got %#v", req.Reasoning.Effort)
+	}
+	if len(req.Include) != 1 || req.Include[0] != "reasoning.encrypted_content" {
+		t.Fatalf("expected reasoning include, got %v", req.Include)
+	}
+}

--- a/pkg/llm/responses/types.go
+++ b/pkg/llm/responses/types.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/obot-platform/nanobot/pkg/types"
@@ -23,10 +22,6 @@ const (
 	StatusFailed Status = "failed"
 )
 
-var (
-	reasoningPrefix = regexp.MustCompile("^(o[0-9]|gpt-5)")
-)
-
 type Request struct {
 	Input              Input              `json:"input,omitempty"`
 	Model              string             `json:"model,omitempty"`
@@ -40,11 +35,9 @@ type Request struct {
 	ServiceTier        *string            `json:"service_tier,omitempty"`
 	Store              *bool              `json:"store,omitempty"`
 	Stream             *bool              `json:"stream,omitempty"`
-	Temperature        *json.Number       `json:"temperature,omitempty"`
 	Text               *TextFormatting    `json:"text,omitempty"`
 	ToolChoice         *ToolChoice        `json:"tool_choice,omitempty"`
 	Tools              []Tool             `json:"tools,omitempty,omitzero"`
-	TopP               *json.Number       `json:"top_p,omitempty"`
 	Truncation         *string            `json:"truncation,omitempty"`
 	User               string             `json:"user,omitempty"`
 }
@@ -810,6 +803,8 @@ type IncompleteDetails struct {
 type ResponseError struct {
 	Code    string `json:"code,omitempty"`
 	Message string `json:"message,omitempty"`
+	Param   string `json:"param,omitempty"`
+	Type    string `json:"type,omitempty"`
 }
 
 type ResponseOutput struct {


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/6595

- Do not use Temperature: unsupported for newer models
- Always use Reasoning
- Provide user-friendly errors for models that do not support reasoning

<img width="931" height="242" alt="Screenshot 2026-05-13 at 14 26 50" src="https://github.com/user-attachments/assets/a1d9d82a-14cb-4c93-804e-9441e8bf38e4" />
