### PR TITLE
fix: stop exiting if stdio command exits cleanly

### DIFF
--- a/pkg/mcp/runner.go
+++ b/pkg/mcp/runner.go
@@ -210,9 +210,6 @@ func (r *Runner) doStream(ctx context.Context, serverName string, cmd *sandbox.C
 
 	go func() {
 		sandbox.PipeOut(ctx, stderrPipe, serverName)
-		if err := cmd.Wait(); err != nil {
-			slog.Error("command exited with error", "server", serverName, "error", err)
-		}
 	}()
 
 	return &streamResult{
@@ -250,6 +247,18 @@ func (r *Runner) Stream(ctx context.Context, roots func(context.Context) ([]Root
 		cancel()
 		return nil, fmt.Errorf("failed to run stdio command: %w", err)
 	}
-	result.Close = cancel
+
+	once := new(sync.Once)
+	result.Close = func() {
+		cancel()
+		if result.cmd != nil {
+			once.Do(func() {
+				if err := result.cmd.Wait(); err != nil {
+					slog.Error("command exited with error", "server", serverName, "error", err)
+				}
+			})
+		}
+	}
+
 	return result, nil
 }

--- a/pkg/mcp/session.go
+++ b/pkg/mcp/session.go
@@ -468,6 +468,15 @@ func (s *Session) Close(deleteSession bool) {
 	s.cancel(fmt.Errorf("session closed: %s, delete=%v", s.ID(), deleteSession))
 }
 
+func (s *Session) IsActive() bool {
+	select {
+	case <-s.ctx.Done():
+		return false
+	default:
+		return true
+	}
+}
+
 func (s *Session) Wait() {
 	if s.wire == nil {
 		<-s.ctx.Done()

--- a/pkg/mcp/stdio.go
+++ b/pkg/mcp/stdio.go
@@ -126,6 +126,7 @@ func (s *Stdio) start(ctx context.Context, handler WireHandler) error {
 		}
 		go handler(ctx, msg)
 	}
+
 	return buf.Err()
 }
 

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -225,7 +225,7 @@ func (c *clientFactory) get(envHash string) (*mcp.Client, error) {
 	c.clientLock.Lock()
 	defer c.clientLock.Unlock()
 
-	if c.client != nil && c.envHash == envHash {
+	if c.client != nil && c.client.Session.IsActive() && c.envHash == envHash {
 		return c.client, nil
 	}
 


### PR DESCRIPTION
If an stdio command exited cleanly, then a couple things could happen, both of which result in errors and the system is not recoverable and must be restarted.

This change properly waits for the command to exit and will read all of the contents of stdout, resulting in no error. Secondly, an exited stdio command will be restarted on the next call, if necessary.

Issue: https://github.com/obot-platform/nanobot/issues/301