### PR TITLE
fix: support MCP servers with empty ToolOverrides

### DIFF
--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -54,6 +54,7 @@ func TestSchema(t *testing.T) {
 	"mcpServers": {
 		"server1": {
 			"command": "command1",
+			"noTools": true,
 			"workdir": "/path/to/workdir",
 			"args": ["arg1", "arg2"],
 			"url": "http://example.com",

--- a/pkg/config/schema.yaml
+++ b/pkg/config/schema.yaml
@@ -377,6 +377,10 @@ definitions:
           or input schema, or to disable specific tools.
         additionalProperties:
           $ref: "#/definitions/ToolOverride"
+      noTools:
+        type: boolean
+        description: |
+          Disable all tools from this MCP Server. Prompts and resources remain available.
       toolPrefix:
         type: string
         description: |

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -20,6 +20,7 @@ import (
 type Client struct {
 	Session       *Session
 	serverName    string
+	noTools       bool
 	toolOverrides ToolOverrides
 	toolPrefix    string
 }
@@ -157,6 +158,7 @@ type Server struct {
 	// If providing tool overrides, any tools not included will be implicitly disabled.
 	// If providing no tool overrides, all tools will be enabled.
 	ToolOverrides ToolOverrides `json:"toolOverrides,omitzero"`
+	NoTools       bool          `json:"noTools,omitempty"`
 
 	// ToolPrefix is prepended to the name of every tool this server exposes
 	// (after any ToolOverrides rename). Incoming tool calls are stripped of the
@@ -380,6 +382,7 @@ func NewClient(ctx context.Context, serverName string, config Server, opts ...Cl
 	c := &Client{
 		Session:       session,
 		serverName:    serverName,
+		noTools:       config.NoTools,
 		toolOverrides: config.ToolOverrides,
 		toolPrefix:    config.ToolPrefix,
 	}
@@ -538,6 +541,10 @@ func (c *Client) ListTools(ctx context.Context) (*ListToolsResult, error) {
 	ctx, span := startOutboundSpan(ctx, "mcp.tools.list",
 		attribute.String("mcp.server.name", c.serverName),
 	)
+	if c.noTools {
+		finishOutboundSpan(span, nil)
+		return &ListToolsResult{}, nil
+	}
 	if c.Session.InitializeResult.Capabilities.Tools == nil {
 		finishOutboundSpan(span, nil)
 		return &ListToolsResult{}, nil
@@ -545,7 +552,7 @@ func (c *Client) ListTools(ctx context.Context) (*ListToolsResult, error) {
 
 	var tools ListToolsResult
 	err := c.Session.Exchange(ctx, "tools/list", struct{}{}, &tools)
-	if err == nil && len(c.toolOverrides) > 0 {
+	if err == nil && c.toolOverrides != nil {
 		filtered := tools.Tools[:0] // reuse the backing array
 		for _, tool := range tools.Tools {
 			override, ok := c.toolOverrides[tool.Name]

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -158,7 +158,8 @@ type Server struct {
 	// If providing tool overrides, any tools not included will be implicitly disabled.
 	// If providing no tool overrides, all tools will be enabled.
 	ToolOverrides ToolOverrides `json:"toolOverrides,omitzero"`
-	NoTools       bool          `json:"noTools,omitempty"`
+	// NoTools is used to differentiate between empty ToolOverrides meaning "all enabled" or "none enalbed"
+	NoTools bool `json:"noTools,omitempty"`
 
 	// ToolPrefix is prepended to the name of every tool this server exposes
 	// (after any ToolOverrides rename). Incoming tool calls are stripped of the

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -542,11 +542,7 @@ func (c *Client) ListTools(ctx context.Context) (*ListToolsResult, error) {
 	ctx, span := startOutboundSpan(ctx, "mcp.tools.list",
 		attribute.String("mcp.server.name", c.serverName),
 	)
-	if c.noTools {
-		finishOutboundSpan(span, nil)
-		return &ListToolsResult{}, nil
-	}
-	if c.Session.InitializeResult.Capabilities.Tools == nil {
+	if c.noTools || c.Session.InitializeResult.Capabilities.Tools == nil {
 		finishOutboundSpan(span, nil)
 		return &ListToolsResult{}, nil
 	}

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -158,7 +158,7 @@ type Server struct {
 	// If providing tool overrides, any tools not included will be implicitly disabled.
 	// If providing no tool overrides, all tools will be enabled.
 	ToolOverrides ToolOverrides `json:"toolOverrides,omitzero"`
-	// NoTools is used to differentiate between empty ToolOverrides meaning "all enabled" or "none enalbed"
+	// NoTools is used to differentiate between empty ToolOverrides meaning "all enabled" or "none enabled"
 	NoTools bool `json:"noTools,omitempty"`
 
 	// ToolPrefix is prepended to the name of every tool this server exposes

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -620,20 +620,17 @@ func (c *Client) Call(ctx context.Context, tool string, args any, opts ...CallOp
 	// A non-nil ToolOverrides map is an allow-list: tools absent from it are
 	// hidden from tools/list and must not be callable by their upstream name.
 	if c.toolOverrides != nil {
-		var ok bool
-		for name, o := range c.toolOverrides {
-			if tool == name {
-				ok = true
-				break
+		if _, ok := c.toolOverrides[tool]; !ok {
+			for name, o := range c.toolOverrides {
+				if o.Name != "" && tool == o.Name {
+					tool = name
+					ok = true
+					break
+				}
 			}
-			if o.Name != "" && tool == o.Name {
-				tool = name
-				ok = true
-				break
+			if !ok {
+				return result, fmt.Errorf("tool %q not found", tool)
 			}
-		}
-		if !ok {
-			return result, fmt.Errorf("tool %q not found", tool)
 		}
 	}
 

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -552,7 +552,7 @@ func (c *Client) ListTools(ctx context.Context) (*ListToolsResult, error) {
 
 	var tools ListToolsResult
 	err := c.Session.Exchange(ctx, "tools/list", struct{}{}, &tools)
-	if err == nil && c.toolOverrides != nil {
+	if err == nil && len(c.toolOverrides) > 0 {
 		filtered := tools.Tools[:0] // reuse the backing array
 		for _, tool := range tools.Tools {
 			override, ok := c.toolOverrides[tool.Name]
@@ -617,10 +617,14 @@ func (c *Client) Call(ctx context.Context, tool string, args any, opts ...CallOp
 	// rename — the upstream server only knows the original (or override) name.
 	tool = strings.TrimPrefix(tool, c.toolPrefix)
 
-	// A non-nil ToolOverrides map is an allow-list: tools absent from it are
+	// A non-empty ToolOverrides map is an allow-list: tools absent from it are
 	// hidden from tools/list and must not be callable by their upstream name.
-	if c.toolOverrides != nil {
-		if _, ok := c.toolOverrides[tool]; !ok {
+	if len(c.toolOverrides) > 0 {
+		if override, ok := c.toolOverrides[tool]; ok {
+			if override.Name != "" && override.Name != tool {
+				return result, fmt.Errorf("tool %q not found", tool)
+			}
+		} else {
 			for name, o := range c.toolOverrides {
 				if o.Name != "" && tool == o.Name {
 					tool = name

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -607,7 +607,7 @@ func (c *Client) Call(ctx context.Context, tool string, args any, opts ...CallOp
 	opt := complete.Complete(opts...)
 	result = new(CallToolResult)
 	if c.noTools {
-		return result, fmt.Errorf("no tools available")
+		return result, fmt.Errorf("no tools allowed")
 	}
 
 	// Strip the per-server tool prefix before reverse-resolving any override

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -621,21 +621,20 @@ func (c *Client) Call(ctx context.Context, tool string, args any, opts ...CallOp
 	// A non-empty ToolOverrides map is an allow-list: tools absent from it are
 	// hidden from tools/list and must not be callable by their upstream name.
 	if len(c.toolOverrides) > 0 {
-		if override, ok := c.toolOverrides[tool]; ok {
-			if override.Name != "" && override.Name != tool {
-				return result, fmt.Errorf("tool %q not found", tool)
+		found := false
+		for name, o := range c.toolOverrides {
+			if tool == name && (o.Name == "" || o.Name == tool) {
+				found = true
+				break
 			}
-		} else {
-			for name, o := range c.toolOverrides {
-				if o.Name != "" && tool == o.Name {
-					tool = name
-					ok = true
-					break
-				}
+			if o.Name != "" && tool == o.Name {
+				tool = name
+				found = true
+				break
 			}
-			if !ok {
-				return result, fmt.Errorf("tool %q not found", tool)
-			}
+		}
+		if !found {
+			return result, fmt.Errorf("tool %q not found", tool)
 		}
 	}
 

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -609,15 +609,31 @@ func (c CallOption) Merge(other CallOption) (result CallOption) {
 func (c *Client) Call(ctx context.Context, tool string, args any, opts ...CallOption) (result *CallToolResult, err error) {
 	opt := complete.Complete(opts...)
 	result = new(CallToolResult)
+	if c.noTools {
+		return result, fmt.Errorf("no tools available")
+	}
 
 	// Strip the per-server tool prefix before reverse-resolving any override
 	// rename — the upstream server only knows the original (or override) name.
 	tool = strings.TrimPrefix(tool, c.toolPrefix)
 
-	for name, o := range c.toolOverrides {
-		if o.Name != "" && tool == o.Name {
-			tool = name
-			break
+	// A non-nil ToolOverrides map is an allow-list: tools absent from it are
+	// hidden from tools/list and must not be callable by their upstream name.
+	if c.toolOverrides != nil {
+		var ok bool
+		for name, o := range c.toolOverrides {
+			if tool == name {
+				ok = true
+				break
+			}
+			if o.Name != "" && tool == o.Name {
+				tool = name
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return result, fmt.Errorf("tool %q not found", tool)
 		}
 	}
 

--- a/pkg/mcp/client_test.go
+++ b/pkg/mcp/client_test.go
@@ -1,7 +1,9 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -12,5 +14,29 @@ func TestServerUnmarshalJSONNoTools(t *testing.T) {
 	}
 	if !server.NoTools {
 		t.Fatal("expected noTools true")
+	}
+}
+
+func TestClientListToolsNoToolsDoesNotNeedSession(t *testing.T) {
+	tools, err := (&Client{noTools: true}).ListTools(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tools.Tools) != 0 {
+		t.Fatalf("expected no tools, got %#v", tools.Tools)
+	}
+}
+
+func TestClientCallNoToolsDoesNotNeedSession(t *testing.T) {
+	_, err := (&Client{noTools: true}).Call(context.Background(), "hidden", nil)
+	if err == nil || !strings.Contains(err.Error(), "no tools available") {
+		t.Fatalf("expected no tools error, got %v", err)
+	}
+}
+
+func TestClientCallToolOverridesDisableAbsentTool(t *testing.T) {
+	_, err := (&Client{toolOverrides: ToolOverrides{"allowed": {}}}).Call(context.Background(), "hidden", nil)
+	if err == nil || !strings.Contains(err.Error(), `tool "hidden" not found`) {
+		t.Fatalf("expected tool not found error, got %v", err)
 	}
 }

--- a/pkg/mcp/client_test.go
+++ b/pkg/mcp/client_test.go
@@ -36,3 +36,11 @@ func TestClientCallToolOverridesDisableOriginalRenamedTool(t *testing.T) {
 		t.Fatalf("expected tool not found error, got %v", err)
 	}
 }
+
+func TestClientCallEmptyToolOverridesDoesNotDisableTools(t *testing.T) {
+	s := NewEmptySession(t.Context())
+	_, err := (&Client{Session: s, toolOverrides: ToolOverrides{}}).Call(context.Background(), "someTool", nil)
+	if err == nil || strings.Contains(err.Error(), `tool "someTool" not found`) {
+		t.Fatalf("expected call to reach session exchange (not be blocked by empty ToolOverrides), got %v", err)
+	}
+}

--- a/pkg/mcp/client_test.go
+++ b/pkg/mcp/client_test.go
@@ -18,7 +18,7 @@ func TestClientListToolsNoToolsDoesNotNeedSession(t *testing.T) {
 
 func TestClientCallNoToolsDoesNotNeedSession(t *testing.T) {
 	_, err := (&Client{noTools: true}).Call(context.Background(), "hidden", nil)
-	if err == nil || !strings.Contains(err.Error(), "no tools available") {
+	if err == nil || !strings.Contains(err.Error(), "no tools allowed") {
 		t.Fatalf("expected no tools error, got %v", err)
 	}
 }

--- a/pkg/mcp/client_test.go
+++ b/pkg/mcp/client_test.go
@@ -1,0 +1,16 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestServerUnmarshalJSONNoTools(t *testing.T) {
+	var server Server
+	if err := json.Unmarshal([]byte(`{"url":"https://example.com/mcp","noTools":true}`), &server); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !server.NoTools {
+		t.Fatal("expected noTools true")
+	}
+}

--- a/pkg/mcp/client_test.go
+++ b/pkg/mcp/client_test.go
@@ -2,20 +2,9 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"testing"
 )
-
-func TestServerUnmarshalJSONNoTools(t *testing.T) {
-	var server Server
-	if err := json.Unmarshal([]byte(`{"url":"https://example.com/mcp","noTools":true}`), &server); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !server.NoTools {
-		t.Fatal("expected noTools true")
-	}
-}
 
 func TestClientListToolsNoToolsDoesNotNeedSession(t *testing.T) {
 	tools, err := (&Client{noTools: true}).ListTools(context.Background())
@@ -37,6 +26,13 @@ func TestClientCallNoToolsDoesNotNeedSession(t *testing.T) {
 func TestClientCallToolOverridesDisableAbsentTool(t *testing.T) {
 	_, err := (&Client{toolOverrides: ToolOverrides{"allowed": {}}}).Call(context.Background(), "hidden", nil)
 	if err == nil || !strings.Contains(err.Error(), `tool "hidden" not found`) {
+		t.Fatalf("expected tool not found error, got %v", err)
+	}
+}
+
+func TestClientCallToolOverridesDisableOriginalRenamedTool(t *testing.T) {
+	_, err := (&Client{toolOverrides: ToolOverrides{"original": {Name: "renamed"}}}).Call(context.Background(), "original", nil)
+	if err == nil || !strings.Contains(err.Error(), `tool "original" not found`) {
 		t.Fatalf("expected tool not found error, got %v", err)
 	}
 }


### PR DESCRIPTION
Addresses: https://github.com/obot-platform/obot/issues/7085, https://github.com/obot-platform/obot/issues/7088

Uses NoTools from Obot to differentiate "no tool overrides" from "no tools enabled".

Copilot also suggested updating Call to not allow calls to disabled tools so I made that change as well.