### PR TITLE
chore: only support authorization_code and refresh_token in OAuth

### DIFF
--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -879,12 +879,7 @@ func AuthServerMetadataToClientRegistration(authServer AuthorizationServerMetada
 		merged.TokenEndpointAuthMethod = "client_secret_basic"
 	}
 
-	// grant_types: default is "authorization_code" if not specified
-	if len(authServer.GrantTypesSupported) > 0 {
-		merged.GrantTypes = authServer.GrantTypesSupported
-	} else {
-		merged.GrantTypes = []string{"authorization_code"}
-	}
+	merged.GrantTypes = supportedClientGrantTypes(authServer.GrantTypesSupported)
 
 	// response_types: default is "code" if not specified
 	if len(authServer.ResponseTypesSupported) > 0 {
@@ -904,6 +899,22 @@ func AuthServerMetadataToClientRegistration(authServer AuthorizationServerMetada
 	}
 
 	return merged
+}
+
+func supportedClientGrantTypes(grantTypesSupported []string) []string {
+	supported := make(map[string]struct{}, len(grantTypesSupported))
+	for _, grantType := range grantTypesSupported {
+		supported[grantType] = struct{}{}
+	}
+
+	var grantTypes []string
+	for _, grantType := range []string{"authorization_code", "refresh_token"} {
+		if _, ok := supported[grantType]; ok {
+			grantTypes = append(grantTypes, grantType)
+		}
+	}
+
+	return grantTypes
 }
 
 // clientRegistrationResponse represents OAuth 2.0 Dynamic Client Registration Response

--- a/pkg/mcp/oauth_test.go
+++ b/pkg/mcp/oauth_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"sync/atomic"
 	"testing"
 
@@ -107,6 +108,43 @@ func TestGetOAuthMetadata(t *testing.T) {
 	}
 	if clientRegistration.Scope != "read" {
 		t.Fatalf("unexpected scope: %s", clientRegistration.Scope)
+	}
+	if !slices.Equal(clientRegistration.GrantTypes, []string{"authorization_code"}) {
+		t.Fatalf("unexpected grant types: %v", clientRegistration.GrantTypes)
+	}
+}
+
+func TestAuthServerMetadataToClientRegistrationFiltersGrantTypes(t *testing.T) {
+	tests := []struct {
+		name      string
+		supported []string
+		want      []string
+	}{
+		{
+			name:      "keeps only authorization code and refresh token",
+			supported: []string{"client_credentials", "refresh_token", "authorization_code", "implicit"},
+			want:      []string{"authorization_code", "refresh_token"},
+		},
+		{
+			name:      "omits unsupported grant types",
+			supported: []string{"client_credentials", "implicit"},
+		},
+		{
+			name:      "keeps refresh token when advertised",
+			supported: []string{"refresh_token"},
+			want:      []string{"refresh_token"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientRegistration := AuthServerMetadataToClientRegistration(AuthorizationServerMetadata{
+				GrantTypesSupported: tt.supported,
+			}, "", "", "")
+			if !slices.Equal(clientRegistration.GrantTypes, tt.want) {
+				t.Fatalf("unexpected grant types: got %v, want %v", clientRegistration.GrantTypes, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
There are a couple other grant_types that are supported by dynamic client registration, but these two are the only ones we realistically support. Furthermore, an authorization server could report that it supports other grant_types that are not supported for dynamic client registration, which would fail if we include them in the client registration request.

Issue: https://github.com/obot-platform/obot/issues/7018