### PR TITLE
feat: add the ability to disable lazy initialization

### DIFF
--- a/pkg/config/schema.yaml
+++ b/pkg/config/schema.yaml
@@ -253,6 +253,11 @@ definitions:
         description: |
           The entrypoint for the Nanobot. This is the tool, agent, or flow that
           will be invoked when "nanobot run" is executed.
+      lazyInitialize:
+        type: boolean
+        description: |
+          Whether to lazily initialize the published MCP servers. Defaults to true
+          when unset, except when publishing a single MCP server as a proxy.
 
   ToolOverride:
     type: object

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -412,14 +412,19 @@ func (s *Server) handleInitialize(ctx context.Context, msg mcp.Message, payload 
 		experimental[types.MetaNanobot] = meta
 	}
 
-	if c.Publish.IsSingleServerProxy() {
-		// This nanobot just exposes a single MCP server. Call the initialize directly and return its response.
-		c, err := s.data.InitializedClient(ctx, c.Publish.MCPServers[0])
-		if err != nil {
-			return fmt.Errorf("failed to initialize client: %w", err)
-		}
+	if !c.Publish.IsLazyInitialize() {
+		// We need to initialize the clients immediately
+		for _, server := range c.Publish.MCPServers {
+			client, err := s.data.InitializedClient(ctx, server)
+			if err != nil {
+				return fmt.Errorf("failed to initialize client for %q: %w", server, err)
+			}
 
-		return msg.Reply(ctx, c.Session.InitializeResult)
+			if c.Publish.IsSingleServerProxy() {
+				// If this is just one server, then return the initialize result all the way back to the client.
+				return msg.Reply(ctx, client.Session.InitializeResult)
+			}
+		}
 	}
 
 	return msg.Reply(ctx, mcp.InitializeResult{

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -239,6 +239,14 @@ type Publish struct {
 	ResourceTemplates StringList          `json:"resourceTemplates,omitzero"`
 	MCPServers        StringList          `json:"mcpServers,omitzero"`
 	Entrypoint        StringList          `json:"entrypoint,omitempty"`
+	LazyInitialize    *bool               `json:"lazyInitialize,omitempty"`
+}
+
+func (p Publish) IsLazyInitialize() bool {
+	if p.IsSingleServerProxy() {
+		return false
+	}
+	return p.LazyInitialize == nil || *p.LazyInitialize
 }
 
 func (p Publish) IsSingleServerProxy() bool {


### PR DESCRIPTION
Initializing with nanobot will not intialize any of the downstream MCP servers unless there is exactly one. This change adds the ability to initialize all MCP servers upfront. The functionality still defaults to lazy initialization.

Issue: https://github.com/obot-platform/obot/issues/7129