### PR TITLE
fix: handle default oauth protected resource metadata URLs

### DIFF
--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -99,22 +99,33 @@ func (o *oauth) loadFromStorage(ctx context.Context, connectURL string) *http.Cl
 }
 
 func discoverOAuthMetadata(ctx context.Context, client *http.Client, baseURL, authenticateHeader, clientName, redirectURL string, headers map[string]string) (oauthMetadataDiscovery, bool, error) {
-	resourceMetadataURL, scope, u, err := oauthResourceMetadataURL(baseURL, authenticateHeader)
+	resourceMetadataURLs, scope, err := oauthResourceMetadataURLs(baseURL, authenticateHeader)
 	if err != nil {
 		return oauthMetadataDiscovery{}, false, err
 	}
-	slog.Info("fetching protected resource metadata", "url", resourceMetadataURL)
 
-	protectedResourceMetadataJSON, ok, err := getOAuthMetadataJSON(ctx, client, resourceMetadataURL, headers)
-	if err != nil {
-		return oauthMetadataDiscovery{}, false, fmt.Errorf("failed to get protected resource metadata: %w", err)
-	}
+	var (
+		finalResourceMetadataURL      *url.URL
+		protectedResourceMetadata     protectedResourceMetadata
+		protectedResourceMetadataJSON json.RawMessage
+		ok                            bool
+	)
+	for _, resourceMetadataURL := range resourceMetadataURLs {
+		finalResourceMetadataURL = resourceMetadataURL
+		slog.Info("fetching protected resource metadata", "url", resourceMetadataURL)
 
-	var protectedResourceMetadata protectedResourceMetadata
-	if ok {
-		protectedResourceMetadata, err = parseProtectedResourceMetadata(bytes.NewReader(protectedResourceMetadataJSON))
+		protectedResourceMetadataJSON, ok, err = getOAuthMetadataJSON(ctx, client, resourceMetadataURL.String(), headers)
 		if err != nil {
-			return oauthMetadataDiscovery{}, false, fmt.Errorf("failed to parse protected resource metadata: %w", err)
+			return oauthMetadataDiscovery{}, false, fmt.Errorf("failed to get protected resource metadata: %w", err)
+		}
+
+		if ok {
+			protectedResourceMetadata, err = parseProtectedResourceMetadata(bytes.NewReader(protectedResourceMetadataJSON))
+			if err != nil {
+				return oauthMetadataDiscovery{}, false, fmt.Errorf("failed to parse protected resource metadata: %w", err)
+			}
+
+			break
 		}
 	}
 
@@ -125,7 +136,7 @@ func discoverOAuthMetadata(ctx context.Context, client *http.Client, baseURL, au
 	}
 
 	if len(protectedResourceMetadata.AuthorizationServers) == 0 {
-		protectedResourceMetadata.AuthorizationServers = []string{fmt.Sprintf("%s://%s", u.Scheme, u.Host)}
+		protectedResourceMetadata.AuthorizationServers = []string{fmt.Sprintf("%s://%s", finalResourceMetadataURL.Scheme, finalResourceMetadataURL.Host)}
 	}
 	authorizationServerURL := protectedResourceMetadata.AuthorizationServers[0]
 
@@ -147,7 +158,7 @@ func discoverOAuthMetadata(ctx context.Context, client *http.Client, baseURL, au
 	}
 
 	return oauthMetadataDiscovery{
-		ProtectedResourceURL:              resourceMetadataURL,
+		ProtectedResourceURL:              finalResourceMetadataURL.String(),
 		ProtectedResourceMetadata:         protectedResourceMetadata,
 		ProtectedResourceMetadataJSON:     protectedResourceMetadataJSON,
 		AuthorizationServerURL:            authorizationServerURL,
@@ -160,27 +171,44 @@ func discoverOAuthMetadata(ctx context.Context, client *http.Client, baseURL, au
 	}, true, nil
 }
 
-func oauthResourceMetadataURL(baseURL, authenticateHeader string) (string, string, *url.URL, error) {
+func oauthResourceMetadataURLs(baseURL, authenticateHeader string) ([]*url.URL, string, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
-		return "", "", nil, fmt.Errorf("failed to parse MCP URL: %w", err)
+		return nil, "", fmt.Errorf("failed to parse MCP URL: %w", err)
 	}
 
 	var (
-		resourceMetadataURL string
-		scope               string
+		resourceMetadataURLFromHeader string
+		resourceMetadataURLs          []*url.URL
+		scope                         string
 	)
 	if authenticateHeader != "" {
-		resourceMetadataURL = parseResourceMetadata(authenticateHeader)
+		resourceMetadataURLFromHeader = parseResourceMetadata(authenticateHeader)
 		scope = parseScopeFromAuthenticateHeader(authenticateHeader)
 	}
-	if resourceMetadataURL == "" {
+
+	if resourceMetadataURLFromHeader == "" {
 		// If the authenticate header was not sent back or it did not have a resource metadata URL, then the spec says we should default to...
+		slog.Info("no resource metadata URL in authenticate header, defaulting to .well-known/oauth-protected-resource")
+		originalPath := strings.TrimPrefix(u.Path, "/")
+
+		if originalPath != "" {
+			withoutPathSuffix := *u
+			withoutPathSuffix.Path = ".well-known/oauth-protected-resource/" + originalPath
+			resourceMetadataURLs = append(resourceMetadataURLs, &withoutPathSuffix)
+		}
+
 		u.Path = "/.well-known/oauth-protected-resource"
-		resourceMetadataURL = u.String()
+		resourceMetadataURLs = append(resourceMetadataURLs, u)
+	} else {
+		parsedURL, err := url.Parse(resourceMetadataURLFromHeader)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to parse resource metadata URL: %w", err)
+		}
+		resourceMetadataURLs = []*url.URL{parsedURL}
 	}
 
-	return resourceMetadataURL, scope, u, nil
+	return resourceMetadataURLs, scope, nil
 }
 
 func (o *oauth) oauthClient(ctx context.Context, c *HTTPClient, connectURL, authenticateHeader string) (*http.Client, error) {

--- a/pkg/mcp/oauth_test.go
+++ b/pkg/mcp/oauth_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestGetOAuthMetadata(t *testing.T) {
 	var serverURL string
+	var pathMetadataRequested, rootMetadataRequested atomic.Bool
 	const (
 		clientName  = "Test Client"
 		redirectURL = "http://localhost/callback"
@@ -29,9 +30,13 @@ func TestGetOAuthMetadata(t *testing.T) {
 				http.NotFound(w, req)
 				return
 			}
-			w.Header().Set("WWW-Authenticate", `Bearer resource_metadata="`+serverURL+`/.well-known/oauth-protected-resource/mcp"`)
+			w.Header().Set("WWW-Authenticate", "Bearer")
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 		case "/.well-known/oauth-protected-resource/mcp":
+			pathMetadataRequested.Store(true)
+			http.NotFound(w, req)
+		case "/.well-known/oauth-protected-resource":
+			rootMetadataRequested.Store(true)
 			if req.Header.Get("X-Test") != "value" {
 				http.Error(w, "missing test header", http.StatusBadRequest)
 				return
@@ -68,8 +73,11 @@ func TestGetOAuthMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if result.ProtectedResourceMetadataURL != ts.URL+"/.well-known/oauth-protected-resource/mcp" {
+	if result.ProtectedResourceMetadataURL != ts.URL+"/.well-known/oauth-protected-resource" {
 		t.Fatalf("unexpected protected resource URL: %s", result.ProtectedResourceMetadataURL)
+	}
+	if !pathMetadataRequested.Load() || !rootMetadataRequested.Load() {
+		t.Fatalf("expected path and root protected resource metadata URLs to be requested")
 	}
 	if result.AuthorizationServerMetadataURL != ts.URL+"/.well-known/oauth-authorization-server/issuer" {
 		t.Fatalf("unexpected authorization server URL: %s", result.AuthorizationServerMetadataURL)
@@ -112,6 +120,62 @@ func TestGetOAuthMetadata(t *testing.T) {
 	}
 	if !slices.Equal(clientRegistration.GrantTypes, []string{"authorization_code"}) {
 		t.Fatalf("unexpected grant types: %v", clientRegistration.GrantTypes)
+	}
+}
+
+func TestOAuthResourceMetadataURLs(t *testing.T) {
+	tests := []struct {
+		name               string
+		baseURL            string
+		authenticateHeader string
+		wantURLs           []string
+		wantScope          string
+	}{
+		{
+			name:    "defaults to path-specific then root metadata without an auth header",
+			baseURL: "https://mcp.example.com/mcp",
+			wantURLs: []string{
+				"https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+				"https://mcp.example.com/.well-known/oauth-protected-resource",
+			},
+		},
+		{
+			name:               "retains challenge scope for default metadata URLs",
+			baseURL:            "https://mcp.example.com/v1/mcp",
+			authenticateHeader: `Bearer scope="read write"`,
+			wantURLs: []string{
+				"https://mcp.example.com/.well-known/oauth-protected-resource/v1/mcp",
+				"https://mcp.example.com/.well-known/oauth-protected-resource",
+			},
+			wantScope: "read write",
+		},
+		{
+			name:               "uses advertised resource metadata URL exclusively",
+			baseURL:            "https://mcp.example.com/mcp",
+			authenticateHeader: `Bearer resource_metadata="https://auth.example.com/resources/mcp" scope="read"`,
+			wantURLs:           []string{"https://auth.example.com/resources/mcp"},
+			wantScope:          "read",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			urls, scope, err := oauthResourceMetadataURLs(tt.baseURL, tt.authenticateHeader)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			gotURLs := make([]string, len(urls))
+			for i, u := range urls {
+				gotURLs[i] = u.String()
+			}
+			if !slices.Equal(gotURLs, tt.wantURLs) {
+				t.Fatalf("unexpected resource metadata URLs: got %v, want %v", gotURLs, tt.wantURLs)
+			}
+			if scope != tt.wantScope {
+				t.Fatalf("unexpected scope: got %q, want %q", scope, tt.wantScope)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
If the WWW-Authenticate header doesn't have a resource_metadata field, then we are supposed to try two different URLs. Prior to this change, we were only try one, and this failed for certain MCP servers.

Issue: https://github.com/obot-platform/obot/issues/7160