### PR TITLE
fix: make OAuth protected-resource discovery path-aware (RFC 9728 §3.1)

### DIFF
--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -178,7 +178,9 @@ func oauthResourceMetadataURL(baseURL, authenticateHeader string) (string, strin
 	}
 	if resourceMetadataURL == "" {
 		// If the authenticate header was not sent back or it did not have a resource metadata URL, then the spec says we should default to...
-		u.Path = "/.well-known/oauth-protected-resource"
+		// RFC 9728 §3.1: the well-known segment is inserted between host and the resource path (path-aware),
+		// preserving any path component (e.g. /mcp-connect/{id}) and the original scheme of the base URL.
+		u.Path = "/.well-known/oauth-protected-resource" + strings.TrimSuffix(u.Path, "/")
 		resourceMetadataURL = u.String()
 	}
 


### PR DESCRIPTION
## What

In `oauthResourceMetadataURL`, when there is no `WWW-Authenticate`
`resource_metadata` pointer, build the Protected Resource Metadata URL by
**inserting** `/.well-known/oauth-protected-resource` between the host and the
resource path, instead of **overwriting** the path.

```go
// before
u.Path = "/.well-known/oauth-protected-resource"

// after
resourcePath := strings.TrimSuffix(u.Path, "/")
u.Path = "/.well-known/oauth-protected-resource" + resourcePath
```

## Why

RFC 9728 §3.1 requires the well-known suffix to be inserted between the host and
the path component of the resource identifier (the terminating `/`, if any, is
removed first). The previous code discarded the path, so discovery for any
path-scoped resource resolved the **host-root** metadata document. On hosts that
serve several resources under distinct paths, that document describes a different
resource — leading the client to the wrong authorization server and wrong scopes,
and breaking the OAuth flow.

This only affected the **bare-401 fallback**: when the server returns
`WWW-Authenticate: ... resource_metadata="…"`, that URL is honored verbatim and
was already correct. The sibling `getAuthServerMetadata` (RFC 8414) already
inserts the path; this change makes the protected-resource branch consistent
with it.

Same class of bug as modelcontextprotocol/python-sdk#1400 / SEP-985.

## Tests

- `TestGetOAuthMetadataResourceWithPathNoAuthenticateHeader` — path-scoped
  resource + bare 401. The `httptest` server also serves a host-root metadata
  document with *wrong* scopes; the test asserts discovery lands on the
  path-scoped document. **Fails before the fix, passes after.**
- `TestGetOAuthMetadataRootResourceNoAuthenticateHeader` — root resource + bare
  401, asserting the suffix still resolves to the host root (no regression for
  single-resource-at-root servers).

`make validate` (gofmt, `go vet`, `go test ./...`) passes.

## Scope / notes

- Minimal and consistent with the RFC 8414 sibling: query/fragment handling is
  left exactly as the sibling does (path-only insertion), keeping the change
  focused on §3.1.
- No behavior change when a `WWW-Authenticate` `resource_metadata` pointer is
  present.

Fixes #326
