### PR TITLE
feat: support lazy-auth MCP servers (OAuth required without a 401 challenge)

### DIFF
--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -151,6 +151,13 @@ type Server struct {
 	Headers            map[string]string `json:"headers,omitempty"`
 	PassthroughHeaders []string          `json:"passthroughHeaders,omitempty"`
 
+	// OAuthRequired forces OAuth metadata discovery even when the server
+	// completes `initialize` without a 401 challenge. Some MCP servers only
+	// enforce auth on tool calls (never challenging at connect) yet still
+	// publish RFC 9728 protected-resource metadata; set this so OAuth is
+	// configured at connect time instead of failing on the first tool call.
+	OAuthRequired bool `json:"oauthRequired,omitempty"`
+
 	// If providing tool overrides, any tools not included will be implicitly disabled.
 	// If providing no tool overrides, all tools will be enabled.
 	ToolOverrides ToolOverrides `json:"toolOverrides,omitzero"`

--- a/pkg/mcp/httpclient.go
+++ b/pkg/mcp/httpclient.go
@@ -56,6 +56,14 @@ type HTTPClient struct {
 	waiter             *waiter
 	sse                bool
 
+	// lazy-auth support. oauthRequired forces the OAuth flow even when the
+	// server returns 200 on initialize (e.g. BigQuery, which only challenges on
+	// tool-call). oauthTokenLoaded records whether a stored token was loaded at Start
+	// (don't re-auth if we already have one). oauthStarted guards against re-entry.
+	oauthRequired    bool
+	oauthTokenLoaded bool
+	oauthStarted     bool
+
 	tokenExchangeEndpoint     string
 	tokenExchangeClientID     string
 	tokenExchangeClientSecret string
@@ -106,6 +114,7 @@ func newHTTPClient(serverName string, config Server, opts HTTPClientOptions, ses
 		displayName:        complete.First(config.Name, config.ShortName, serverName),
 		headers:            maps.Clone(headers),
 		passthroughHeaders: slices.Clone(config.PassthroughHeaders),
+		oauthRequired:      config.OAuthRequired,
 		waiter:             newWaiter(),
 		needReconnect:      watchesEvents,
 		sessionID:          sessionID,
@@ -493,6 +502,7 @@ func (s *HTTPClient) Start(ctx context.Context, handler WireHandler) error {
 
 	if httpClient := s.oauthHandler.loadFromStorage(s.ctx, s.baseURL); httpClient != nil {
 		s.httpClient = instrumentHTTPClient(httpClient)
+		s.oauthTokenLoaded = true
 		slog.Info("mcp client loaded oauth token from storage", "server", s.serverName)
 	}
 
@@ -553,6 +563,19 @@ func (s *HTTPClient) initialize(ctx context.Context, msg Message) error {
 		// The client is marked as initialized in ensureSSE after it receives a successful response to the initialize request
 		// to avoid a race with marking the client as initialized here and sending the notifications/initialized message.
 		return nil
+	}
+
+	// lazy-auth servers (e.g. BigQuery) return 200 on initialize and only
+	// challenge with 401 on tool-call. When this server is flagged OAuthRequired and
+	// we have no token yet, synthesize an auth-required error so the standard OAuth
+	// flow runs now (Send -> oauthClient: discovery + authorization URL via the
+	// callback handler, using static client creds). Guarded so we never delete/replace
+	// an already-loaded token and never loop.
+	if s.oauthRequired && !s.oauthTokenLoaded && !s.oauthStarted {
+		s.oauthStarted = true
+		return AuthRequiredErr{
+			Err: fmt.Errorf("oauth required for server %s: lazy-auth server returned 200 on initialize with no token", s.serverName),
+		}
 	}
 
 	sessionID := resp.Header.Get(SessionIDHeader)

--- a/pkg/mcp/httpclient_test.go
+++ b/pkg/mcp/httpclient_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -42,4 +43,34 @@ func TestHTTPClientPassthroughHeaders(t *testing.T) {
 	if got := outgoing.Header.Get("X-Not-Allowed"); got != "" {
 		t.Fatalf("X-Not-Allowed = %q, want empty", got)
 	}
+}
+
+// a lazy-auth server (e.g. BigQuery) returns 200 on initialize with no 401
+// challenge. When the server is flagged OAuthRequired and no token is stored, initialize
+// must still surface AuthRequiredErr so the standard OAuth flow runs.
+func TestHTTPClientOAuthRequiredTriggersOnClean200(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(SessionIDHeader, "sess-1")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	defer ts.Close()
+
+	initMsg, err := NewMessage("initialize", InitializeRequest{ProtocolVersion: "2025-06-18"})
+	if err != nil {
+		t.Fatalf("NewMessage: %v", err)
+	}
+
+	// OAuthRequired=true, no stored token (Start not called -> oauthTokenLoaded stays false):
+	// a clean 200 must be turned into an auth-required error.
+	c, err := newHTTPClient("test", Server{BaseURL: ts.URL, OAuthRequired: true}, HTTPClientOptions{}, nil, nil, false)
+	if err != nil {
+		t.Fatalf("newHTTPClient: %v", err)
+	}
+	err = c.initialize(context.Background(), *initMsg)
+	if _, ok := errors.AsType[AuthRequiredErr](err); !ok {
+		t.Fatalf("OAuthRequired=true on clean 200: want AuthRequiredErr, got %v", err)
+	}
+	// The guard fields (oauthTokenLoaded / oauthStarted) are exercised via the e2e path;
+	// here we keep to the synthetic-trigger assertion which returns before any wire I/O.
 }

--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -178,7 +178,9 @@ func oauthResourceMetadataURL(baseURL, authenticateHeader string) (string, strin
 	}
 	if resourceMetadataURL == "" {
 		// If the authenticate header was not sent back or it did not have a resource metadata URL, then the spec says we should default to...
-		u.Path = "/.well-known/oauth-protected-resource"
+		// RFC 9728 §3.1: the well-known segment is inserted between host and the resource path (path-aware),
+		// preserving any path component (e.g. /mcp-connect/{id}) and the original scheme of the base URL.
+		u.Path = "/.well-known/oauth-protected-resource" + strings.TrimSuffix(u.Path, "/")
 		resourceMetadataURL = u.String()
 	}
 

--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -341,7 +341,12 @@ func GetOAuthMetadata(ctx context.Context, server Server, clientName, redirectUR
 	if err != nil {
 		return OAuthMetadata{}, err
 	}
-	if initialized {
+	// A clean `initialize` (no 401) normally means the server needs no OAuth, so
+	// we skip discovery. But some servers only challenge on tool calls and never
+	// at connect, while still publishing protected-resource metadata; when the
+	// caller marks the server as OAuthRequired, discover anyway so OAuth is set
+	// up now rather than failing later.
+	if initialized && !server.OAuthRequired {
 		return OAuthMetadata{}, nil
 	}
 
@@ -491,9 +496,11 @@ func getAuthServerMetadata(ctx context.Context, client *http.Client, authURL str
 	if authorizationServerMetadataContent.TokenEndpoint == "" {
 		authorizationServerMetadataContent.TokenEndpoint = fmt.Sprintf("%s/token", authServerURL)
 	}
-	if authorizationServerMetadataContent.RegistrationEndpoint == "" {
-		authorizationServerMetadataContent.RegistrationEndpoint = fmt.Sprintf("%s/register", authServerURL)
-	}
+	// do NOT fabricate a registration endpoint. An absent registration_endpoint
+	// means the authorization server does not support RFC 7591 dynamic client registration
+	// (e.g. Google / accounts.google.com). Fabricating {issuer}/register sends a doomed DCR
+	// request (Google answers 400). Leaving it empty makes the flow rely on static client
+	// credentials (clientLookup) instead, which is the correct behavior for these servers.
 
 	return authorizationServerMetadataContent, metadataURL, authorizationServerMetadataJSON, true, nil
 }

--- a/pkg/mcp/oauth_test.go
+++ b/pkg/mcp/oauth_test.go
@@ -165,6 +165,62 @@ func TestGetOAuthMetadataInitializeSuccessDeletesSession(t *testing.T) {
 	}
 }
 
+// TestGetOAuthMetadataOAuthRequiredDiscoversOnCleanInitialize covers servers
+// that complete `initialize` without a 401 (auth enforced only on tool calls)
+// yet still publish protected-resource metadata. By default such a server is
+// treated as open (no discovery); when the caller sets OAuthRequired, discovery
+// runs anyway so OAuth is configured at connect time.
+func TestGetOAuthMetadataOAuthRequiredDiscoversOnCleanInitialize(t *testing.T) {
+	var serverURL string
+	authorizationServerMetadata := json.RawMessage(`{"issuer":"issuer","authorization_endpoint":"authorize","token_endpoint":"token","response_types_supported":["code"]}`)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch {
+		case req.Method == http.MethodPost && req.URL.Path == "/":
+			// initialize succeeds without an auth challenge.
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{}})
+		case req.URL.Path == "/.well-known/oauth-protected-resource":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"resource":              serverURL,
+				"authorization_servers": []string{serverURL},
+				"scopes_supported":      []string{"data.read"},
+			})
+		case req.URL.Path == "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(authorizationServerMetadata)
+		default:
+			http.NotFound(w, req)
+		}
+	}))
+	defer ts.Close()
+	serverURL = ts.URL
+
+	// Default (OAuthRequired=false): a clean initialize is treated as open.
+	openResult, err := GetOAuthMetadata(context.Background(), Server{BaseURL: ts.URL}, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if openResult.ProtectedResourceMetadataURL != "" || len(openResult.ProtectedResourceMetadata) != 0 {
+		t.Fatalf("expected empty result without OAuthRequired: %#v", openResult)
+	}
+
+	// OAuthRequired=true: discover even though initialize succeeded.
+	result, err := GetOAuthMetadata(context.Background(), Server{BaseURL: ts.URL, OAuthRequired: true}, "Test Client", "http://localhost/callback")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := ts.URL + "/.well-known/oauth-protected-resource"; result.ProtectedResourceMetadataURL != want {
+		t.Fatalf("protected resource metadata URL:\n got: %s\nwant: %s", result.ProtectedResourceMetadataURL, want)
+	}
+	var clientRegistration ClientRegistrationMetadata
+	if err := json.Unmarshal(result.ClientRegistration, &clientRegistration); err != nil {
+		t.Fatalf("failed to parse client registration metadata: %v", err)
+	}
+	if clientRegistration.Scope != "data.read" {
+		t.Fatalf("unexpected scope: %q", clientRegistration.Scope)
+	}
+}
+
 func TestGetOAuthMetadataAuthorizationServerNoRegistration(t *testing.T) {
 	var serverURL string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Some MCP servers (e.g. Google's hosted BigQuery MCP) complete `initialize` with HTTP 200 and only challenge with 401 on the first tool call, yet still publish RFC 9728 protected-resource metadata. Today the client treats a clean `initialize` as "no auth needed" and then fails on the first tool call.

This adds an opt-in to handle that class of servers:

- `Server.OAuthRequired`: discover OAuth metadata even when `initialize` succeeds without a challenge.
- When `OAuthRequired` is set and no token is stored, surface `AuthRequiredErr` on a clean `initialize` so the normal OAuth flow runs at connect time (guarded so a stored token is never dropped and the flow can't loop).
- Stop fabricating a `{issuer}/register` endpoint when the authorization server does not advertise one: an absent `registration_endpoint` means no RFC 7591 dynamic client registration (e.g. Google), so the flow should rely on static client credentials instead of sending a doomed DCR request.

Tests: `TestGetOAuthMetadataOAuthRequiredDiscoversOnCleanInitialize`, `TestHTTPClientOAuthRequiredTriggersOnClean200`.

Depends on #327 (path-aware protected-resource discovery) — lazy-auth servers reached under a sub-path need it to locate their PRM.

Validated end-to-end with a downstream consumer (obot) brokering per-user OAuth to a Google BigQuery MCP behind a composite server; obot integration changes will reference this PR.