### PR TITLE
fix: include timing for requests that don't expect a response

### DIFF
--- a/pkg/mcp/auditlogs/auditlog.go
+++ b/pkg/mcp/auditlogs/auditlog.go
@@ -45,6 +45,17 @@ type MCPWebhookStatus struct {
 	Message string `json:"message,omitempty"`
 }
 
+// SetProcessingTime records the elapsed processing time for a completed audit
+// entry. Durations are reported in whole milliseconds, with sub-millisecond
+// calls rounded up so completed calls are not mistaken for missing durations.
+func (m *MCPAuditLog) SetProcessingTime() {
+	m.ProcessingTimeMs = processingTimeMilliseconds(time.Since(m.CreatedAt))
+}
+
+func processingTimeMilliseconds(elapsed time.Duration) int64 {
+	return max(elapsed.Milliseconds(), 1)
+}
+
 // RedactAPIKey redacts an API key, keeping everything to the third hyphen, or the first 12 characters, whichever is longer.
 // If the API key is less than 20 characters, it compares the third hyphen prefix to the first half and returns whichever is longer.
 func RedactAPIKey(apiKey string) string {

--- a/pkg/mcp/auditlogs/auditlog_test.go
+++ b/pkg/mcp/auditlogs/auditlog_test.go
@@ -1,6 +1,21 @@
 package auditlogs
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
+
+func TestProcessingTimeMillisecondsRoundsUpSubMillisecondDuration(t *testing.T) {
+	if got := processingTimeMilliseconds(500 * time.Microsecond); got != 1 {
+		t.Fatalf("processingTimeMilliseconds() = %d, want 1", got)
+	}
+}
+
+func TestProcessingTimeMillisecondsPreservesWholeMilliseconds(t *testing.T) {
+	if got := processingTimeMilliseconds(10 * time.Millisecond); got != 10 {
+		t.Fatalf("processingTimeMilliseconds() = %d, want 10", got)
+	}
+}
 
 func TestRedactAPIKey(t *testing.T) {
 	tests := []struct {

--- a/pkg/mcp/httpserver.go
+++ b/pkg/mcp/httpserver.go
@@ -319,7 +319,7 @@ func (h *HTTPServer) serveHTTP(rw http.ResponseWriter, req *http.Request) {
 			auditLog.ResponseStatus = recorder.statusCode
 			responseHeaders, _ := json.Marshal(recorder.Header())
 			auditLog.ResponseHeaders = responseHeaders
-			auditLog.ProcessingTimeMs = time.Since(auditLog.CreatedAt).Milliseconds()
+			auditLog.SetProcessingTime()
 			h.auditLogCollector.CollectMCPAuditEntry(auditLog)
 			slog.Debug("mcp server completed http request",
 				"http_method", req.Method,
@@ -403,7 +403,7 @@ func (h *HTTPServer) serveHTTP(rw http.ResponseWriter, req *http.Request) {
 		auditLog.ResponseBody = recorder.body.Bytes()
 		responseHeaders, _ := json.Marshal(recorder.Header())
 		auditLog.ResponseHeaders = responseHeaders
-		auditLog.ProcessingTimeMs = time.Since(auditLog.CreatedAt).Milliseconds()
+		auditLog.SetProcessingTime()
 		h.auditLogCollector.CollectMCPAuditEntry(auditLog)
 		slog.Debug("mcp server completed message",
 			"method", msg.Method,

--- a/pkg/mcp/httpserver_test.go
+++ b/pkg/mcp/httpserver_test.go
@@ -1,0 +1,87 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/obot-platform/nanobot/pkg/mcp/auditlogs"
+)
+
+type recordingAuditLogCollector struct {
+	mu      sync.Mutex
+	entries []auditlogs.MCPAuditLog
+}
+
+func (c *recordingAuditLogCollector) CollectMCPAuditEntry(entry auditlogs.MCPAuditLog) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = append(c.entries, entry)
+}
+
+func (*recordingAuditLogCollector) Close() {}
+
+func (c *recordingAuditLogCollector) entry(callType string) (auditlogs.MCPAuditLog, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, entry := range c.entries {
+		if entry.CallType == callType {
+			return entry, true
+		}
+	}
+	return auditlogs.MCPAuditLog{}, false
+}
+
+func TestHTTPServerNotificationAuditLogHasProcessingTime(t *testing.T) {
+	collector := new(recordingAuditLogCollector)
+	handler := MessageHandlerFunc(func(ctx context.Context, msg Message) {
+		if msg.Method == "initialize" {
+			if err := msg.Reply(ctx, InitializeResult{
+				ProtocolVersion: "2025-06-18",
+				ServerInfo: ServerInfo{
+					Name:    "test-server",
+					Version: "1.0.0",
+				},
+			}); err != nil {
+				t.Errorf("reply to initialize: %v", err)
+			}
+		}
+	})
+	server, err := NewHTTPServer(nil, handler, HTTPServerOptions{
+		BaseContext:       t.Context(),
+		AuditLogCollector: collector,
+	})
+	if err != nil {
+		t.Fatalf("create HTTP server: %v", err)
+	}
+
+	initialize := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}`,
+	))
+	initializeResponse := httptest.NewRecorder()
+	server.ServeHTTP(initializeResponse, initialize)
+	if initializeResponse.Code != http.StatusOK {
+		t.Fatalf("initialize status = %d, want %d; body: %s", initializeResponse.Code, http.StatusOK, initializeResponse.Body.String())
+	}
+
+	initialized := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+	))
+	initialized.Header.Set("Mcp-Session-Id", initializeResponse.Header().Get("Mcp-Session-Id"))
+	initializedResponse := httptest.NewRecorder()
+	server.ServeHTTP(initializedResponse, initialized)
+	if initializedResponse.Code != http.StatusAccepted {
+		t.Fatalf("initialized status = %d, want %d; body: %s", initializedResponse.Code, http.StatusAccepted, initializedResponse.Body.String())
+	}
+
+	auditLog, ok := collector.entry("notifications/initialized")
+	if !ok {
+		t.Fatal("notifications/initialized audit log was not collected")
+	}
+	if auditLog.ProcessingTimeMs < 1 {
+		t.Fatalf("ProcessingTimeMs = %d, want at least 1", auditLog.ProcessingTimeMs)
+	}
+}

--- a/pkg/tools/service.go
+++ b/pkg/tools/service.go
@@ -154,7 +154,7 @@ func (s *Service) collectAuditLog(auditLog *auditlogs.MCPAuditLog) {
 		return
 	}
 
-	auditLog.ProcessingTimeMs = time.Since(auditLog.CreatedAt).Milliseconds()
+	auditLog.SetProcessingTime()
 	if auditLog.ResponseStatus == 0 {
 		if auditLog.Error != "" {
 			auditLog.ResponseStatus = http.StatusInternalServerError


### PR DESCRIPTION
Audit logs were missing timing information for requests that don't expect a response (like initialized or notifications). This change ensures they do.