### PR TITLE
fix: pass trusted OAuth parameters when set

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hexops/autogold/v2 v2.3.0
 	github.com/maximhq/bifrost/core v1.5.2
-	github.com/obot-platform/mcp-oauth-proxy v0.0.3-0.20260106135339-3745d9b14a30
+	github.com/obot-platform/mcp-oauth-proxy v0.0.3-0.20260526141817-32b8278fcf00
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdh
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
-github.com/obot-platform/mcp-oauth-proxy v0.0.3-0.20260106135339-3745d9b14a30 h1:PbvvLXjoUHQGpQ4ZzV9Aj8n8y0evpZljPlpDu96lFC4=
-github.com/obot-platform/mcp-oauth-proxy v0.0.3-0.20260106135339-3745d9b14a30/go.mod h1:8I+MeGRPsv42hk7/MCSqWHvz4p7xvIR0CIh1GG3vtXM=
+github.com/obot-platform/mcp-oauth-proxy v0.0.3-0.20260526141817-32b8278fcf00 h1:IzmiE4JJMEsceK7K5f/iYLG4f3YIFUHiSn6zWonypFc=
+github.com/obot-platform/mcp-oauth-proxy v0.0.3-0.20260526141817-32b8278fcf00/go.mod h1:IBdiWaE+aSlf5TpqKhtDkpGwxPetHtjaScewJ/UoSGQ=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -157,6 +157,8 @@ func mcpProxy(auth Auth, dsn string, next http.Handler) (http.Handler, error) {
 		Mode:                 "middleware",
 		MCPPaths:             []string{"/mcp", "/api"},
 		OAuthJWKSURL:         auth.OAuthJWKSURL,
+		TrustedIssuer:        auth.TrustedIssuer,
+		TrustedAudiences:     auth.TrustedAudiences,
 		CookieNamePrefix:     "nanobot_",
 		APIKeyAuthWebhookURL: auth.APIKeyAuthWebhookURL,
 		MCPServerID:          auth.MCPServerID,


### PR DESCRIPTION
This ensures that mcp-oauth-proxy will validate the issuer and audience on the JWT token.