### PR TITLE
fix: close downstream MCP clients on session teardown to stop session leak

### DIFF
--- a/pkg/mcp/session.go
+++ b/pkg/mcp/session.go
@@ -461,6 +461,23 @@ func (s *Session) Attributes() map[string]any {
 }
 
 func (s *Session) Close(deleteSession bool) {
+	// Close any attribute that owns a closable resource (e.g. downstream MCP
+	// client factories). Otherwise those clients are orphaned when the session
+	// is torn down: their upstream session is never deleted and their reader
+	// goroutines leak. Snapshot under the lock, then close without holding it so
+	// a closer may call back into the session without deadlocking.
+	s.lock.Lock()
+	var closers []interface{ Close(bool) }
+	for _, v := range s.attributes {
+		if c, ok := v.(interface{ Close(bool) }); ok {
+			closers = append(closers, c)
+		}
+	}
+	s.lock.Unlock()
+	for _, c := range closers {
+		c.Close(deleteSession)
+	}
+
 	if s.wire != nil {
 		s.wire.Close(deleteSession)
 	}

--- a/pkg/mcp/session_close_test.go
+++ b/pkg/mcp/session_close_test.go
@@ -1,0 +1,42 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+)
+
+// recordingCloser records the deleteSession values it was closed with.
+type recordingCloser struct {
+	closed []bool
+}
+
+func (r *recordingCloser) Close(deleteSession bool) {
+	r.closed = append(r.closed, deleteSession)
+}
+
+// TestSessionCloseClosesAttributeClosers verifies that closing a session also
+// closes any attribute value that owns a closable resource (such as a
+// downstream MCP client factory). Without this, downstream clients stored in
+// session attributes are orphaned when the session is torn down: their upstream
+// MCP session is never deleted (no DELETE is sent) and their goroutines leak.
+func TestSessionCloseClosesAttributeClosers(t *testing.T) {
+	for _, deleteSession := range []bool{true, false} {
+		sess := NewEmptySession(context.Background())
+
+		rc := &recordingCloser{}
+		sess.Set("clients/grocy", rc)
+		// A non-closer attribute must be left untouched (and must not panic).
+		sess.Set("config-hash", SavedString("abc123"))
+
+		sess.Close(deleteSession)
+
+		if len(rc.closed) != 1 {
+			t.Fatalf("deleteSession=%v: expected closable attribute to be closed exactly once, got %d calls (%v)",
+				deleteSession, len(rc.closed), rc.closed)
+		}
+		if rc.closed[0] != deleteSession {
+			t.Fatalf("deleteSession=%v: expected closer to receive %v, got %v",
+				deleteSession, deleteSession, rc.closed[0])
+		}
+	}
+}

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -226,7 +226,7 @@ func (c *clientFactory) get(envHash string) (*mcp.Client, error) {
 	}
 
 	if c.client != nil {
-		c.client.Close(false)
+		c.client.Close(true)
 		c.client = nil
 	}
 
@@ -237,6 +237,20 @@ func (c *clientFactory) get(envHash string) (*mcp.Client, error) {
 	c.client = newClient
 	c.envHash = envHash
 	return c.client, nil
+}
+
+// Close releases the live client, sending a DELETE to the upstream MCP server
+// so its session is freed and its reader goroutine stops. A factory is only
+// closed when its client is being permanently discarded (session teardown or
+// config refresh); the upstream session will not be resumed, so it is always
+// deleted regardless of the caller's deleteSession hint.
+func (c *clientFactory) Close(bool) {
+	c.clientLock.Lock()
+	defer c.clientLock.Unlock()
+	if c.client != nil {
+		c.client.Close(true)
+		c.client = nil
+	}
 }
 
 func (c *clientFactory) Serialize() (any, error) {

--- a/pkg/tools/service_leak_test.go
+++ b/pkg/tools/service_leak_test.go
@@ -1,0 +1,82 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/obot-platform/nanobot/pkg/mcp"
+)
+
+// fakeMCPServer is a minimal Streamable-HTTP MCP server that completes the
+// initialize handshake and records DELETE (session termination) requests.
+func fakeMCPServer(deletes *int32) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodDelete:
+			atomic.AddInt32(deletes, 1)
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			var msg struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			_ = json.Unmarshal(body, &msg)
+			if msg.Method == "initialize" {
+				w.Header().Set("Mcp-Session-Id", "test-session-1")
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + string(msg.ID) +
+					`,"result":{"protocolVersion":"2025-06-18","capabilities":{},` +
+					`"serverInfo":{"name":"fake","version":"1"}}}`))
+				return
+			}
+			// notifications/initialized and anything else
+			w.WriteHeader(http.StatusAccepted)
+		case http.MethodGet:
+			// SSE event stream is unused in this test
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+}
+
+// Compile-time assert the factory is closable so session teardown reaps it.
+var _ interface{ Close(bool) } = (*clientFactory)(nil)
+
+// TestClientFactoryCloseDeletesUpstreamSession proves that closing a
+// clientFactory terminates the upstream MCP session (sends DELETE), preventing
+// the per-reconnect session leak observed against downstream MCP servers.
+func TestClientFactoryCloseDeletesUpstreamSession(t *testing.T) {
+	var deletes int32
+	srv := fakeMCPServer(&deletes)
+	defer srv.Close()
+
+	ctx := context.Background()
+	client, err := mcp.NewClient(ctx, "grocy", mcp.Server{BaseURL: srv.URL})
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+
+	f := newClientFactory(func(*mcp.SessionState) (*mcp.Client, error) {
+		return client, nil
+	})
+	if _, err := f.get("envhash"); err != nil {
+		t.Fatalf("factory.get failed: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&deletes); got != 0 {
+		t.Fatalf("expected no DELETE before close, got %d", got)
+	}
+
+	f.Close(false)
+
+	if got := atomic.LoadInt32(&deletes); got != 1 {
+		t.Fatalf("expected exactly one upstream DELETE after factory close, got %d", got)
+	}
+}

--- a/pkg/tools/service_leak_test.go
+++ b/pkg/tools/service_leak_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/obot-platform/nanobot/pkg/mcp"
 )
