### PR TITLE
fix: support 'sqlite://' DSN

### DIFF
--- a/pkg/gormdsn/dsn.go
+++ b/pkg/gormdsn/dsn.go
@@ -19,7 +19,11 @@ func NewDBFromDSN(dsn string) (*gorm.DB, error) {
 
 	switch {
 	case strings.HasPrefix(dsn, "sqlite:") || strings.HasSuffix(dsn, ".db") || strings.Contains(dsn, ":memory:"):
-		dsn = strings.TrimPrefix(dsn, "sqlite:")
+		if sqliteDSN, ok := strings.CutPrefix(dsn, "sqlite://"); ok {
+			dsn = sqliteDSN
+		} else {
+			dsn = strings.TrimPrefix(dsn, "sqlite:")
+		}
 		dialector = sqlite.Open(dsn)
 	case strings.HasPrefix(dsn, "postgres://") || strings.HasPrefix(dsn, "postgresql://"):
 		dialector = postgres.Open(dsn)

--- a/pkg/gormdsn/dsn_test.go
+++ b/pkg/gormdsn/dsn_test.go
@@ -1,0 +1,37 @@
+package gormdsn
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestNewDBFromDSNSQLiteFormats(t *testing.T) {
+	tests := map[string]string{
+		"scheme":         "sqlite:file:",
+		"absolute URL":   "sqlite://",
+		"bare file path": "",
+	}
+
+	for name, prefix := range tests {
+		t.Run(name, func(t *testing.T) {
+			databasePath := filepath.Join(t.TempDir(), "nanobot.db")
+			db, err := NewDBFromDSN(prefix + databasePath)
+			if err != nil {
+				t.Fatalf("NewDBFromDSN: %v", err)
+			}
+			if err := db.Exec("CREATE TABLE test (id INTEGER PRIMARY KEY)").Error; err != nil {
+				t.Fatalf("create table: %v", err)
+			}
+		})
+	}
+
+	t.Run("memory", func(t *testing.T) {
+		db, err := NewDBFromDSN("sqlite::memory:")
+		if err != nil {
+			t.Fatalf("NewDBFromDSN: %v", err)
+		}
+		if err := db.Exec("CREATE TABLE test (id INTEGER PRIMARY KEY)").Error; err != nil {
+			t.Fatalf("create table: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Support Obot's SQLite DSN

Related: https://github.com/obot-platform/obot/pull/7145