### PR TITLE
fix: stop sending temperature and top_p to Anthropic

### DIFF
--- a/pkg/llm/anthropic/translate.go
+++ b/pkg/llm/anthropic/translate.go
@@ -64,12 +64,10 @@ func toRequest(req *types.CompletionRequest) (Request, error) {
 	}
 
 	result := Request{
-		Model:       req.Model,
-		System:      strings.TrimSpace(req.SystemPrompt),
-		MaxTokens:   req.MaxTokens,
-		Temperature: req.Temperature,
-		TopP:        req.TopP,
-		Metadata:    req.Metadata,
+		Model:     req.Model,
+		System:    strings.TrimSpace(req.SystemPrompt),
+		MaxTokens: req.MaxTokens,
+		Metadata:  req.Metadata,
 	}
 
 	for _, tool := range req.Tools {

--- a/pkg/llm/anthropic/translate_test.go
+++ b/pkg/llm/anthropic/translate_test.go
@@ -73,3 +73,34 @@ func TestToRequestDropsResourceLinkContent(t *testing.T) {
 		t.Fatalf("request still contains null content: %s", data)
 	}
 }
+
+// TestToRequestOmitsSamplingControls ensures deprecated temperature and top_p fields are omitted.
+func TestToRequestOmitsSamplingControls(t *testing.T) {
+	temperature := json.Number("0.7")
+	topP := json.Number("0.9")
+
+	req, err := toRequest(&types.CompletionRequest{
+		Model:       "claude-opus-4-8",
+		Temperature: &temperature,
+		TopP:        &topP,
+	})
+	if err != nil {
+		t.Fatalf("toRequest failed: %v", err)
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if _, ok := raw["temperature"]; ok {
+		t.Fatalf("request includes temperature: %s", data)
+	}
+	if _, ok := raw["top_p"]; ok {
+		t.Fatalf("request includes top_p: %s", data)
+	}
+}

--- a/pkg/llm/anthropic/types.go
+++ b/pkg/llm/anthropic/types.go
@@ -11,10 +11,8 @@ type Request struct {
 	StopSequences []string       `json:"stop_sequences,omitempty"`
 	Stream        bool           `json:"stream,omitempty"`
 	System        string         `json:"system,omitempty"`
-	Temperature   *json.Number   `json:"temperature,omitempty"`
 	ToolChoice    *ToolChoice    `json:"tool_choice,omitempty"`
 	Tools         []CustomTool   `json:"tools,omitempty"`
-	TopP          *json.Number   `json:"top_p,omitempty"`
 	Metadata      map[string]any `json:"metadata,omitempty"`
 }
 


### PR DESCRIPTION
The Messages API temperature and top_p parameters are deprecated and now
return 400 errors on every Anthropic model released after claude-opus-4.6
(Opus 4.7+, Fable 5), which broke agent chat whenever a default temperature
was supplied. Both fields are optional on all Anthropic models, so omit them
entirely from the request rather than gating on model version — this fixes
the newer models without affecting older ones, which simply fall back to
their defaults.

Drop the Temperature and TopP fields from the request type and the request
builder, and add a regression test asserting neither is ever marshaled onto
the wire.

Addresses https://github.com/obot-platform/obot/issues/6967

