### PR TITLE
feat: add support for CIMD

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -45,18 +45,19 @@ func New() *cobra.Command {
 }
 
 type Nanobot struct {
-	Debug                bool     `usage:"Enable debug logging"`
-	Trace                bool     `usage:"Enable trace logging"`
-	Env                  []string `usage:"Environment variables to set in the form of KEY=VALUE, or KEY to load from current environ" short:"e"`
-	EnvFile              string   `usage:"Path to the environment file (default: ./nanobot.env)" default:"./nanobot.env"`
-	EmptyEnv             bool     `usage:"Do not load environment variables from the environment by default"`
-	DefaultModel         string   `usage:"Default model to use for completions" default:"gpt-4.1" env:"NANOBOT_DEFAULT_MODEL" name:"default-model"`
-	DefaultMiniModel     string   `usage:"Default model to use for things like thread summaries" default:"gpt-4.1" env:"NANOBOT_DEFAULT_MINI_MODEL" name:"default-mini-model"`
-	MaxConcurrency       int      `usage:"The maximum number of concurrent tasks in a parallel loop" default:"10" hidden:"true"`
-	Chdir                string   `usage:"Change directory to this path before running the nanobot" default:"." short:"C"`
-	State                string   `usage:"Path to the state file" default:"./nanobot.db"`
-	ConfigPath           []string `usage:"Configuration file, directory, URL, or repo ref. Repeat to merge multiple configs; later entries override earlier ones" name:"config" short:"c"`
-	ExcludeBuiltInAgents bool     `usage:"Exclude built-in agents from the configuration"`
+	Debug                         bool     `usage:"Enable debug logging"`
+	Trace                         bool     `usage:"Enable trace logging"`
+	Env                           []string `usage:"Environment variables to set in the form of KEY=VALUE, or KEY to load from current environ" short:"e"`
+	EnvFile                       string   `usage:"Path to the environment file (default: ./nanobot.env)" default:"./nanobot.env"`
+	EmptyEnv                      bool     `usage:"Do not load environment variables from the environment by default"`
+	DefaultModel                  string   `usage:"Default model to use for completions" default:"gpt-4.1" env:"NANOBOT_DEFAULT_MODEL" name:"default-model"`
+	DefaultMiniModel              string   `usage:"Default model to use for things like thread summaries" default:"gpt-4.1" env:"NANOBOT_DEFAULT_MINI_MODEL" name:"default-mini-model"`
+	OAuthClientIDMetadataDocument string   `usage:"OAuth client ID metadata document URL for MCP server OAuth flows" env:"NANOBOT_OAUTH_CLIENT_ID_METADATA_DOCUMENT" name:"oauth-client-id-metadata-document"`
+	MaxConcurrency                int      `usage:"The maximum number of concurrent tasks in a parallel loop" default:"10" hidden:"true"`
+	Chdir                         string   `usage:"Change directory to this path before running the nanobot" default:"." short:"C"`
+	State                         string   `usage:"Path to the state file" default:"./nanobot.db"`
+	ConfigPath                    []string `usage:"Configuration file, directory, URL, or repo ref. Repeat to merge multiple configs; later entries override earlier ones" name:"config" short:"c"`
+	ExcludeBuiltInAgents          bool     `usage:"Exclude built-in agents from the configuration"`
 
 	otel *telemetry.Otel
 }

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -130,15 +130,16 @@ func (r *Run) Run(cmd *cobra.Command, args []string) (err error) {
 	callbackHandler := mcp.NewCallbackServer(confirm.New())
 	configPaths := r.n.ConfigPaths()
 	runtimeOpt := runtime.Options{
-		Roots:                     roots,
-		MaxConcurrency:            r.n.MaxConcurrency,
-		CallbackHandler:           callbackHandler,
-		TokenExchangeEndpoint:     r.Auth.OAuthTokenURL,
-		TokenExchangeClientID:     r.Auth.OAuthClientID,
-		TokenExchangeClientSecret: r.Auth.OAuthClientSecret,
-		DefaultModel:              r.n.DefaultModel,
-		ConfigDir:                 r.n.RuntimeConfigDir(),
-		LoopbackURL:               "http://" + r.ListenAddress + "/mcp/chat",
+		Roots:                         roots,
+		MaxConcurrency:                r.n.MaxConcurrency,
+		CallbackHandler:               callbackHandler,
+		TokenExchangeEndpoint:         r.Auth.OAuthTokenURL,
+		TokenExchangeClientID:         r.Auth.OAuthClientID,
+		TokenExchangeClientSecret:     r.Auth.OAuthClientSecret,
+		OAuthClientIDMetadataDocument: r.n.OAuthClientIDMetadataDocument,
+		DefaultModel:                  r.n.DefaultModel,
+		ConfigDir:                     r.n.RuntimeConfigDir(),
+		LoopbackURL:                   "http://" + r.ListenAddress + "/mcp/chat",
 	}
 
 	cfgFactory := types.ConfigFactory(func(ctx context.Context, profiles string) (types.Config, error) {

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -119,6 +119,7 @@ func (c ClientOption) Merge(other ClientOption) (result ClientOption) {
 	result.TokenExchangeEndpoint = complete.Last(c.TokenExchangeEndpoint, other.TokenExchangeEndpoint)
 	result.TokenExchangeClientID = complete.Last(c.TokenExchangeClientID, other.TokenExchangeClientID)
 	result.TokenExchangeClientSecret = complete.Last(c.TokenExchangeClientSecret, other.TokenExchangeClientSecret)
+	result.OAuthClientIDMetadataDocument = complete.Last(c.OAuthClientIDMetadataDocument, other.OAuthClientIDMetadataDocument)
 	result.OAuthClientName = complete.Last(c.OAuthClientName, other.OAuthClientName)
 	result.Env = complete.MergeMap(c.Env, other.Env)
 	result.SessionState = complete.Last(c.SessionState, other.SessionState)

--- a/pkg/mcp/httpclient.go
+++ b/pkg/mcp/httpclient.go
@@ -69,14 +69,15 @@ type HTTPClient struct {
 }
 
 type HTTPClientOptions struct {
-	OAuthClientName           string
-	OAuthRedirectURL          string
-	CallbackHandler           CallbackHandler
-	ClientCredLookup          ClientCredLookup
-	TokenStorage              TokenStorage
-	TokenExchangeEndpoint     string
-	TokenExchangeClientID     string
-	TokenExchangeClientSecret string
+	OAuthClientName               string
+	OAuthRedirectURL              string
+	CallbackHandler               CallbackHandler
+	ClientCredLookup              ClientCredLookup
+	TokenStorage                  TokenStorage
+	TokenExchangeEndpoint         string
+	TokenExchangeClientID         string
+	TokenExchangeClientSecret     string
+	OAuthClientIDMetadataDocument string
 }
 
 func newHTTPClient(serverName string, config Server, opts HTTPClientOptions, sessionState *SessionState, headers map[string]string, watchesEvents bool) (*HTTPClient, error) {
@@ -98,7 +99,7 @@ func newHTTPClient(serverName string, config Server, opts HTTPClientOptions, ses
 
 	return &HTTPClient{
 		httpClient:         instrumentHTTPClient(http.DefaultClient),
-		oauthHandler:       newOAuth(opts.CallbackHandler, opts.ClientCredLookup, opts.TokenStorage, opts.OAuthClientName, opts.OAuthRedirectURL),
+		oauthHandler:       newOAuth(opts.CallbackHandler, opts.ClientCredLookup, opts.TokenStorage, opts.OAuthClientName, opts.OAuthRedirectURL, opts.OAuthClientIDMetadataDocument),
 		baseURL:            config.BaseURL,
 		messageURL:         config.BaseURL,
 		serverName:         serverName,

--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -26,41 +26,45 @@ var (
 )
 
 type oauth struct {
-	redirectURL, clientName string
-	currentToken            oauth2.Token
-	metadataClient          *http.Client
-	callbackHandler         CallbackHandler
-	clientLookup            ClientCredLookup
-	tokenStorage            TokenStorage
+	redirectURL, clientName  string
+	clientIDMetadataDocument string
+	currentToken             oauth2.Token
+	metadataClient           *http.Client
+	callbackHandler          CallbackHandler
+	clientLookup             ClientCredLookup
+	tokenStorage             TokenStorage
 }
 
 type oauthMetadataDiscovery struct {
-	ProtectedResourceURL            string
-	ProtectedResourceMetadata       protectedResourceMetadata
-	ProtectedResourceMetadataJSON   json.RawMessage
-	AuthorizationServerURL          string
-	AuthorizationServerMetadataURL  string
-	AuthorizationServerMetadata     AuthorizationServerMetadata
-	AuthorizationServerMetadataJSON json.RawMessage
-	DynamicClientRegistration       bool
-	ClientRegistration              ClientRegistrationMetadata
+	ProtectedResourceURL              string
+	ProtectedResourceMetadata         protectedResourceMetadata
+	ProtectedResourceMetadataJSON     json.RawMessage
+	AuthorizationServerURL            string
+	AuthorizationServerMetadataURL    string
+	AuthorizationServerMetadata       AuthorizationServerMetadata
+	AuthorizationServerMetadataJSON   json.RawMessage
+	DynamicClientRegistration         bool
+	ClientRegistration                ClientRegistrationMetadata
+	ClientIDMetadataDocumentSupported bool
 }
 
 // OAuthMetadata contains discovered OAuth metadata for an MCP server.
 type OAuthMetadata struct {
-	ProtectedResourceMetadataURL   string          `json:"protectedResourceMetadataUrl,omitempty"`
-	AuthorizationServerMetadataURL string          `json:"authorizationServerMetadataUrl,omitempty"`
-	ProtectedResourceMetadata      json.RawMessage `json:"protectedResourceMetadata,omitempty"`
-	AuthorizationServerMetadata    json.RawMessage `json:"authorizationServerMetadata,omitempty"`
-	ClientRegistration             json.RawMessage `json:"clientRegistration,omitempty"`
-	DynamicClientRegistration      bool            `json:"dynamicClientRegistration,omitempty"`
+	ProtectedResourceMetadataURL      string          `json:"protectedResourceMetadataUrl,omitempty"`
+	AuthorizationServerMetadataURL    string          `json:"authorizationServerMetadataUrl,omitempty"`
+	ProtectedResourceMetadata         json.RawMessage `json:"protectedResourceMetadata,omitempty"`
+	AuthorizationServerMetadata       json.RawMessage `json:"authorizationServerMetadata,omitempty"`
+	ClientRegistration                json.RawMessage `json:"clientRegistration,omitempty"`
+	DynamicClientRegistration         bool            `json:"dynamicClientRegistration,omitempty"`
+	ClientIDMetadataDocumentSupported bool            `json:"clientIdMetadataDocumentSupported,omitempty"`
 }
 
-func newOAuth(callbackHandler CallbackHandler, clientLookup ClientCredLookup, tokenStorage TokenStorage, clientName, redirectURL string) *oauth {
+func newOAuth(callbackHandler CallbackHandler, clientLookup ClientCredLookup, tokenStorage TokenStorage, clientName, redirectURL, clientIDMetadataDocument string) *oauth {
 	return &oauth{
-		clientName:      clientName,
-		redirectURL:     redirectURL,
-		callbackHandler: callbackHandler,
+		clientName:               clientName,
+		redirectURL:              redirectURL,
+		clientIDMetadataDocument: clientIDMetadataDocument,
+		callbackHandler:          callbackHandler,
 		metadataClient: instrumentHTTPClient(&http.Client{
 			Timeout: 5 * time.Second,
 		}),
@@ -145,15 +149,16 @@ func discoverOAuthMetadata(ctx context.Context, client *http.Client, baseURL, au
 	}
 
 	return oauthMetadataDiscovery{
-		ProtectedResourceURL:            resourceMetadataURL,
-		ProtectedResourceMetadata:       protectedResourceMetadata,
-		ProtectedResourceMetadataJSON:   protectedResourceMetadataJSON,
-		AuthorizationServerURL:          authorizationServerURL,
-		AuthorizationServerMetadataURL:  authorizationServerMetadataURL,
-		AuthorizationServerMetadata:     authorizationServerMetadata,
-		AuthorizationServerMetadataJSON: authorizationServerMetadataJSON,
-		ClientRegistration:              AuthServerMetadataToClientRegistration(authorizationServerMetadata, clientName, redirectURL, scope),
-		DynamicClientRegistration:       rawAuthorizationServerMetadata.RegistrationEndpoint != "",
+		ProtectedResourceURL:              resourceMetadataURL,
+		ProtectedResourceMetadata:         protectedResourceMetadata,
+		ProtectedResourceMetadataJSON:     protectedResourceMetadataJSON,
+		AuthorizationServerURL:            authorizationServerURL,
+		AuthorizationServerMetadataURL:    authorizationServerMetadataURL,
+		AuthorizationServerMetadata:       authorizationServerMetadata,
+		AuthorizationServerMetadataJSON:   authorizationServerMetadataJSON,
+		ClientRegistration:                AuthServerMetadataToClientRegistration(authorizationServerMetadata, clientName, redirectURL, scope),
+		DynamicClientRegistration:         rawAuthorizationServerMetadata.RegistrationEndpoint != "",
+		ClientIDMetadataDocumentSupported: authorizationServerMetadata.ClientIDMetadataDocumentSupported,
 	}, true, nil
 }
 
@@ -199,30 +204,13 @@ func (o *oauth) oauthClient(ctx context.Context, c *HTTPClient, connectURL, auth
 	if !ok {
 		return nil, fmt.Errorf("failed to get authorization server metadata")
 	}
-	protectedResourceMetadata := discovery.ProtectedResourceMetadata
 	authorizationServerMetadata := discovery.AuthorizationServerMetadata
 	slog.Info("resolved oauth scope for server", "server", c.serverName, "scope", discovery.ClientRegistration.Scope)
 	slog.Info("resolved authorization server", "server", c.serverName, "authorization_server", discovery.AuthorizationServerURL)
 
-	// Before trying to register a client, check if there is a static client configuration.
-	var (
-		clientInfo clientRegistrationResponse
-		lookupErr  error
-	)
-	clientInfo.ClientID, clientInfo.ClientSecret, lookupErr = o.clientLookup.Lookup(ctx, protectedResourceMetadata.AuthorizationServers[0])
-	if lookupErr == nil && clientInfo.ClientID != "" && clientInfo.ClientSecret != "" {
-		slog.Info("using static oauth client credentials", "server", c.serverName, "authorization_server", protectedResourceMetadata.AuthorizationServers[0])
-	}
-
-	// If we didn't get a result from the lookup, register a client dynamically.
-	if lookupErr != nil || clientInfo.ClientID == "" || clientInfo.ClientSecret == "" {
-		clientInfo, err = RegisterOAuthClient(ctx, o.metadataClient, c.serverName, authorizationServerMetadata, discovery.ClientRegistration)
-		if err != nil {
-			if lookupErr != nil {
-				return nil, fmt.Errorf("%w - static OAuth client lookup also failed: %v", err, lookupErr)
-			}
-			return nil, err
-		}
+	clientInfo, err := o.resolveClientInfo(ctx, c.serverName, discovery)
+	if err != nil {
+		return nil, err
 	}
 
 	conf := &oauth2.Config{
@@ -237,15 +225,7 @@ func (o *oauth) oauthClient(ctx context.Context, c *HTTPClient, connectURL, auth
 	if discovery.ClientRegistration.Scope != "" {
 		conf.Scopes = strings.Split(discovery.ClientRegistration.Scope, " ")
 	}
-	switch discovery.ClientRegistration.TokenEndpointAuthMethod {
-	case "client_secret_basic":
-		conf.Endpoint.AuthStyle = oauth2.AuthStyleInHeader
-	case "client_secret_post":
-		conf.Endpoint.AuthStyle = oauth2.AuthStyleInParams
-	default:
-		conf.Endpoint.AuthStyle = oauth2.AuthStyleAutoDetect
-	}
-
+	conf.Endpoint.AuthStyle = tokenEndpointAuthStyle(discovery.ClientRegistration.TokenEndpointAuthMethod, clientInfo.ClientSecret != "")
 	authURL, ch, verifier, err := GetOAuthAuthorizationURL(ctx, o.callbackHandler, conf, authorizationServerMetadata.AuthorizationEndpoint, connectURL)
 	if err != nil {
 		return nil, err
@@ -295,6 +275,55 @@ func (o *oauth) oauthClient(ctx context.Context, c *HTTPClient, connectURL, auth
 	return oauth2.NewClient(ctx, newTokenSource(ctx, o.tokenStorage, connectURL, conf, tok)), nil
 }
 
+func tokenEndpointAuthStyle(tokenEndpointAuthMethod string, hasClientSecret bool) oauth2.AuthStyle {
+	if !hasClientSecret {
+		return oauth2.AuthStyleInParams
+	}
+
+	switch tokenEndpointAuthMethod {
+	case "client_secret_basic":
+		return oauth2.AuthStyleInHeader
+	case "client_secret_post":
+		return oauth2.AuthStyleInParams
+	default:
+		return oauth2.AuthStyleAutoDetect
+	}
+}
+
+func (o *oauth) resolveClientInfo(ctx context.Context, serverName string, discovery oauthMetadataDiscovery) (clientRegistrationResponse, error) {
+	authorizationServerMetadata := discovery.AuthorizationServerMetadata
+	protectedResourceMetadata := discovery.ProtectedResourceMetadata
+
+	if authorizationServerMetadata.ClientIDMetadataDocumentSupported && o.clientIDMetadataDocument != "" {
+		slog.Info("using oauth client ID metadata document", "server", serverName, "client_id", o.clientIDMetadataDocument)
+		return clientRegistrationResponse{
+			ClientID: o.clientIDMetadataDocument,
+		}, nil
+	}
+
+	// Before trying to register a client, check if there is a static client configuration.
+	var (
+		clientInfo clientRegistrationResponse
+		lookupErr  error
+	)
+	clientInfo.ClientID, clientInfo.ClientSecret, lookupErr = o.clientLookup.Lookup(ctx, protectedResourceMetadata.AuthorizationServers[0])
+	if lookupErr == nil && clientInfo.ClientID != "" && clientInfo.ClientSecret != "" {
+		slog.Info("using static oauth client credentials", "server", serverName, "authorization_server", protectedResourceMetadata.AuthorizationServers[0])
+		return clientInfo, nil
+	}
+
+	// If we didn't get a result from the lookup, register a client dynamically.
+	clientInfo, err := RegisterOAuthClient(ctx, o.metadataClient, serverName, authorizationServerMetadata, discovery.ClientRegistration)
+	if err != nil {
+		if lookupErr != nil {
+			return clientRegistrationResponse{}, fmt.Errorf("%w - static OAuth client lookup also failed: %v", err, lookupErr)
+		}
+		return clientRegistrationResponse{}, err
+	}
+
+	return clientInfo, nil
+}
+
 // GetOAuthMetadata discovers OAuth protected resource and authorization server
 // metadata for an HTTP MCP server. Missing metadata endpoints are not errors.
 func GetOAuthMetadata(ctx context.Context, server Server, clientName, redirectURL string) (OAuthMetadata, error) {
@@ -328,12 +357,13 @@ func GetOAuthMetadata(ctx context.Context, server Server, clientName, redirectUR
 	}
 
 	return OAuthMetadata{
-		ProtectedResourceMetadataURL:   discovery.ProtectedResourceURL,
-		AuthorizationServerMetadataURL: discovery.AuthorizationServerMetadataURL,
-		ProtectedResourceMetadata:      discovery.ProtectedResourceMetadataJSON,
-		AuthorizationServerMetadata:    discovery.AuthorizationServerMetadataJSON,
-		ClientRegistration:             clientRegistrationJSON,
-		DynamicClientRegistration:      discovery.DynamicClientRegistration,
+		ProtectedResourceMetadataURL:      discovery.ProtectedResourceURL,
+		AuthorizationServerMetadataURL:    discovery.AuthorizationServerMetadataURL,
+		ProtectedResourceMetadata:         discovery.ProtectedResourceMetadataJSON,
+		AuthorizationServerMetadata:       discovery.AuthorizationServerMetadataJSON,
+		ClientRegistration:                clientRegistrationJSON,
+		DynamicClientRegistration:         discovery.DynamicClientRegistration,
+		ClientIDMetadataDocumentSupported: discovery.ClientIDMetadataDocumentSupported,
 	}, nil
 }
 
@@ -782,6 +812,9 @@ type AuthorizationServerMetadata struct {
 
 	// OPTIONAL. JSON array containing PKCE code challenge methods
 	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported,omitempty"`
+
+	// OPTIONAL. Boolean indicating whether the client ID metadata document is supported
+	ClientIDMetadataDocumentSupported bool `json:"client_id_metadata_document_supported,omitempty"`
 }
 
 // ClientRegistrationMetadata represents OAuth 2.0 Dynamic Client Registration metadata

--- a/pkg/mcp/oauth_test.go
+++ b/pkg/mcp/oauth_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+
+	"golang.org/x/oauth2"
 )
 
 func TestGetOAuthMetadata(t *testing.T) {
@@ -16,7 +18,7 @@ func TestGetOAuthMetadata(t *testing.T) {
 		redirectURL = "http://localhost/callback"
 	)
 	protectedResourceMetadata := json.RawMessage(`{"resource":"resource","authorization_servers":["issuer"],"scopes_supported":["read"]}`)
-	authorizationServerMetadata := json.RawMessage(`{"issuer":"issuer","authorization_endpoint":"authorize","token_endpoint":"token","registration_endpoint":"register","response_types_supported":["code"]}`)
+	authorizationServerMetadata := json.RawMessage(`{"issuer":"issuer","authorization_endpoint":"authorize","token_endpoint":"token","registration_endpoint":"register","response_types_supported":["code"],"client_id_metadata_document_supported":true}`)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
@@ -78,6 +80,20 @@ func TestGetOAuthMetadata(t *testing.T) {
 	}
 	if !result.DynamicClientRegistration {
 		t.Fatalf("expected dynamic client registration support")
+	}
+	if !result.ClientIDMetadataDocumentSupported {
+		t.Fatalf("expected client ID metadata document support")
+	}
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal oauth metadata: %v", err)
+	}
+	var resultFields map[string]json.RawMessage
+	if err := json.Unmarshal(resultJSON, &resultFields); err != nil {
+		t.Fatalf("failed to parse oauth metadata: %v", err)
+	}
+	if string(resultFields["clientIdMetadataDocumentSupported"]) != "true" {
+		t.Fatalf("expected clientIdMetadataDocumentSupported JSON field, got %s", resultFields["clientIdMetadataDocumentSupported"])
 	}
 	var clientRegistration ClientRegistrationMetadata
 	if err := json.Unmarshal(result.ClientRegistration, &clientRegistration); err != nil {
@@ -178,5 +194,105 @@ func TestGetOAuthMetadataAuthorizationServerNoRegistration(t *testing.T) {
 	}
 	if result.DynamicClientRegistration {
 		t.Fatalf("expected no dynamic client registration support")
+	}
+}
+
+type testClientCredLookup struct {
+	clientID     string
+	clientSecret string
+	calls        int
+}
+
+func (l *testClientCredLookup) Lookup(context.Context, string) (string, string, error) {
+	l.calls++
+	return l.clientID, l.clientSecret, nil
+}
+
+func TestResolveClientInfoUsesClientIDMetadataDocument(t *testing.T) {
+	lookup := &testClientCredLookup{
+		clientID:     "static-client-id",
+		clientSecret: "static-client-secret",
+	}
+	o := &oauth{
+		clientIDMetadataDocument: "https://client.example/oauth-client-metadata.json",
+		clientLookup:             lookup,
+	}
+
+	clientInfo, err := o.resolveClientInfo(context.Background(), "test-server", oauthMetadataDiscovery{
+		ProtectedResourceMetadata: protectedResourceMetadata{
+			AuthorizationServers: []string{"https://issuer.example"},
+		},
+		AuthorizationServerMetadata: AuthorizationServerMetadata{
+			ClientIDMetadataDocumentSupported: true,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if clientInfo.ClientID != o.clientIDMetadataDocument {
+		t.Fatalf("expected metadata document client ID %q, got %q", o.clientIDMetadataDocument, clientInfo.ClientID)
+	}
+	if clientInfo.ClientSecret != "" {
+		t.Fatalf("expected empty client secret, got %q", clientInfo.ClientSecret)
+	}
+	if lookup.calls != 0 {
+		t.Fatalf("static client lookup should not be called, got %d calls", lookup.calls)
+	}
+}
+
+func TestResolveClientInfoFallsBackWhenClientIDMetadataDocumentUnsupported(t *testing.T) {
+	lookup := &testClientCredLookup{
+		clientID:     "static-client-id",
+		clientSecret: "static-client-secret",
+	}
+	o := &oauth{
+		clientIDMetadataDocument: "https://client.example/oauth-client-metadata.json",
+		clientLookup:             lookup,
+	}
+
+	clientInfo, err := o.resolveClientInfo(context.Background(), "test-server", oauthMetadataDiscovery{
+		ProtectedResourceMetadata: protectedResourceMetadata{
+			AuthorizationServers: []string{"https://issuer.example"},
+		},
+		AuthorizationServerMetadata: AuthorizationServerMetadata{
+			ClientIDMetadataDocumentSupported: false,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if clientInfo.ClientID != lookup.clientID {
+		t.Fatalf("expected static client ID %q, got %q", lookup.clientID, clientInfo.ClientID)
+	}
+	if clientInfo.ClientSecret != lookup.clientSecret {
+		t.Fatalf("expected static client secret %q, got %q", lookup.clientSecret, clientInfo.ClientSecret)
+	}
+	if lookup.calls != 1 {
+		t.Fatalf("expected one static client lookup, got %d calls", lookup.calls)
+	}
+}
+
+func TestTokenEndpointAuthStyleUsesParamsWithoutClientSecret(t *testing.T) {
+	if got := tokenEndpointAuthStyle("client_secret_basic", false); got != oauth2.AuthStyleInParams {
+		t.Fatalf("expected params auth style without client secret, got %v", got)
+	}
+}
+
+func TestTokenEndpointAuthStyleHonorsClientSecretMethods(t *testing.T) {
+	tests := []struct {
+		method string
+		want   oauth2.AuthStyle
+	}{
+		{method: "client_secret_basic", want: oauth2.AuthStyleInHeader},
+		{method: "client_secret_post", want: oauth2.AuthStyleInParams},
+		{method: "", want: oauth2.AuthStyleAutoDetect},
+	}
+
+	for _, tt := range tests {
+		if got := tokenEndpointAuthStyle(tt.method, true); got != tt.want {
+			t.Fatalf("expected auth style %v for method %q, got %v", tt.want, tt.method, got)
+		}
 	}
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -35,21 +35,22 @@ type Runtime struct {
 }
 
 type Options struct {
-	Roots                     []mcp.Root
-	Profiles                  []string
-	MaxConcurrency            int
-	CallbackHandler           mcp.CallbackHandler
-	TokenStorage              mcp.TokenStorage
-	OAuthRedirectURL          string
-	DSN                       string
-	Store                     *session.Store
-	TokenExchangeEndpoint     string
-	TokenExchangeClientID     string
-	TokenExchangeClientSecret string
-	AuditLogCollector         *auditlogs.Collector
-	DefaultModel              string
-	ConfigDir                 string
-	LoopbackURL               string
+	Roots                         []mcp.Root
+	Profiles                      []string
+	MaxConcurrency                int
+	CallbackHandler               mcp.CallbackHandler
+	TokenStorage                  mcp.TokenStorage
+	OAuthRedirectURL              string
+	DSN                           string
+	Store                         *session.Store
+	TokenExchangeEndpoint         string
+	TokenExchangeClientID         string
+	TokenExchangeClientSecret     string
+	OAuthClientIDMetadataDocument string
+	AuditLogCollector             *auditlogs.Collector
+	DefaultModel                  string
+	ConfigDir                     string
+	LoopbackURL                   string
 }
 
 func (o Options) Merge(other Options) (result Options) {
@@ -64,6 +65,7 @@ func (o Options) Merge(other Options) (result Options) {
 	result.TokenExchangeEndpoint = complete.Last(o.TokenExchangeEndpoint, other.TokenExchangeEndpoint)
 	result.TokenExchangeClientID = complete.Last(o.TokenExchangeClientID, other.TokenExchangeClientID)
 	result.TokenExchangeClientSecret = complete.Last(o.TokenExchangeClientSecret, other.TokenExchangeClientSecret)
+	result.OAuthClientIDMetadataDocument = complete.Last(o.OAuthClientIDMetadataDocument, other.OAuthClientIDMetadataDocument)
 	result.AuditLogCollector = complete.Last(o.AuditLogCollector, other.AuditLogCollector)
 	result.DefaultModel = complete.Last(o.DefaultModel, other.DefaultModel)
 	result.ConfigDir = complete.Last(o.ConfigDir, other.ConfigDir)
@@ -87,15 +89,16 @@ func NewRuntime(ctx context.Context, cfg llm.Config, opts ...Options) (*Runtime,
 
 	completer := llm.NewClient(cfg)
 	registry := tools.NewToolsService(tools.Options{
-		Roots:                     opt.Roots,
-		Concurrency:               opt.MaxConcurrency,
-		CallbackHandler:           opt.CallbackHandler,
-		OAuthRedirectURL:          opt.OAuthRedirectURL,
-		TokenStorage:              opt.TokenStorage,
-		TokenExchangeEndpoint:     opt.TokenExchangeEndpoint,
-		TokenExchangeClientID:     opt.TokenExchangeClientID,
-		TokenExchangeClientSecret: opt.TokenExchangeClientSecret,
-		AuditLogCollector:         opt.AuditLogCollector,
+		Roots:                         opt.Roots,
+		Concurrency:                   opt.MaxConcurrency,
+		CallbackHandler:               opt.CallbackHandler,
+		OAuthRedirectURL:              opt.OAuthRedirectURL,
+		TokenStorage:                  opt.TokenStorage,
+		TokenExchangeEndpoint:         opt.TokenExchangeEndpoint,
+		TokenExchangeClientID:         opt.TokenExchangeClientID,
+		TokenExchangeClientSecret:     opt.TokenExchangeClientSecret,
+		OAuthClientIDMetadataDocument: opt.OAuthClientIDMetadataDocument,
+		AuditLogCollector:             opt.AuditLogCollector,
 	})
 	agentsService := agents.New(completer, registry)
 	sampler := sampling.NewSampler(agentsService)

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -27,18 +27,19 @@ import (
 )
 
 type Service struct {
-	roots                     []mcp.Root
-	sampler                   Sampler
-	runner                    mcp.Runner
-	callbackHandler           mcp.CallbackHandler
-	oauthRedirectURL          string
-	tokenStorage              mcp.TokenStorage
-	concurrency               int
-	serverFactories           map[string]func(name string) mcp.MessageHandler
-	tokenExchangeEndpoint     string
-	tokenExchangeClientID     string
-	tokenExchangeClientSecret string
-	auditLogCollector         *auditlogs.Collector
+	roots                         []mcp.Root
+	sampler                       Sampler
+	runner                        mcp.Runner
+	callbackHandler               mcp.CallbackHandler
+	oauthRedirectURL              string
+	tokenStorage                  mcp.TokenStorage
+	concurrency                   int
+	serverFactories               map[string]func(name string) mcp.MessageHandler
+	tokenExchangeEndpoint         string
+	tokenExchangeClientID         string
+	tokenExchangeClientSecret     string
+	oauthClientIDMetadataDocument string
+	auditLogCollector             *auditlogs.Collector
 }
 
 type Sampler interface {
@@ -46,15 +47,16 @@ type Sampler interface {
 }
 
 type Options struct {
-	Roots                     []mcp.Root
-	Concurrency               int
-	CallbackHandler           mcp.CallbackHandler
-	OAuthRedirectURL          string
-	TokenStorage              mcp.TokenStorage
-	TokenExchangeEndpoint     string
-	TokenExchangeClientID     string
-	TokenExchangeClientSecret string
-	AuditLogCollector         *auditlogs.Collector
+	Roots                         []mcp.Root
+	Concurrency                   int
+	CallbackHandler               mcp.CallbackHandler
+	OAuthRedirectURL              string
+	TokenStorage                  mcp.TokenStorage
+	TokenExchangeEndpoint         string
+	TokenExchangeClientID         string
+	TokenExchangeClientSecret     string
+	OAuthClientIDMetadataDocument string
+	AuditLogCollector             *auditlogs.Collector
 }
 
 func (r Options) Merge(other Options) (result Options) {
@@ -66,6 +68,7 @@ func (r Options) Merge(other Options) (result Options) {
 	result.TokenExchangeEndpoint = complete.Last(r.TokenExchangeEndpoint, other.TokenExchangeEndpoint)
 	result.TokenExchangeClientID = complete.Last(r.TokenExchangeClientID, other.TokenExchangeClientID)
 	result.TokenExchangeClientSecret = complete.Last(r.TokenExchangeClientSecret, other.TokenExchangeClientSecret)
+	result.OAuthClientIDMetadataDocument = complete.Last(r.OAuthClientIDMetadataDocument, other.OAuthClientIDMetadataDocument)
 	result.AuditLogCollector = complete.Last(r.AuditLogCollector, other.AuditLogCollector)
 	return result
 }
@@ -80,15 +83,16 @@ func (r Options) Complete() Options {
 func NewToolsService(opts ...Options) *Service {
 	opt := complete.Complete(opts...)
 	return &Service{
-		roots:                     opt.Roots,
-		concurrency:               opt.Concurrency,
-		oauthRedirectURL:          opt.OAuthRedirectURL,
-		callbackHandler:           opt.CallbackHandler,
-		tokenStorage:              opt.TokenStorage,
-		tokenExchangeEndpoint:     opt.TokenExchangeEndpoint,
-		tokenExchangeClientID:     opt.TokenExchangeClientID,
-		tokenExchangeClientSecret: opt.TokenExchangeClientSecret,
-		auditLogCollector:         opt.AuditLogCollector,
+		roots:                         opt.Roots,
+		concurrency:                   opt.Concurrency,
+		oauthRedirectURL:              opt.OAuthRedirectURL,
+		callbackHandler:               opt.CallbackHandler,
+		tokenStorage:                  opt.TokenStorage,
+		tokenExchangeEndpoint:         opt.TokenExchangeEndpoint,
+		tokenExchangeClientID:         opt.TokenExchangeClientID,
+		tokenExchangeClientSecret:     opt.TokenExchangeClientSecret,
+		oauthClientIDMetadataDocument: opt.OAuthClientIDMetadataDocument,
+		auditLogCollector:             opt.AuditLogCollector,
 	}
 }
 
@@ -452,12 +456,13 @@ func (s *Service) newClient(ctx context.Context, name string, state *mcp.Session
 		},
 		Runner: &s.runner,
 		HTTPClientOptions: mcp.HTTPClientOptions{
-			OAuthRedirectURL:          oauthRedirectURL,
-			CallbackHandler:           s.callbackHandler,
-			TokenStorage:              s.tokenStorage,
-			TokenExchangeEndpoint:     s.tokenExchangeEndpoint,
-			TokenExchangeClientID:     s.tokenExchangeClientID,
-			TokenExchangeClientSecret: s.tokenExchangeClientSecret,
+			OAuthRedirectURL:              oauthRedirectURL,
+			CallbackHandler:               s.callbackHandler,
+			TokenStorage:                  s.tokenStorage,
+			TokenExchangeEndpoint:         s.tokenExchangeEndpoint,
+			TokenExchangeClientID:         s.tokenExchangeClientID,
+			TokenExchangeClientSecret:     s.tokenExchangeClientSecret,
+			OAuthClientIDMetadataDocument: s.oauthClientIDMetadataDocument,
 		},
 		Wire:         wire,
 		SessionState: state,


### PR DESCRIPTION
This change introduces support for CIMD. If a client ID metdata document URL is provided and the authorization server supports it, nanobot will use the CIMD to request an authorization code.

Issue: https://github.com/obot-platform/obot/issues/6833