### PR TITLE
feat: support per-request audit log and configuration

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -276,7 +276,7 @@ type mcpOpts struct {
 	StartUI            bool
 }
 
-func (n *Nanobot) runMCP(ctx context.Context, baseConfig types.ConfigFactory, runt *runtime.Runtime, oauthCallbackHandler mcp.CallbackServer, auditLogCollector *auditlogs.Collector, store *session.Store, opts mcpOpts) error {
+func (n *Nanobot) runMCP(ctx context.Context, baseConfig types.ConfigFactory, runt *runtime.Runtime, oauthCallbackHandler mcp.CallbackServer, auditLogCollector auditlogs.Collector, store *session.Store, opts mcpOpts) error {
 	envProvider := func() (map[string]string, error) {
 		return n.loadEnv()
 	}
@@ -322,7 +322,7 @@ func (n *Nanobot) runMCP(ctx context.Context, baseConfig types.ConfigFactory, ru
 		return nil
 	}
 
-	httpServer, err := mcp.NewHTTPServer(ctx, envProvider, mcpServer, mcp.HTTPServerOptions{
+	httpServer, err := mcp.NewHTTPServer(envProvider, mcpServer, mcp.HTTPServerOptions{
 		HealthCheckPath:   opts.HealthzPath,
 		RunHealthChecker:  opts.HealthzPath != "" && os.Getenv("NANOBOT_DISABLE_HEALTH_CHECKER") != "true",
 		SessionStore:      sessionManager,

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -269,11 +269,12 @@ func (n *Nanobot) Run(cmd *cobra.Command, _ []string) error {
 }
 
 type mcpOpts struct {
-	Auth               auth.Auth
-	ListenAddress      string
-	HealthzPath        string
-	ForceFetchToolList bool
-	StartUI            bool
+	Auth                           auth.Auth
+	ListenAddress                  string
+	HealthzPath                    string
+	ForceFetchToolList             bool
+	StartUI                        bool
+	SessionGarbageCollectionPeriod time.Duration
 }
 
 func (n *Nanobot) runMCP(ctx context.Context, baseConfig types.ConfigFactory, runt *runtime.Runtime, oauthCallbackHandler mcp.CallbackServer, auditLogCollector auditlogs.Collector, store *session.Store, opts mcpOpts) error {
@@ -306,7 +307,7 @@ func (n *Nanobot) runMCP(ctx context.Context, baseConfig types.ConfigFactory, ru
 		return fmt.Errorf("https:// is not supported, use http:// instead")
 	}
 
-	sessionManager := session.NewManager(store)
+	sessionManager := session.NewManager(ctx, store, opts.SessionGarbageCollectionPeriod)
 
 	var mcpServer mcp.MessageHandler = server.NewServer(runt, config, sessionManager, server.Options{
 		ForceFetchToolList: opts.ForceFetchToolList,

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -36,6 +36,7 @@ type Run struct {
 	BlockLoopback                bool              `usage:"Block MCP HTTP requests to loopback IP addresses"`
 	BlockPrivateIP               bool              `usage:"Block MCP HTTP requests to private IP addresses"`
 	BlockLinkLocal               bool              `usage:"Block MCP HTTP requests to link-local IP addresses"`
+	AllowedHost                  []string          `usage:"Allow MCP HTTP requests to specific hosts even if they resolve to blocked IP ranges. Supports exact hosts, IPs, and wildcard suffixes like *.example.com; optional :port must match exactly" name:"allow-host"`
 	n                            *Nanobot
 }
 
@@ -146,6 +147,7 @@ func (r *Run) Run(cmd *cobra.Command, args []string) (err error) {
 		BlockLoopback:                 r.BlockLoopback,
 		BlockPrivateIP:                r.BlockPrivateIP,
 		BlockLinkLocal:                r.BlockLinkLocal,
+		AllowedHosts:                  r.AllowedHost,
 	}
 
 	cfgFactory := types.ConfigFactory(func(ctx context.Context, profiles string) (types.Config, error) {

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -182,7 +182,7 @@ func (r *Run) Run(cmd *cobra.Command, args []string) (err error) {
 
 	slog.Info("config", "json", once.Redacted())
 
-	var auditLogCollector *auditlogs.Collector
+	var auditLogCollector *auditlogs.HTTPCollector
 	if r.AuditLogSendURL != "" {
 		auditLogCollector = auditlogs.NewCollector(r.AuditLogSendURL, r.AuditLogToken, r.AuditLogBatchSize, time.Duration(r.AuditLogFlushIntervalSeconds)*time.Second, r.AuditLogMetadata)
 		defer auditLogCollector.Close()

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -31,6 +31,7 @@ type Run struct {
 	AuditLogMetadata             map[string]string `usage:"Metadata to send with audit logs"`
 	AuditLogBatchSize            int               `usage:"Batch size for sending audit logs" default:"1000"`
 	AuditLogFlushIntervalSeconds int               `usage:"Interval for flushing audit logs" default:"5"`
+	SessionGCPeriod              string            `usage:"How long idle sessions are kept before garbage collection; <= 0 disables garbage collection. Examples: 168h, 30m" default:"168h"`
 	Roots                        []string          `usage:"Roots to expose the MCP server in the form of name:directory" short:"r"`
 	EntrypointAgent              string            `usage:"ID of the agent to use for chat" name:"agent"`
 	BlockLoopback                bool              `usage:"Block MCP HTTP requests to loopback IP addresses"`
@@ -126,6 +127,11 @@ func (r *Run) Run(cmd *cobra.Command, args []string) (err error) {
 		return fmt.Errorf("trusted issuer and audience must be set together")
 	}
 
+	sessionGarbageCollectionPeriod, err := time.ParseDuration(r.SessionGCPeriod)
+	if err != nil {
+		return fmt.Errorf("invalid session GC period %q: %w", r.SessionGCPeriod, err)
+	}
+
 	roots, err := r.getRoots()
 	if err != nil {
 		return err
@@ -205,10 +211,11 @@ func (r *Run) Run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	return r.n.runMCP(cmd.Context(), cfgFactory, runtime, callbackHandler, auditLogCollector, store, mcpOpts{
-		Auth:               auth.Auth(r.Auth),
-		ListenAddress:      r.ListenAddress,
-		HealthzPath:        r.HealthzPath,
-		ForceFetchToolList: r.ForceFetchToolList,
-		StartUI:            !r.DisableUI,
+		Auth:                           auth.Auth(r.Auth),
+		ListenAddress:                  r.ListenAddress,
+		HealthzPath:                    r.HealthzPath,
+		ForceFetchToolList:             r.ForceFetchToolList,
+		StartUI:                        !r.DisableUI,
+		SessionGarbageCollectionPeriod: sessionGarbageCollectionPeriod,
 	})
 }

--- a/pkg/mcp/auditlogs/collector.go
+++ b/pkg/mcp/auditlogs/collector.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"sync"
 	"time"
@@ -13,7 +14,12 @@ import (
 	"log/slog"
 )
 
-type Collector struct {
+type Collector interface {
+	CollectMCPAuditEntry(entry MCPAuditLog)
+	Close()
+}
+
+type HTTPCollector struct {
 	auditBuffer      []MCPAuditLog
 	auditLock        sync.Mutex
 	auditLogMetadata map[string]string
@@ -22,8 +28,8 @@ type Collector struct {
 	sendURL, token   string
 }
 
-func NewCollector(sendURL, token string, batchSize int, flushInterval time.Duration, auditLogMetadata map[string]string) *Collector {
-	c := &Collector{
+func NewCollector(sendURL, token string, batchSize int, flushInterval time.Duration, auditLogMetadata map[string]string) *HTTPCollector {
+	c := &HTTPCollector{
 		sendURL:          sendURL,
 		token:            token,
 		done:             make(chan struct{}),
@@ -38,7 +44,7 @@ func NewCollector(sendURL, token string, batchSize int, flushInterval time.Durat
 }
 
 // Close closes the collector and waits for all pending audit logs to be persisted.
-func (c *Collector) Close() {
+func (c *HTTPCollector) Close() {
 	if c == nil {
 		return
 	}
@@ -47,14 +53,18 @@ func (c *Collector) Close() {
 	<-c.done
 }
 
-func (c *Collector) CollectMCPAuditEntry(entry MCPAuditLog) {
+func (c *HTTPCollector) CollectMCPAuditEntry(entry MCPAuditLog) {
 	if c == nil || entry.CallType == "" {
 		// If the call type is empty, then this is a response to a request.
 		// The audit log will be handled elsewhere.
 		return
 	}
 
-	entry.Metadata = c.auditLogMetadata
+	if len(c.auditLogMetadata) != 0 {
+		merged := maps.Clone(c.auditLogMetadata)
+		maps.Copy(merged, entry.Metadata)
+		entry.Metadata = merged
+	}
 
 	c.auditLock.Lock()
 	defer c.auditLock.Unlock()
@@ -68,7 +78,7 @@ func (c *Collector) CollectMCPAuditEntry(entry MCPAuditLog) {
 	}
 }
 
-func (c *Collector) runPersistenceLoop(flushInterval time.Duration) {
+func (c *HTTPCollector) runPersistenceLoop(flushInterval time.Duration) {
 	timer := time.NewTimer(flushInterval)
 	defer timer.Stop()
 	defer close(c.done)
@@ -93,7 +103,7 @@ func (c *Collector) runPersistenceLoop(flushInterval time.Duration) {
 	}
 }
 
-func (c *Collector) persistAuditLogs() error {
+func (c *HTTPCollector) persistAuditLogs() error {
 	c.auditLock.Lock()
 	if len(c.auditBuffer) == 0 {
 		c.auditLock.Unlock()
@@ -117,7 +127,7 @@ func (c *Collector) persistAuditLogs() error {
 	return nil
 }
 
-func (c *Collector) sendMCPAuditLogs(ctx context.Context, logs []MCPAuditLog) error {
+func (c *HTTPCollector) sendMCPAuditLogs(ctx context.Context, logs []MCPAuditLog) error {
 	h := http.Client{
 		Timeout: 10 * time.Second,
 	}

--- a/pkg/mcp/auditlogs/noop.go
+++ b/pkg/mcp/auditlogs/noop.go
@@ -1,0 +1,11 @@
+package auditlogs
+
+type noopAuditLogCollector struct{}
+
+func NewNoopCollector() Collector {
+	return new(noopAuditLogCollector)
+}
+
+func (*noopAuditLogCollector) CollectMCPAuditEntry(log MCPAuditLog) {}
+
+func (*noopAuditLogCollector) Close() {}

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -124,6 +124,7 @@ func (c ClientOption) Merge(other ClientOption) (result ClientOption) {
 	result.BlockLoopback = c.BlockLoopback || other.BlockLoopback
 	result.BlockPrivateIP = c.BlockPrivateIP || other.BlockPrivateIP
 	result.BlockLinkLocal = c.BlockLinkLocal || other.BlockLinkLocal
+	result.AllowedHosts = append(c.AllowedHosts, other.AllowedHosts...)
 	result.OAuthClientName = complete.Last(c.OAuthClientName, other.OAuthClientName)
 	result.Env = complete.MergeMap(c.Env, other.Env)
 	result.SessionState = complete.Last(c.SessionState, other.SessionState)

--- a/pkg/mcp/context.go
+++ b/pkg/mcp/context.go
@@ -62,6 +62,17 @@ func AuditLogFromContext(ctx context.Context) *auditlogs.MCPAuditLog {
 	return auditLog
 }
 
+type auditLogMetadataKey struct{}
+
+func WithAuditLogMetadata(ctx context.Context, metadata map[string]string) context.Context {
+	return context.WithValue(ctx, auditLogMetadataKey{}, metadata)
+}
+
+func AuditLogMetadataFromContext(ctx context.Context) map[string]string {
+	metadata, _ := ctx.Value(auditLogMetadataKey{}).(map[string]string)
+	return metadata
+}
+
 type mcpServerConfigKey struct{}
 
 func WithMCPServerConfig(ctx context.Context, config Server) context.Context {

--- a/pkg/mcp/httpclient.go
+++ b/pkg/mcp/httpclient.go
@@ -72,6 +72,7 @@ type HTTPClient struct {
 	blockLoopback  bool
 	blockPrivateIP bool
 	blockLinkLocal bool
+	allowedHosts   []string
 }
 
 type HTTPClientOptions struct {
@@ -87,6 +88,7 @@ type HTTPClientOptions struct {
 	BlockLoopback                 bool
 	BlockPrivateIP                bool
 	BlockLinkLocal                bool
+	AllowedHosts                  []string
 }
 
 func newHTTPClient(serverName string, config Server, opts HTTPClientOptions, sessionState *SessionState, headers map[string]string, watchesEvents bool) (*HTTPClient, error) {
@@ -107,9 +109,9 @@ func newHTTPClient(serverName string, config Server, opts HTTPClientOptions, ses
 	}
 
 	return &HTTPClient{
-		httpClient: newSafeHTTPClient(opts.BlockLoopback, opts.BlockPrivateIP, opts.BlockLinkLocal, http.DefaultClient.Timeout),
+		httpClient: newSafeHTTPClient(opts.BlockLoopback, opts.BlockPrivateIP, opts.BlockLinkLocal, opts.AllowedHosts, http.DefaultClient.Timeout),
 		oauthHandler: newOAuth(
-			newSafeHTTPClient(opts.BlockLoopback, opts.BlockPrivateIP, opts.BlockLinkLocal, 5*time.Second),
+			newSafeHTTPClient(opts.BlockLoopback, opts.BlockPrivateIP, opts.BlockLinkLocal, opts.AllowedHosts, 5*time.Second),
 			opts.CallbackHandler,
 			opts.ClientCredLookup,
 			opts.TokenStorage,
@@ -134,22 +136,23 @@ func newHTTPClient(serverName string, config Server, opts HTTPClientOptions, ses
 		blockLoopback:             opts.BlockLoopback,
 		blockPrivateIP:            opts.BlockPrivateIP,
 		blockLinkLocal:            opts.BlockLinkLocal,
+		allowedHosts:              slices.Clone(opts.AllowedHosts),
 	}, nil
 }
 
-func newSafeHTTPClient(blockLoopback, blockPrivate, blockLinkLocal bool, timeout time.Duration) *http.Client {
+func newSafeHTTPClient(blockLoopback, blockPrivate, blockLinkLocal bool, allowedHosts []string, timeout time.Duration) *http.Client {
 	// Create an HTTP client with the default timeout and configured address blocking.
-	return instrumentHTTPClient(safehttp.NewClientWithTimeout(blockLoopback, blockPrivate, blockLinkLocal, timeout))
+	return instrumentHTTPClient(safehttp.NewClientWithAllowListAndTimeout(blockLoopback, blockPrivate, blockLinkLocal, allowedHosts, timeout))
 }
 
 func (s *HTTPClient) instrumentMCPHTTPClient(client *http.Client) *http.Client {
 	if client == nil {
-		return newSafeHTTPClient(s.blockLoopback, s.blockPrivateIP, s.blockLinkLocal, http.DefaultClient.Timeout)
+		return newSafeHTTPClient(s.blockLoopback, s.blockPrivateIP, s.blockLinkLocal, s.allowedHosts, http.DefaultClient.Timeout)
 	}
 	cloned := *client
 	if transport, ok := cloned.Transport.(*oauth2.Transport); ok {
 		transportClone := *transport
-		transportClone.Base = safehttp.NewClient(s.blockLoopback, s.blockPrivateIP, s.blockLinkLocal).Transport
+		transportClone.Base = safehttp.NewClientWithAllowList(s.blockLoopback, s.blockPrivateIP, s.blockLinkLocal, s.allowedHosts).Transport
 		cloned.Transport = &transportClone
 	}
 	return instrumentHTTPClient(&cloned)
@@ -695,7 +698,7 @@ func (s *HTTPClient) Send(ctx context.Context, msg Message) error {
 			// error that we need to continue the process.
 
 			s.clientLock.Lock()
-			s.httpClient = newSafeHTTPClient(s.blockLoopback, s.blockPrivateIP, s.blockLinkLocal, http.DefaultClient.Timeout)
+			s.httpClient = newSafeHTTPClient(s.blockLoopback, s.blockPrivateIP, s.blockLinkLocal, s.allowedHosts, http.DefaultClient.Timeout)
 			s.clientLock.Unlock()
 
 			// Use the exported Send method here so that we catch the AuthRequiredErr above on the recursed call.

--- a/pkg/mcp/httpclient_test.go
+++ b/pkg/mcp/httpclient_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -74,12 +75,42 @@ func TestHTTPClientBlockingOptions(t *testing.T) {
 		t.Fatalf("expected loopback block error, got %v", err)
 	}
 
+	serverURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	allowListed, err := newHTTPClient("test", Server{BaseURL: ts.URL}, HTTPClientOptions{
+		BlockLoopback: true,
+		AllowedHosts:  []string{serverURL.Host},
+	}, nil, nil, false)
+	if err != nil {
+		t.Fatalf("newHTTPClient failed: %v", err)
+	}
+
+	resp, err := allowListed.oauthHandler.metadataClient.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("expected allow-listed loopback metadata request to be allowed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("unexpected status: %d", resp.StatusCode)
+	}
+
+	resp, err = allowListed.httpClient.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("expected allow-listed loopback MCP request to be allowed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("unexpected status: %d", resp.StatusCode)
+	}
+
 	allowed, err := newHTTPClient("test", Server{BaseURL: ts.URL}, HTTPClientOptions{}, nil, nil, false)
 	if err != nil {
 		t.Fatalf("newHTTPClient failed: %v", err)
 	}
 
-	resp, err := allowed.oauthHandler.metadataClient.Get(ts.URL)
+	resp, err = allowed.oauthHandler.metadataClient.Get(ts.URL)
 	if err != nil {
 		t.Fatalf("expected loopback metadata request to be allowed: %v", err)
 	}

--- a/pkg/mcp/httpserver.go
+++ b/pkg/mcp/httpserver.go
@@ -87,7 +87,14 @@ func buildAuditLog(req *http.Request, method string, sessionID string) auditlogs
 	}
 	headersJSON, _ := json.Marshal(sanitizedHeaders)
 
+	metadata := AuditLogMetadataFromContext(req.Context())
+	subject := UserFromContext(req.Context()).Sub
+	if subject == "" {
+		subject = metadata["userID"]
+	}
+
 	return auditlogs.MCPAuditLog{
+		Subject:        subject,
 		CreatedAt:      startTime,
 		ClientIP:       strings.TrimSpace(clientIP),
 		CallType:       method,
@@ -95,6 +102,7 @@ func buildAuditLog(req *http.Request, method string, sessionID string) auditlogs
 		APIKey:         redactedAPIKey,
 		UserAgent:      req.Header.Get("User-Agent"),
 		RequestHeaders: headersJSON,
+		Metadata:       metadata,
 	}
 }
 
@@ -112,7 +120,7 @@ type HTTPServer struct {
 	healthErr       *error
 	healthMu        sync.RWMutex
 
-	auditLogCollector *auditlogs.Collector
+	auditLogCollector auditlogs.Collector
 }
 
 type HTTPServerOptions struct {
@@ -121,7 +129,7 @@ type HTTPServerOptions struct {
 	HealthCheckPath   string
 	ResourceName      string
 	RunHealthChecker  bool
-	AuditLogCollector *auditlogs.Collector
+	AuditLogCollector auditlogs.Collector
 }
 
 func (h HTTPServerOptions) Complete() HTTPServerOptions {
@@ -131,7 +139,9 @@ func (h HTTPServerOptions) Complete() HTTPServerOptions {
 	if h.BaseContext == nil {
 		h.BaseContext = context.Background()
 	}
-
+	if h.AuditLogCollector == nil {
+		h.AuditLogCollector = auditlogs.NewNoopCollector()
+	}
 	if h.ResourceName == "" {
 		h.ResourceName = "Nanobot MCP Server"
 	}
@@ -148,7 +158,7 @@ func (h HTTPServerOptions) Merge(other HTTPServerOptions) (result HTTPServerOpti
 	return h
 }
 
-func NewHTTPServer(ctx context.Context, envProvider func() (map[string]string, error), handler MessageHandler, opts ...HTTPServerOptions) (*HTTPServer, error) {
+func NewHTTPServer(envProvider func() (map[string]string, error), handler MessageHandler, opts ...HTTPServerOptions) (*HTTPServer, error) {
 	o := complete.Complete(opts...)
 	h := &HTTPServer{
 		MessageHandler:    handler,
@@ -321,7 +331,6 @@ func (h *HTTPServer) serveHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	ctx := req.Context()
-	auditLog.Subject = UserFromContext(ctx).Sub
 	if req.Method == http.MethodGet {
 		h.streamEvents(rw, req, auditLog)
 		return
@@ -426,6 +435,7 @@ func (h *HTTPServer) serveHTTP(rw http.ResponseWriter, req *http.Request) {
 		streamingSession.session.Set("subject", auditLog.Subject)
 		streamingSession.session.Set("clientIP", auditLog.ClientIP)
 		streamingSession.session.Set("apiKey", auditLog.APIKey)
+		streamingSession.session.Set("auditLogMetadata", auditLog.Metadata)
 
 		auditLog.ClientName = streamingSession.session.InitializeRequest.ClientInfo.Name
 		auditLog.ClientVersion = streamingSession.session.InitializeRequest.ClientInfo.Version

--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -184,8 +184,6 @@ func oauthResourceMetadataURL(baseURL, authenticateHeader string) (string, strin
 }
 
 func (o *oauth) oauthClient(ctx context.Context, c *HTTPClient, connectURL, authenticateHeader string) (*http.Client, error) {
-	slog.Info("starting oauth flow", "server", c.serverName, "connect_url", connectURL)
-
 	if httpClient := o.loadFromStorage(ctx, connectURL); httpClient != nil {
 		slog.Info("oauth flow skipped, using stored token", "server", c.serverName, "connect_url", connectURL)
 		return httpClient, nil
@@ -194,6 +192,8 @@ func (o *oauth) oauthClient(ctx context.Context, c *HTTPClient, connectURL, auth
 	if o.callbackHandler == nil || o.redirectURL == "" {
 		return nil, fmt.Errorf("oauth callback server is not configured")
 	}
+
+	slog.Info("starting oauth flow", "server", c.serverName, "connect_url", connectURL)
 
 	discovery, ok, err := discoverOAuthMetadata(ctx, o.metadataClient, c.baseURL, authenticateHeader, o.clientName, o.redirectURL, nil)
 	if err != nil {

--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -353,7 +353,11 @@ func GetOAuthMetadataSafely(ctx context.Context, server Server, clientName, redi
 }
 
 func GetOAuthMetadataWithBlockingConfig(ctx context.Context, server Server, clientName, redirectURL string, blockLoopback, blockPrivateIP, blockLinkLocal bool) (OAuthMetadata, error) {
-	return GetOAuthMetadataWithClient(ctx, newSafeHTTPClient(blockLoopback, blockPrivateIP, blockLinkLocal, 5*time.Second), server, clientName, redirectURL)
+	return GetOAuthMetadataWithBlockingConfigAndAllowList(ctx, server, clientName, redirectURL, blockLoopback, blockPrivateIP, blockLinkLocal, nil)
+}
+
+func GetOAuthMetadataWithBlockingConfigAndAllowList(ctx context.Context, server Server, clientName, redirectURL string, blockLoopback, blockPrivateIP, blockLinkLocal bool, allowedHosts []string) (OAuthMetadata, error) {
+	return GetOAuthMetadataWithClient(ctx, newSafeHTTPClient(blockLoopback, blockPrivateIP, blockLinkLocal, allowedHosts, 5*time.Second), server, clientName, redirectURL)
 }
 
 // GetOAuthMetadataWithClient discovers OAuth protected resource and authorization server

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -54,6 +54,7 @@ type Options struct {
 	BlockLoopback                 bool
 	BlockPrivateIP                bool
 	BlockLinkLocal                bool
+	AllowedHosts                  []string
 }
 
 func (o Options) Merge(other Options) (result Options) {
@@ -76,6 +77,7 @@ func (o Options) Merge(other Options) (result Options) {
 	result.BlockLoopback = o.BlockLoopback || other.BlockLoopback
 	result.BlockPrivateIP = o.BlockPrivateIP || other.BlockPrivateIP
 	result.BlockLinkLocal = o.BlockLinkLocal || other.BlockLinkLocal
+	result.AllowedHosts = append(append([]string{}, o.AllowedHosts...), other.AllowedHosts...)
 	return
 }
 
@@ -108,6 +110,7 @@ func NewRuntime(ctx context.Context, cfg llm.Config, opts ...Options) (*Runtime,
 		BlockLoopback:                 opt.BlockLoopback,
 		BlockPrivateIP:                opt.BlockPrivateIP,
 		BlockLinkLocal:                opt.BlockLinkLocal,
+		AllowedHosts:                  opt.AllowedHosts,
 	})
 	agentsService := agents.New(completer, registry)
 	sampler := sampling.NewSampler(agentsService)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -47,7 +47,7 @@ type Options struct {
 	TokenExchangeClientID         string
 	TokenExchangeClientSecret     string
 	OAuthClientIDMetadataDocument string
-	AuditLogCollector             *auditlogs.Collector
+	AuditLogCollector             auditlogs.Collector
 	DefaultModel                  string
 	ConfigDir                     string
 	LoopbackURL                   string

--- a/pkg/safehttp/client.go
+++ b/pkg/safehttp/client.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 )
 
@@ -15,8 +17,20 @@ func NewClient(blockLoopback, blockPrivateIP, blockLinkLocal bool) *http.Client 
 	return NewClientWithTimeout(blockLoopback, blockPrivateIP, blockLinkLocal, defaultTimeout)
 }
 
+// NewClientWithAllowList returns an HTTP client that can block selected local address ranges,
+// except for matching hosts in the allow list.
+func NewClientWithAllowList(blockLoopback, blockPrivateIP, blockLinkLocal bool, allowList []string) *http.Client {
+	return NewClientWithAllowListAndTimeout(blockLoopback, blockPrivateIP, blockLinkLocal, allowList, defaultTimeout)
+}
+
 // NewClientWithTimeout returns an HTTP client that can block selected local address ranges with a custom timeout.
 func NewClientWithTimeout(blockLoopback, blockPrivateIP, blockLinkLocal bool, timeout time.Duration) *http.Client {
+	return NewClientWithAllowListAndTimeout(blockLoopback, blockPrivateIP, blockLinkLocal, nil, timeout)
+}
+
+// NewClientWithAllowListAndTimeout returns an HTTP client that can block selected local address ranges
+// with a custom timeout, except for matching hosts in the allow list.
+func NewClientWithAllowListAndTimeout(blockLoopback, blockPrivateIP, blockLinkLocal bool, allowList []string, timeout time.Duration) *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	dialer := &safeDialer{
 		dialer:         &net.Dialer{},
@@ -24,6 +38,7 @@ func NewClientWithTimeout(blockLoopback, blockPrivateIP, blockLinkLocal bool, ti
 		blockLoopback:  blockLoopback,
 		blockPrivateIP: blockPrivateIP,
 		blockLinkLocal: blockLinkLocal,
+		allowList:      parseAllowList(allowList),
 	}
 	transport.DialContext = dialer.DialContext
 
@@ -40,7 +55,7 @@ type checkingTransport struct {
 
 func (t checkingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if host := req.URL.Hostname(); host != "" {
-		if _, err := t.dialer.checkHost(req.Context(), host); err != nil {
+		if _, err := t.dialer.checkHost(req.Context(), host, portForURL(req.URL)); err != nil {
 			return nil, err
 		}
 	}
@@ -54,6 +69,7 @@ type safeDialer struct {
 	blockLoopback  bool
 	blockPrivateIP bool
 	blockLinkLocal bool
+	allowList      []allowListEntry
 }
 
 func (d *safeDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
@@ -62,7 +78,7 @@ func (d *safeDialer) DialContext(ctx context.Context, network, address string) (
 		return nil, err
 	}
 
-	ips, err := d.checkHost(ctx, host)
+	ips, err := d.checkHost(ctx, host, port)
 	if err != nil {
 		return nil, err
 	}
@@ -81,17 +97,40 @@ func (d *safeDialer) DialContext(ctx context.Context, network, address string) (
 	return nil, fmt.Errorf("address %s resolved to no IP addresses", host)
 }
 
-func (d *safeDialer) checkHost(ctx context.Context, host string) ([]net.IP, error) {
+func (d *safeDialer) checkHost(ctx context.Context, host, port string) ([]net.IP, error) {
 	ips, err := d.lookup(ctx, host)
 	if err != nil {
 		return nil, err
 	}
+	if d.isAllowed(host, port) {
+		return ips, nil
+	}
+
 	for _, ip := range ips {
 		if reason := d.blockedReason(ip); reason != "" {
 			return nil, fmt.Errorf("address %s resolves to blocked %s IP %s", host, reason, ip)
 		}
 	}
 	return ips, nil
+}
+
+func (d *safeDialer) isAllowed(host, port string) bool {
+	host = normalizeHost(host)
+	for _, entry := range d.allowList {
+		if entry.port != "" && entry.port != port {
+			continue
+		}
+		if entry.suffix {
+			if strings.HasSuffix(host, entry.host) && host != entry.host {
+				return true
+			}
+			continue
+		}
+		if host == entry.host {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *safeDialer) lookup(ctx context.Context, host string) ([]net.IP, error) {
@@ -125,4 +164,84 @@ func (d *safeDialer) blockedReason(ip net.IP) string {
 		return "link-local"
 	}
 	return ""
+}
+
+type allowListEntry struct {
+	host   string
+	port   string
+	suffix bool
+}
+
+func parseAllowList(entries []string) []allowListEntry {
+	result := make([]allowListEntry, 0, len(entries))
+	for _, entry := range entries {
+		parsed, ok := parseAllowListEntry(entry)
+		if ok {
+			result = append(result, parsed)
+		}
+	}
+	return result
+}
+
+func parseAllowListEntry(entry string) (allowListEntry, bool) {
+	entry = strings.TrimSpace(entry)
+	if entry == "" {
+		return allowListEntry{}, false
+	}
+
+	host, port := splitAllowListHostPort(entry)
+	host = normalizeHost(host)
+	if host == "" {
+		return allowListEntry{}, false
+	}
+
+	host, suffix := strings.CutPrefix(host, "*")
+	if suffix {
+		if host == "" || !strings.HasPrefix(host, ".") || strings.Contains(host, "*") {
+			return allowListEntry{}, false
+		}
+	} else if strings.Contains(host, "*") {
+		return allowListEntry{}, false
+	}
+
+	return allowListEntry{
+		host:   host,
+		port:   port,
+		suffix: suffix,
+	}, true
+}
+
+func splitAllowListHostPort(entry string) (string, string) {
+	if host, port, err := net.SplitHostPort(entry); err == nil {
+		return host, port
+	}
+	if strings.Count(entry, ":") == 1 {
+		host, port, ok := strings.Cut(entry, ":")
+		if ok && host != "" && port != "" {
+			return host, port
+		}
+	}
+	return entry, ""
+}
+
+func normalizeHost(host string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+	host = strings.TrimPrefix(host, "[")
+	host = strings.TrimSuffix(host, "]")
+	host = strings.TrimSuffix(host, ".")
+	return host
+}
+
+func portForURL(u *url.URL) string {
+	if port := u.Port(); port != "" {
+		return port
+	}
+	switch u.Scheme {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	default:
+		return ""
+	}
 }

--- a/pkg/safehttp/client_test.go
+++ b/pkg/safehttp/client_test.go
@@ -3,6 +3,7 @@ package safehttp
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -71,5 +72,140 @@ func TestClientAllowsExplicitlyDisabledBlockedRanges(t *testing.T) {
 
 	if resp.StatusCode != http.StatusNoContent {
 		t.Fatalf("unexpected status: %d", resp.StatusCode)
+	}
+}
+
+func TestClientAllowsBlockedIPWhenAllowListed(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	serverURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := NewClientWithAllowList(true, false, false, []string{serverURL.Host}).Get(ts.URL)
+	if err != nil {
+		t.Fatalf("expected allow-listed loopback IP to be allowed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("unexpected status: %d", resp.StatusCode)
+	}
+}
+
+func TestClientAllowsBlockedHostnameWhenAllowListed(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	serverURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	localURL := strings.Replace(ts.URL, "127.0.0.1", "localhost", 1)
+
+	resp, err := NewClientWithAllowList(true, false, false, []string{"localhost:" + serverURL.Port()}).Get(localURL)
+	if err != nil {
+		t.Fatalf("expected allow-listed localhost to be allowed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("unexpected status: %d", resp.StatusCode)
+	}
+}
+
+func TestClientBlocksAllowListedHostnameWithMismatchedPort(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		t.Fatal("request should have been blocked before reaching server")
+	}))
+	defer ts.Close()
+
+	localURL := strings.Replace(ts.URL, "127.0.0.1", "localhost", 1)
+	_, err := NewClientWithAllowList(true, false, false, []string{"localhost:1"}).Get(localURL)
+	if err == nil {
+		t.Fatal("expected localhost to be blocked when allow-list port mismatches")
+	}
+	if !strings.Contains(err.Error(), "blocked loopback IP") {
+		t.Fatalf("expected loopback error, got %v", err)
+	}
+}
+
+func TestAllowListMatchesExactAndSuffixHosts(t *testing.T) {
+	dialer := safeDialer{
+		allowList: parseAllowList([]string{
+			"api.example.com",
+			"*.internal.example.com",
+			"db.example.com:8443",
+		}),
+	}
+
+	tests := []struct {
+		name string
+		host string
+		port string
+		want bool
+	}{
+		{
+			name: "exact host",
+			host: "api.example.com",
+			port: "443",
+			want: true,
+		},
+		{
+			name: "exact host is not suffix",
+			host: "xapi.example.com",
+			port: "443",
+			want: false,
+		},
+		{
+			name: "suffix host",
+			host: "mcp.internal.example.com",
+			port: "443",
+			want: true,
+		},
+		{
+			name: "suffix host nested",
+			host: "a.b.internal.example.com",
+			port: "443",
+			want: true,
+		},
+		{
+			name: "suffix does not match apex",
+			host: "internal.example.com",
+			port: "443",
+			want: false,
+		},
+		{
+			name: "port match",
+			host: "db.example.com",
+			port: "8443",
+			want: true,
+		},
+		{
+			name: "port mismatch",
+			host: "db.example.com",
+			port: "443",
+			want: false,
+		},
+		{
+			name: "case insensitive",
+			host: "API.EXAMPLE.COM",
+			port: "443",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dialer.isAllowed(tt.host, tt.port); got != tt.want {
+				t.Fatalf("isAllowed(%q, %q) = %v, want %v", tt.host, tt.port, got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/servers/workflows/tools_server_test.go
+++ b/pkg/servers/workflows/tools_server_test.go
@@ -20,7 +20,7 @@ func TestRecordWorkflowRun_DeduplicatesURI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create session store: %v", err)
 	}
-	manager := session.NewManager(store)
+	manager := session.NewManager(t.Context(), store, 0)
 
 	if err := manager.DB.Create(ctx, &session.Session{
 		SessionID: "test-session",

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"maps"
 	"net/http"
 	"os"
@@ -18,22 +19,25 @@ import (
 	"gorm.io/gorm"
 )
 
-func NewManager(store *Store) *Manager {
-	ctx, cancel := context.WithCancel(context.Background())
-	return &Manager{
+const defaultGarbageCollectionInterval = time.Hour
+
+func NewManager(ctx context.Context, store *Store, gcPeriod time.Duration) *Manager {
+	m := &Manager{
 		ctx:          ctx,
-		close:        cancel,
 		DB:           store,
 		root:         &Session{},
 		liveSessions: make(map[string]liveSession),
 	}
+
+	m.startGarbageCollector(gcPeriod)
+
+	return m
 }
 
 type Manager struct {
-	ctx   context.Context
-	close context.CancelFunc
-	DB    *Store
-	root  *Session
+	ctx  context.Context
+	DB   *Store
+	root *Session
 
 	liveSessionsLock sync.Mutex
 	liveSessions     map[string]liveSession
@@ -268,6 +272,52 @@ func (m *Manager) Release(session *mcp.ServerSession) {
 	} else {
 		session.Close(false)
 	}
+}
+
+func (m *Manager) liveSessionIDs() []string {
+	m.liveSessionsLock.Lock()
+	defer m.liveSessionsLock.Unlock()
+
+	return slices.Collect(maps.Keys(m.liveSessions))
+}
+
+func (m *Manager) garbageCollect(maxIdle time.Duration) (int64, error) {
+	if maxIdle <= 0 {
+		return 0, nil
+	}
+
+	cutoff := time.Now().Add(-maxIdle)
+	return m.DB.DeleteSessionsUpdatedBefore(m.ctx, cutoff, m.liveSessionIDs()...)
+}
+
+func (m *Manager) startGarbageCollector(maxIdle time.Duration) {
+	if maxIdle <= 0 {
+		return
+	}
+
+	go func() {
+		if deleted, err := m.garbageCollect(maxIdle); err != nil {
+			slog.Error("failed to garbage collect sessions", "max_idle", maxIdle, "error", err)
+		} else if deleted > 0 {
+			slog.Info("garbage collected sessions", "max_idle", maxIdle, "deleted", deleted)
+		}
+
+		ticker := time.NewTicker(defaultGarbageCollectionInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-m.ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			if deleted, err := m.garbageCollect(maxIdle); err != nil {
+				slog.Error("failed to garbage collect sessions", "max_idle", maxIdle, "error", err)
+			} else if deleted > 0 {
+				slog.Info("garbage collected sessions", "max_idle", maxIdle, "deleted", deleted)
+			}
+		}
+	}()
 }
 
 func (m *Manager) loadSessionFromDatabase(ctx context.Context, server mcp.MessageHandler, id string) (*mcp.ServerSession, bool, error) {

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -97,6 +97,44 @@ func (s *Store) Delete(ctx context.Context, id string) error {
 	return s.db.WithContext(ctx).Where("session_id = ?", id).Delete(&Session{}).Error
 }
 
+func (s *Store) DeleteSessionsUpdatedBefore(ctx context.Context, cutoff time.Time, excludeSessionIDs ...string) (int64, error) {
+	if cutoff.After(time.Now()) {
+		return 0, fmt.Errorf("cutoff cannot be after now")
+	}
+
+	var deleted int64
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		query := tx.Model(&Session{}).Where("updated_at < ?", cutoff)
+		if len(excludeSessionIDs) > 0 {
+			query = query.Where("session_id NOT IN ?", excludeSessionIDs)
+		}
+
+		var sessionIDs []string
+		if err := query.Pluck("session_id", &sessionIDs).Error; err != nil {
+			return err
+		}
+		if len(sessionIDs) == 0 {
+			return nil
+		}
+
+		if err := tx.Where("session_id IN ?", sessionIDs).Delete(&WorkflowRun{}).Error; err != nil {
+			return err
+		}
+
+		result := tx.Unscoped().Where("session_id IN ?", sessionIDs).Delete(&Session{})
+		if result.Error != nil {
+			return result.Error
+		}
+
+		deleted = result.RowsAffected
+		return nil
+	}); err != nil {
+		return 0, err
+	}
+
+	return deleted, nil
+}
+
 func (s *Store) Get(ctx context.Context, id string) (*Session, error) {
 	var session Session
 	err := s.db.WithContext(ctx).Where("session_id = ?", id).First(&session).Error

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -1,0 +1,96 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+
+	store, err := NewStoreFromDSN(filepath.Join(t.TempDir(), "nanobot.db"))
+	if err != nil {
+		t.Fatalf("NewStoreFromDSN: %v", err)
+	}
+	return store
+}
+
+func createTestSession(t *testing.T, store *Store, id string, updatedAt time.Time) {
+	t.Helper()
+
+	if err := store.Create(context.Background(), &Session{
+		SessionID: id,
+		AccountID: "account-1",
+		State: State{
+			ID: id,
+		},
+	}); err != nil {
+		t.Fatalf("Create(%s): %v", id, err)
+	}
+
+	if err := store.db.Model(&Session{}).
+		Where("session_id = ?", id).
+		UpdateColumn("updated_at", updatedAt).
+		Error; err != nil {
+		t.Fatalf("UpdateColumn(%s): %v", id, err)
+	}
+}
+
+func TestDeleteSessionsUpdatedBefore(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+	cutoff := now.Add(-7 * 24 * time.Hour)
+
+	createTestSession(t, store, "old", now.Add(-8*24*time.Hour))
+	createTestSession(t, store, "fresh", now.Add(-6*24*time.Hour))
+	createTestSession(t, store, "excluded", now.Add(-8*24*time.Hour))
+
+	if err := store.AddWorkflowRun(ctx, "old", "workflow:///old"); err != nil {
+		t.Fatalf("AddWorkflowRun(old): %v", err)
+	}
+	if err := store.AddWorkflowRun(ctx, "excluded", "workflow:///excluded"); err != nil {
+		t.Fatalf("AddWorkflowRun(excluded): %v", err)
+	}
+
+	deleted, err := store.DeleteSessionsUpdatedBefore(ctx, cutoff, "excluded")
+	if err != nil {
+		t.Fatalf("DeleteSessionsUpdatedBefore: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
+	}
+
+	if _, err := store.Get(ctx, "old"); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("old session lookup err = %v, want gorm.ErrRecordNotFound", err)
+	}
+	var oldRows int64
+	if err := store.db.Unscoped().Model(&Session{}).Where("session_id = ?", "old").Count(&oldRows).Error; err != nil {
+		t.Fatalf("count old session rows: %v", err)
+	}
+	if oldRows != 0 {
+		t.Fatalf("old session should be hard-deleted, found %d unscoped rows", oldRows)
+	}
+	if _, err := store.Get(ctx, "fresh"); err != nil {
+		t.Fatalf("fresh session should remain: %v", err)
+	}
+	if _, err := store.Get(ctx, "excluded"); err != nil {
+		t.Fatalf("excluded session should remain: %v", err)
+	}
+
+	workflowURIs, err := store.ListWorkflowURIs(ctx, "old", "excluded")
+	if err != nil {
+		t.Fatalf("ListWorkflowURIs: %v", err)
+	}
+	if len(workflowURIs["old"]) != 0 {
+		t.Fatalf("old workflow runs should be deleted, got %v", workflowURIs["old"])
+	}
+	if got := workflowURIs["excluded"]; len(got) != 1 || got[0] != "workflow:///excluded" {
+		t.Fatalf("excluded workflow runs = %v, want [workflow:///excluded]", got)
+	}
+}

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -39,7 +39,7 @@ type Service struct {
 	tokenExchangeClientID         string
 	tokenExchangeClientSecret     string
 	oauthClientIDMetadataDocument string
-	auditLogCollector             *auditlogs.Collector
+	auditLogCollector             auditlogs.Collector
 	blockLoopback                 bool
 	blockPrivateIP                bool
 	blockLinkLocal                bool
@@ -59,7 +59,7 @@ type Options struct {
 	TokenExchangeClientID         string
 	TokenExchangeClientSecret     string
 	OAuthClientIDMetadataDocument string
-	AuditLogCollector             *auditlogs.Collector
+	AuditLogCollector             auditlogs.Collector
 	BlockLoopback                 bool
 	BlockPrivateIP                bool
 	BlockLinkLocal                bool
@@ -138,6 +138,7 @@ func buildAuditLog(msg *mcp.Message, session *mcp.Session) *auditlogs.MCPAuditLo
 	session.Get("subject", &auditLog.Subject)
 	session.Get("clientIP", &auditLog.ClientIP)
 	session.Get("apiKey", &auditLog.APIKey)
+	session.Get("auditLogMetadata", &auditLog.Metadata)
 
 	return auditLog
 }
@@ -376,7 +377,7 @@ func (s *Service) newClient(ctx context.Context, name string, state *mcp.Session
 	}
 
 	var oauthRedirectURL string
-	if session.Get(types.PublicURLSessionKey, &oauthRedirectURL) {
+	if s.callbackHandler != nil && session.Get(types.PublicURLSessionKey, &oauthRedirectURL) {
 		u, err := url.Parse(oauthRedirectURL)
 		if err == nil {
 			oauthRedirectURL = u.Scheme + "://" + u.Host
@@ -384,6 +385,16 @@ func (s *Service) newClient(ctx context.Context, name string, state *mcp.Session
 		oauthRedirectURL = strings.TrimSuffix(oauthRedirectURL, "/") + "/oauth/callback"
 	} else {
 		oauthRedirectURL = s.oauthRedirectURL
+	}
+
+	tokenExchangeEndpoint, tokenExchangeClientID, tokenExchangeClientSecret := s.tokenExchangeEndpoint, s.tokenExchangeClientID, s.tokenExchangeClientSecret
+	if config.Auth != nil {
+		if config.Auth.OAuthClientID != "" {
+			tokenExchangeClientID = config.Auth.OAuthClientID
+		}
+		if config.Auth.OAuthClientSecret != "" {
+			tokenExchangeClientSecret = config.Auth.OAuthClientSecret
+		}
 	}
 
 	clientOpts := mcp.ClientOption{
@@ -471,9 +482,9 @@ func (s *Service) newClient(ctx context.Context, name string, state *mcp.Session
 			OAuthRedirectURL:              oauthRedirectURL,
 			CallbackHandler:               s.callbackHandler,
 			TokenStorage:                  s.tokenStorage,
-			TokenExchangeEndpoint:         s.tokenExchangeEndpoint,
-			TokenExchangeClientID:         s.tokenExchangeClientID,
-			TokenExchangeClientSecret:     s.tokenExchangeClientSecret,
+			TokenExchangeEndpoint:         tokenExchangeEndpoint,
+			TokenExchangeClientID:         tokenExchangeClientID,
+			TokenExchangeClientSecret:     tokenExchangeClientSecret,
 			OAuthClientIDMetadataDocument: s.oauthClientIDMetadataDocument,
 			BlockLoopback:                 s.blockLoopback,
 			BlockPrivateIP:                s.blockPrivateIP,

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -43,6 +43,7 @@ type Service struct {
 	blockLoopback                 bool
 	blockPrivateIP                bool
 	blockLinkLocal                bool
+	allowedHosts                  []string
 }
 
 type Sampler interface {
@@ -63,6 +64,7 @@ type Options struct {
 	BlockLoopback                 bool
 	BlockPrivateIP                bool
 	BlockLinkLocal                bool
+	AllowedHosts                  []string
 }
 
 func (r Options) Merge(other Options) (result Options) {
@@ -79,6 +81,7 @@ func (r Options) Merge(other Options) (result Options) {
 	result.BlockLoopback = r.BlockLoopback || other.BlockLoopback
 	result.BlockPrivateIP = r.BlockPrivateIP || other.BlockPrivateIP
 	result.BlockLinkLocal = r.BlockLinkLocal || other.BlockLinkLocal
+	result.AllowedHosts = append(append([]string{}, r.AllowedHosts...), other.AllowedHosts...)
 	return result
 }
 
@@ -105,6 +108,7 @@ func NewToolsService(opts ...Options) *Service {
 		blockLoopback:                 opt.BlockLoopback,
 		blockPrivateIP:                opt.BlockPrivateIP,
 		blockLinkLocal:                opt.BlockLinkLocal,
+		allowedHosts:                  slices.Clone(opt.AllowedHosts),
 	}
 }
 
@@ -489,6 +493,7 @@ func (s *Service) newClient(ctx context.Context, name string, state *mcp.Session
 			BlockLoopback:                 s.blockLoopback,
 			BlockPrivateIP:                s.blockPrivateIP,
 			BlockLinkLocal:                s.blockLinkLocal,
+			AllowedHosts:                  s.allowedHosts,
 		},
 		Wire:         wire,
 		SessionState: state,


### PR DESCRIPTION
This allows us to collapse the shims in Obot down to a single shim for all MCP servers while being backwards compatible.

Issue: https://github.com/obot-platform/obot/issues/6261