@@ -26,11 +27,20 @@ func fakeMCPServer(deletes *int32) *httptest.Server {
 				ID     json.RawMessage `json:"id"`
 				Method string          `json:"method"`
 			}
-			_ = json.Unmarshal(body, &msg)
+			if err := json.Unmarshal(body, &msg); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
 			if msg.Method == "initialize" {
+				// Always emit a valid JSON-RPC id; default to null if the
+				// request omitted one so the response can never be malformed.
+				id := string(msg.ID)
+				if id == "" {
+					id = "null"
+				}
 				w.Header().Set("Mcp-Session-Id", "test-session-1")
 				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + string(msg.ID) +
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + id +
 					`,"result":{"protocolVersion":"2025-06-18","capabilities":{},` +
 					`"serverInfo":{"name":"fake","version":"1"}}}`))
 				return
@@ -76,6 +86,14 @@ func TestClientFactoryCloseDeletesUpstreamSession(t *testing.T) {
 
 	f.Close(false)
 
+	// Close sends the upstream DELETE synchronously today, but poll so the test
+	// stays correct even if client teardown ever becomes asynchronous. A
+	// trailing settle confirms exactly one DELETE is sent (no duplicates).
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadInt32(&deletes) == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	time.Sleep(50 * time.Millisecond)
 	if got := atomic.LoadInt32(&deletes); got != 1 {
 		t.Fatalf("expected exactly one upstream DELETE after factory close, got %d", got)
 	}


### PR DESCRIPTION
## Problem

When an `mcp.Session` is torn down — idle eviction in the session manager (`Manager.Release` evicts after 10s and calls `Session.Close(false)`), or a config refresh (`Data.Refresh`) — the downstream MCP **client factories** stored in the session's attributes are never closed.

Two gaps combine:
- `clientFactory` had **no `Close` method**, so the `value.(interface{ Close(bool) })` assertion in `Data.Refresh` silently no-op'd.
- `Session.Close` ignored attributes entirely.

As a result every torn-down session **orphans its downstream clients**: the upstream MCP session is never terminated (no `DELETE /mcp` is sent) and the client's SSE reader goroutine leaks. On the next request the session is rebuilt and a **brand-new upstream session is initialized**, so a downstream MCP server that nanobot polls on a fixed cadence accumulates one leaked session per cycle.

### Evidence (production)

Against a downstream MCP server connected to nanobot v0.0.83, captured from a live container:

- A full `initialize` producing a **new session id every 60.000s** (`0b74…→22e2…→90f4…→52c8…`), with **no client-close in between**.
- **13,047 `GET /mcp` opens vs 218 `DELETE /mcp` closes** over 9 days (~1,470 leaked sessions/day).
- ~**3.6 GB/day** RSS growth on the downstream server from the accumulated per-session server instances; corresponding unbounded growth on the nanobot side.

## Fix

- `Session.Close` now closes any attribute implementing `Close(bool)`, so session teardown reaps the resources its attributes own. Closers are snapshotted under the lock and closed outside it to avoid deadlock/re-entrancy.
- `clientFactory` implements `Close`, terminating its live client with `deleteSession=true` so the upstream session receives a `DELETE` and the reader goroutine stops. The replacement path in `get()` (env-hash change) is likewise switched from `Close(false)` → `Close(true)`.

A factory is only closed when its client is being **permanently discarded** (teardown / refresh / env-hash change), so the upstream session will not be resumed — it is always deleted.

### Note on session resume

The persisted-state machinery (`Serialize`/`Deserialize`/`SessionState`) appears intended to let a reconstructed session *resume* the upstream session id rather than re-initialize. In practice it does not (the 13k distinct upstream sessions show a fresh `initialize` every cycle), which is the leak. This change makes teardown delete the upstream session unconditionally; since re-init already happens every cycle it regresses nothing observable, and it stays compatible with a future proper resume fix (which would reuse the *live* client and never reach `Close`). Happy to adjust if maintainers prefer fixing resume instead.

## Tests

- `pkg/mcp` — `TestSessionCloseClosesAttributeClosers`: `Session.Close` closes closable attributes (and passes the `deleteSession` flag through) while leaving non-closers untouched.
- `pkg/tools` — `TestClientFactoryCloseDeletesUpstreamSession`: a real `mcp.Client` against an in-process MCP server, stored in a `clientFactory`; closing the factory sends exactly one upstream `DELETE`. Plus a compile-time assertion that `*clientFactory` satisfies `Close(bool)`.

Both were written test-first (red → green).

## Validation

Full `make validate` equivalent on `go1.26`: `gofmt -l .` clean · `go vet ./...` clean · `go test ./...` all pass · `go mod tidy` clean (no dependency changes).
