### PR TITLE
fix: propogate session delete to remote clients

### DIFF
--- a/pkg/mcp/httpclient.go
+++ b/pkg/mcp/httpclient.go
@@ -191,6 +191,12 @@ func (s *HTTPClient) SessionID() string {
 func (s *HTTPClient) Close(deleteSession bool) {
 	sessionID := s.SessionID()
 	slog.Info("mcp client closing", "server", s.serverName, "session_id", sessionID, "delete_session", deleteSession)
+	defer func() {
+		if s.cancel != nil {
+			s.cancel(fmt.Errorf("http client closed session: %v, deleteSession=%v", sessionID, deleteSession))
+		}
+		s.waiter.Close()
+	}()
 
 	if deleteSession {
 		s.initializeLock.RLock()
@@ -204,7 +210,13 @@ func (s *HTTPClient) Close(deleteSession bool) {
 			httpClient := s.httpClient
 			s.clientLock.RUnlock()
 
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			closeCtx := context.Background()
+			if s.ctx != nil {
+				// Preserve request-scoped values such as passthrough headers and
+				// token-exchange credentials without inheriting cancellation.
+				closeCtx = context.WithoutCancel(s.ctx)
+			}
+			ctx, cancel := context.WithTimeout(closeCtx, 5*time.Second)
 			defer cancel()
 			req, err := s.newRequest(ctx, http.MethodDelete, nil)
 			if err != nil {
@@ -221,15 +233,6 @@ func (s *HTTPClient) Close(deleteSession bool) {
 			resp.Body.Close()
 		}
 	}
-
-	if s.cancel != nil {
-		sid := ""
-		if s.sessionID != nil {
-			sid = *s.sessionID
-		}
-		s.cancel(fmt.Errorf("http client closed session: %v, deleteSession=%v", sid, deleteSession))
-	}
-	s.waiter.Close()
 }
 
 func (s *HTTPClient) Wait() {
@@ -608,7 +611,7 @@ func (s *HTTPClient) initialize(ctx context.Context, msg Message) error {
 		"status_code", resp.StatusCode)
 
 	go func() {
-		if err = s.ensureSSE(ctx, nil, ""); err != nil {
+		if err := s.ensureSSE(ctx, nil, ""); err != nil {
 			slog.Error("failed to initialize SSE", "error", err)
 		}
 	}()

--- a/pkg/mcp/session.go
+++ b/pkg/mcp/session.go
@@ -31,7 +31,7 @@ func (f MessageHandlerFunc) OnMessage(ctx context.Context, msg Message) {
 type MessageFilter func(ctx context.Context, msg *Message) (*Message, error)
 
 type Wire interface {
-	Close(deleteSession bool)
+	SessionCloser
 	Wait()
 	Start(ctx context.Context, handler WireHandler) error
 	Send(ctx context.Context, req Message) error
@@ -52,6 +52,7 @@ type Session struct {
 	HookRunner        HookRunner
 	attributes        map[string]any
 	lock              sync.Mutex
+	explicitlyDeleted bool
 	filters           []filterRegistration
 	filterID          int
 	sessionManager    SessionStore
@@ -356,8 +357,17 @@ func (s *Session) Set(key string, value any) {
 	if s == nil {
 		return
 	}
+
 	s.lock.Lock()
+	if s.explicitlyDeleted {
+		s.lock.Unlock()
+		if closer, ok := value.(SessionCloser); ok {
+			closer.Close(true)
+		}
+		return
+	}
 	defer s.lock.Unlock()
+
 	if s.attributes == nil {
 		s.attributes = make(map[string]any)
 	}
@@ -410,6 +420,21 @@ func (s *Session) Get(key string, out any) (ret bool) {
 
 	s.lock.Lock()
 	defer s.lock.Unlock()
+	if s.explicitlyDeleted {
+		// A SessionCloser may create external state while deserializing. Once an
+		// explicit deletion starts, do not let a persisted closer be hydrated
+		// and re-attached after the deletion snapshot.
+		if _, ok := out.(SessionCloser); ok {
+			return false
+		}
+	}
+	return s.getLocked(key, out)
+}
+
+// getLocked is like get, but assumes the caller has already acquired the lock.
+// Callers must hold the lock when calling this method.
+// It returns true if the value was found and copied into out, false otherwise.
+func (s *Session) getLocked(key string, out any) bool {
 	v, ok := s.attributes[key]
 	if !ok {
 		return false
@@ -443,6 +468,41 @@ func (s *Session) Get(key string, out any) (ret bool) {
 	panic(fmt.Sprintf("can not marshal %T to type: %T", v, out))
 }
 
+// GetOrSetSessionCloser atomically resolves key into out, storing closer when
+// the key has no usable value. Persisted values are deserialized through out in
+// the same critical section so concurrent callers cannot replace each other's
+// closers. It returns false once explicit session deletion has begun.
+func (s *Session) GetOrSetSessionCloser(key string, closer SessionCloser, out any) bool {
+	if s == nil {
+		return false
+	}
+	ok, closeCloser := s.getOrSetSessionCloser(key, closer, out)
+	if closeCloser {
+		closer.Close(true)
+	}
+	return ok
+}
+
+func (s *Session) getOrSetSessionCloser(key string, closer SessionCloser, out any) (ok, closeCloser bool) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.explicitlyDeleted {
+		return false, true
+	}
+	if s.getLocked(key, out) {
+		return true, false
+	}
+	if s.attributes == nil {
+		s.attributes = make(map[string]any)
+	}
+	s.attributes[key] = closer
+	if s.copyInto(out, closer) {
+		return true, false
+	}
+	delete(s.attributes, key)
+	return false, true
+}
+
 func (s *Session) Attributes() map[string]any {
 	if s == nil || len(s.attributes) == 0 {
 		return nil
@@ -460,12 +520,58 @@ func (s *Session) Attributes() map[string]any {
 	return attributes
 }
 
+type SessionCloser interface {
+	Close(deleteSession bool)
+}
+
+func (s *Session) takeSessionClosers(deleteSession bool) []SessionCloser {
+	// Downstream clients are owned by the root server session. Idle session
+	// eviction uses Close(false) so those remote sessions can be restored later;
+	// only an explicit session deletion should be propagated to them.
+	if !deleteSession {
+		return nil
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.explicitlyDeleted = true
+	if s.Parent != nil {
+		return nil
+	}
+
+	var closers []SessionCloser
+	for key, value := range s.attributes {
+		if closer, ok := value.(SessionCloser); ok {
+			closers = append(closers, closer)
+			// Detach the closer while holding the lock so repeated closes cannot
+			// send duplicate deletion requests and State cannot persist it again.
+			delete(s.attributes, key)
+		}
+	}
+	return closers
+}
+
 func (s *Session) Close(deleteSession bool) {
+	if s == nil {
+		return
+	}
+
+	// Stop existing and new work before taking the deletion snapshot. Any
+	// closer registered before the snapshot is collected below; registrations
+	// after it are rejected by Set once explicitlyDeleted is set.
+	s.cancel(fmt.Errorf("session closed: %s, delete=%v", s.ID(), deleteSession))
+
 	if s.wire != nil {
 		s.wire.Close(deleteSession)
 	}
 	s.pendingRequest.Close()
-	s.cancel(fmt.Errorf("session closed: %s, delete=%v", s.ID(), deleteSession))
+
+	closers := s.takeSessionClosers(deleteSession)
+
+	// Invoke external cleanup without holding the session attribute lock.
+	for _, closer := range closers {
+		closer.Close(true)
+	}
 }
 
 func (s *Session) IsActive() bool {

--- a/pkg/mcp/session_test.go
+++ b/pkg/mcp/session_test.go
@@ -23,10 +23,102 @@ type sequenceHookRunner struct {
 	next      int
 }
 
+type recordingDeleteSessionCloser struct {
+	calls []bool
+}
+
+func (r *recordingDeleteSessionCloser) Close(deleteSession bool) {
+	r.calls = append(r.calls, deleteSession)
+}
+
+type closeCallbackWire struct {
+	onClose func(bool)
+}
+
+func (c *closeCallbackWire) Close(deleteSession bool) {
+	c.onClose(deleteSession)
+}
+
+func (*closeCallbackWire) Wait() {}
+
+func (*closeCallbackWire) Start(context.Context, WireHandler) error {
+	return nil
+}
+
+func (*closeCallbackWire) Send(context.Context, Message) error {
+	return nil
+}
+
+func (*closeCallbackWire) SessionID() string {
+	return "test-session"
+}
+
 func (r *sequenceHookRunner) RunHook(_ context.Context, _, out any, _ string) (bool, error) {
 	*(out.(*SessionMessageHook)) = r.responses[r.next]
 	r.next++
 	return true, nil
+}
+
+func TestSessionClosePropagatesExplicitDeleteToOwnedClosers(t *testing.T) {
+	session := NewEmptySession(context.Background())
+	closer := &recordingDeleteSessionCloser{}
+	session.Set("clients/downstream", closer)
+
+	session.Close(true)
+	session.Close(true)
+
+	if !slices.Equal(closer.calls, []bool{true}) {
+		t.Fatalf("close calls = %v, want [true]", closer.calls)
+	}
+}
+
+func TestSessionCloseDoesNotPropagateIdleCloseToOwnedClosers(t *testing.T) {
+	session := NewEmptySession(context.Background())
+	closer := &recordingDeleteSessionCloser{}
+	session.Set("clients/downstream", closer)
+
+	session.Close(false)
+
+	if len(closer.calls) != 0 {
+		t.Fatalf("close calls = %v, want none", closer.calls)
+	}
+}
+
+func TestSessionCloseCancelsBeforeCollectingOwnedClosers(t *testing.T) {
+	session := NewEmptySession(context.Background())
+	closer := &recordingDeleteSessionCloser{}
+	session.wire = &closeCallbackWire{onClose: func(deleteSession bool) {
+		if !deleteSession {
+			t.Error("wire Close called without explicit deletion")
+		}
+		if session.IsActive() {
+			t.Error("session still active while wire is closing")
+		}
+		// Inject a closer into the old race window. Close must take its snapshot
+		// after the wire has closed so this closer is not missed.
+		session.Set("clients/late", closer)
+	}}
+
+	session.Close(true)
+
+	if !slices.Equal(closer.calls, []bool{true}) {
+		t.Fatalf("close calls = %v, want [true]", closer.calls)
+	}
+}
+
+func TestSessionRejectsCloserAfterExplicitDelete(t *testing.T) {
+	session := NewEmptySession(context.Background())
+	session.Close(true)
+
+	closer := &recordingDeleteSessionCloser{}
+	session.Set("clients/late", closer)
+
+	if !slices.Equal(closer.calls, []bool{true}) {
+		t.Fatalf("close calls = %v, want [true]", closer.calls)
+	}
+	if session.Get("clients/late", nil) {
+		t.Fatal("closer was attached after explicit session deletion")
+	}
 }
 
 func TestCallAllHooksRecordsMutatedToolRequestBody(t *testing.T) {

--- a/pkg/tools/flows.go
+++ b/pkg/tools/flows.go
@@ -56,8 +56,8 @@ func (s *Service) newGlobals(ctx context.Context, vars map[string]any, opt ...Ca
 			continue
 		}
 		var instructions string
-		if cf.client != nil && cf.client.Session != nil {
-			instructions = cf.client.Session.InitializeResult.Instructions
+		if client := cf.state.client.Load(); client != nil && client.Session != nil {
+			instructions = client.Session.InitializeResult.Instructions
 		}
 		servers[serverName] = map[string]any{
 			"instructions": instructions,

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/obot-platform/nanobot/pkg/complete"
@@ -224,55 +225,90 @@ func (s *Service) GetPrompt(ctx context.Context, target, prompt string, args map
 }
 
 type clientFactory struct {
-	clientLock *sync.Mutex
-	client     *mcp.Client
+	state *clientFactoryState
+}
+
+// clientFactory values are copied out of session attributes. Keep all mutable
+// state behind a pointer so every copy continues to own and close the same
+// downstream client.
+type clientFactoryState struct {
+	clientLock sync.Mutex
+	client     atomic.Pointer[mcp.Client]
+	deleted    bool
 	oldState   *mcp.SessionState
 	envHash    string
 	new        func(client *mcp.SessionState) (*mcp.Client, error)
 }
 
+var errClientFactoryClosed = errors.New("client factory is closed")
+
 func newClientFactory(f func(state *mcp.SessionState) (*mcp.Client, error)) clientFactory {
 	return clientFactory{
-		clientLock: &sync.Mutex{},
-		new:        f,
+		state: &clientFactoryState{
+			new: f,
+		},
 	}
 }
 
-func (c *clientFactory) get(envHash string) (*mcp.Client, error) {
-	c.clientLock.Lock()
-	defer c.clientLock.Unlock()
-
-	if c.client != nil && c.client.Session.IsActive() && c.envHash == envHash {
-		return c.client, nil
+func (c *clientFactory) get(ownerCtx context.Context, envHash string) (*mcp.Client, error) {
+	c.state.clientLock.Lock()
+	defer c.state.clientLock.Unlock()
+	if c.state.deleted {
+		return nil, errClientFactoryClosed
+	}
+	if cause := context.Cause(ownerCtx); cause != nil {
+		return nil, fmt.Errorf("%w: owner session: %w", errClientFactoryClosed, cause)
 	}
 
-	if c.client != nil {
-		c.client.Close(false)
-		c.client = nil
+	client := c.state.client.Load()
+	if client != nil && client.Session.IsActive() && c.state.envHash == envHash {
+		return client, nil
 	}
 
-	newClient, err := c.new(c.oldState)
+	if client != nil {
+		client.Close(false)
+		c.state.client.Store(nil)
+	}
+
+	newClient, err := c.state.new(c.state.oldState)
 	if err != nil {
 		return nil, err
 	}
-	c.client = newClient
-	c.envHash = envHash
-	return c.client, nil
+	c.state.client.Store(newClient)
+	c.state.envHash = envHash
+	return newClient, nil
+}
+
+func (c *clientFactory) Close(deleteSession bool) {
+	c.state.clientLock.Lock()
+	defer c.state.clientLock.Unlock()
+	if c.state.deleted {
+		return
+	}
+	c.state.deleted = deleteSession
+
+	client := c.state.client.Swap(nil)
+	c.state.envHash = ""
+	if client != nil {
+		client.Close(deleteSession)
+	}
 }
 
 func (c *clientFactory) Serialize() (any, error) {
-	if c.client == nil || c.client.Session.ID() == "" {
+	client := c.state.client.Load()
+	if client == nil || client.Session.ID() == "" {
 		return nil, nil
 	}
-	return c.client.Session.State()
+	return client.Session.State()
 }
 
 func (c *clientFactory) Deserialize(data any) (_ any, err error) {
 	if data == nil {
 		return &clientFactory{
-			clientLock: &sync.Mutex{},
-			envHash:    c.envHash,
-			new:        c.new,
+			state: &clientFactoryState{
+				envHash: c.state.envHash,
+				new:     c.state.new,
+			},
 		}, nil
 	}
 
@@ -284,10 +320,11 @@ func (c *clientFactory) Deserialize(data any) (_ any, err error) {
 	}
 
 	return &clientFactory{
-		clientLock: &sync.Mutex{},
-		oldState:   &state,
-		envHash:    c.envHash,
-		new:        c.new,
+		state: &clientFactoryState{
+			oldState: &state,
+			envHash:  c.state.envHash,
+			new:      c.state.new,
+		},
 	}, nil
 }
 
@@ -306,15 +343,8 @@ func (s *Service) GetClient(ctx context.Context, name string) (*mcp.Client, erro
 	factory := newClientFactory(func(state *mcp.SessionState) (*mcp.Client, error) {
 		return s.newClient(ctx, name, state)
 	})
-	if session.Get(sessionKey, &factory) {
-		return factory.get(envHash)
-	}
-
-	// ensure we are holding the same object
-	session.Set(sessionKey, &factory)
-	session.Get(sessionKey, &factory)
-
-	return factory.get(envHash)
+	session.GetOrSetSessionCloser(sessionKey, &factory, &factory)
+	return factory.get(session.Context(), envHash)
 }
 
 func envMapHash(env map[string]string) (string, error) {

--- a/pkg/tools/service_test.go
+++ b/pkg/tools/service_test.go
@@ -1,12 +1,292 @@
 package tools
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/obot-platform/nanobot/pkg/mcp"
 	"github.com/obot-platform/nanobot/pkg/types"
 )
+
+func TestClientFactoryCloseIsTerminal(t *testing.T) {
+	var createCount atomic.Int32
+	factory := newClientFactory(func(*mcp.SessionState) (*mcp.Client, error) {
+		createCount.Add(1)
+		return nil, nil
+	})
+
+	factory.Close(true)
+	client, err := factory.get(context.Background(), "env")
+
+	if !errors.Is(err, errClientFactoryClosed) {
+		t.Fatalf("get error = %v, want %v", err, errClientFactoryClosed)
+	}
+	if client != nil {
+		t.Fatal("closed factory returned a client")
+	}
+	if got := createCount.Load(); got != 0 {
+		t.Fatalf("client create count = %d, want 0", got)
+	}
+}
+
+func TestClientFactoryCloseWithoutDeleteRemainsReusable(t *testing.T) {
+	var createCount atomic.Int32
+	factory := newClientFactory(func(*mcp.SessionState) (*mcp.Client, error) {
+		createCount.Add(1)
+		return nil, nil
+	})
+
+	factory.Close(false)
+	if _, err := factory.get(context.Background(), "env"); err != nil {
+		t.Fatalf("get after non-deleting close returned error: %v", err)
+	}
+	if got := createCount.Load(); got != 1 {
+		t.Fatalf("client create count = %d, want 1", got)
+	}
+}
+
+func TestClientFactoryRejectsCanceledOwnerBeforeResume(t *testing.T) {
+	ownerCtx, cancel := context.WithCancelCause(context.Background())
+	ownerErr := errors.New("owner session deleted")
+	cancel(ownerErr)
+
+	var createCount atomic.Int32
+	factory := newClientFactory(func(*mcp.SessionState) (*mcp.Client, error) {
+		createCount.Add(1)
+		return nil, nil
+	})
+	factory.state.oldState = &mcp.SessionState{ID: "persisted-downstream-session"}
+
+	client, err := factory.get(ownerCtx, "env")
+
+	if !errors.Is(err, errClientFactoryClosed) || !errors.Is(err, ownerErr) {
+		t.Fatalf("get error = %v, want closed factory and owner errors", err)
+	}
+	if client != nil {
+		t.Fatal("factory with canceled owner returned a client")
+	}
+	if got := createCount.Load(); got != 0 {
+		t.Fatalf("client create count = %d, want 0", got)
+	}
+}
+
+func TestClientFactoriesRegisterAtomically(t *testing.T) {
+	session := mcp.NewEmptySession(context.Background())
+	start := make(chan struct{})
+	states := make(chan *clientFactoryState, 2)
+
+	for range 2 {
+		factory := newClientFactory(func(*mcp.SessionState) (*mcp.Client, error) {
+			return nil, errors.New("unexpected client creation")
+		})
+		go func() {
+			<-start
+			if !session.GetOrSetSessionCloser("clients/downstream", &factory, &factory) {
+				states <- nil
+				return
+			}
+			states <- factory.state
+		}()
+	}
+	close(start)
+
+	first, second := <-states, <-states
+	if first == nil || second == nil {
+		t.Fatal("client factory registration unexpectedly failed")
+	}
+	if first != second {
+		t.Fatal("concurrent registrations resolved to different client factories")
+	}
+
+	session.Close(true)
+	closedFactory := clientFactory{state: first}
+	if _, err := closedFactory.get(context.Background(), "env"); !errors.Is(err, errClientFactoryClosed) {
+		t.Fatalf("get error after session deletion = %v, want %v", err, errClientFactoryClosed)
+	}
+}
+
+func TestGetClientDoesNotHydrateAfterParentDelete(t *testing.T) {
+	var requestCount atomic.Int32
+	downstream := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		rw.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(downstream.Close)
+
+	parent, err := mcp.NewServerSession(context.Background(), mcp.MessageHandlerFunc(func(context.Context, mcp.Message) {}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent.GetSession().Set("clients/downstream", mcp.SessionState{ID: "persisted-downstream-session"})
+
+	service := NewToolsService()
+	clientCtx := types.WithConfig(parent.GetSession().Context(), types.Config{
+		MCPServers: map[string]mcp.Server{
+			"downstream": {BaseURL: downstream.URL},
+		},
+	})
+	parent.Close(true)
+
+	client, err := service.GetClient(clientCtx, "downstream")
+
+	if !errors.Is(err, errClientFactoryClosed) {
+		t.Fatalf("GetClient error = %v, want %v", err, errClientFactoryClosed)
+	}
+	if client != nil {
+		t.Fatal("GetClient returned a client after parent deletion")
+	}
+	if got := requestCount.Load(); got != 0 {
+		t.Fatalf("downstream request count = %d, want 0", got)
+	}
+}
+
+func TestHTTPServerDeleteClosesDownstreamHTTPSession(t *testing.T) {
+	const (
+		downstreamSessionID = "downstream-session-2"
+		passthroughHeader   = "X-Downstream-Auth"
+		passthroughValue    = "session-token"
+	)
+
+	type deleteRequest struct {
+		sessionID   string
+		passthrough string
+	}
+	deleteRequests := make(chan deleteRequest, 1)
+	var deleteCount atomic.Int32
+	var initializeCount atomic.Int32
+	downstream := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.Method {
+		case http.MethodDelete:
+			deleteCount.Add(1)
+			select {
+			case deleteRequests <- deleteRequest{
+				sessionID:   req.Header.Get(mcp.SessionIDHeader),
+				passthrough: req.Header.Get(passthroughHeader),
+			}:
+			default:
+			}
+			rw.WriteHeader(http.StatusNoContent)
+		case http.MethodGet:
+			// The client may probe for an event stream after initialization.
+			rw.WriteHeader(http.StatusMethodNotAllowed)
+		case http.MethodPost:
+			var msg mcp.Message
+			if err := json.NewDecoder(req.Body).Decode(&msg); err != nil {
+				http.Error(rw, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if msg.Method != "initialize" {
+				rw.WriteHeader(http.StatusAccepted)
+				return
+			}
+
+			result, err := json.Marshal(mcp.InitializeResult{
+				ProtocolVersion: "2025-06-18",
+				ServerInfo: mcp.ServerInfo{
+					Name:    "downstream",
+					Version: "test",
+				},
+			})
+			if err != nil {
+				http.Error(rw, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			rw.Header().Set(mcp.SessionIDHeader, fmt.Sprintf("downstream-session-%d", initializeCount.Add(1)))
+			rw.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(rw).Encode(mcp.Message{
+				JSONRPC: "2.0",
+				ID:      msg.ID,
+				Result:  result,
+			})
+		default:
+			rw.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(downstream.Close)
+
+	parent, err := mcp.NewServerSession(context.Background(), mcp.MessageHandlerFunc(func(context.Context, mcp.Message) {}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { parent.Close(false) })
+
+	service := NewToolsService()
+	clientCtx := types.WithConfig(parent.GetSession().Context(), types.Config{
+		MCPServers: map[string]mcp.Server{
+			"downstream": {
+				BaseURL:            downstream.URL,
+				PassthroughHeaders: []string{passthroughHeader},
+			},
+		},
+	})
+	incoming := httptest.NewRequest(http.MethodPost, "http://nanobot.example/mcp", nil)
+	incoming.Header.Set(passthroughHeader, passthroughValue)
+	clientCtx = mcp.WithRequest(clientCtx, incoming)
+	downstreamClient, err := service.GetClient(clientCtx, "downstream")
+	if err != nil {
+		t.Fatalf("failed to create downstream client: %v", err)
+	}
+	if got := downstreamClient.Session.ID(); got != "downstream-session-1" {
+		t.Fatalf("first downstream session ID = %q, want %q", got, "downstream-session-1")
+	}
+
+	// Force the factory through its copied-value replacement path. The session
+	// attribute must keep ownership of the replacement client so DELETE closes
+	// this second remote session rather than the stale first one.
+	downstreamClient.Close(false)
+	downstreamClient, err = service.GetClient(clientCtx, "downstream")
+	if err != nil {
+		t.Fatalf("failed to replace downstream client: %v", err)
+	}
+	if got := downstreamClient.Session.ID(); got != downstreamSessionID {
+		t.Fatalf("replacement downstream session ID = %q, want %q", got, downstreamSessionID)
+	}
+	if got := deleteCount.Load(); got != 0 {
+		t.Fatalf("downstream DELETE count before parent deletion = %d, want 0", got)
+	}
+
+	sessions := mcp.NewInMemorySessionStore()
+	if err := sessions.Store(context.Background(), parent.ID(), parent); err != nil {
+		t.Fatal(err)
+	}
+	front, err := mcp.NewHTTPServer(nil, mcp.MessageHandlerFunc(func(context.Context, mcp.Message) {}), mcp.HTTPServerOptions{
+		SessionStore: sessions,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "http://nanobot.example/mcp", nil)
+	req.Header.Set(mcp.SessionIDHeader, parent.ID())
+	rw := httptest.NewRecorder()
+	front.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("front DELETE status = %d, want %d; body: %s", rw.Code, http.StatusOK, rw.Body.String())
+	}
+	select {
+	case got := <-deleteRequests:
+		if got.sessionID != downstreamSessionID {
+			t.Fatalf("downstream DELETE session ID = %q, want %q", got.sessionID, downstreamSessionID)
+		}
+		if got.passthrough != passthroughValue {
+			t.Fatalf("downstream DELETE passthrough header = %q, want %q", got.passthrough, passthroughValue)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for downstream DELETE")
+	}
+	if got := deleteCount.Load(); got != 1 {
+		t.Fatalf("downstream DELETE count = %d, want 1", got)
+	}
+}
 
 func testConfig() types.Config {
 	return types.Config{


### PR DESCRIPTION
If a client deletes their session with us, then we should delete our session with any remote MCP servers.