### PR TITLE
fix: improve GitLab MCP compatibility

### DIFF
--- a/pkg/mcp/httpclient.go
+++ b/pkg/mcp/httpclient.go
@@ -819,7 +819,9 @@ func (s *HTTPClient) send(ctx context.Context, msg Message) error {
 		}
 	}
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+	// Requests require a response body; notifications and responses do not.
+	isRequest := msg.Method != "" && msg.ID != nil
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted && (resp.StatusCode != http.StatusNoContent || isRequest) {
 		streamingErrorMessage, _ := io.ReadAll(resp.Body)
 		slog.Error("mcp client request failed",
 			"server", s.serverName,
@@ -835,7 +837,7 @@ func (s *HTTPClient) send(ctx context.Context, msg Message) error {
 		"request_id", MessageIDString(msg.ID),
 		"status_code", resp.StatusCode)
 
-	if s.sse || resp.StatusCode == http.StatusAccepted {
+	if s.sse || resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNoContent {
 		return nil
 	}
 

--- a/pkg/mcp/httpclient_test.go
+++ b/pkg/mcp/httpclient_test.go
@@ -2,12 +2,122 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
+
+func TestHTTPClientInitializationAcceptsNoContentNotification(t *testing.T) {
+	var initialized atomic.Bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var msg Message
+		if err := json.NewDecoder(req.Body).Decode(&msg); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		switch msg.Method {
+		case "initialize":
+			result, err := json.Marshal(InitializeResult{
+				ProtocolVersion: "2025-06-18",
+				ServerInfo: ServerInfo{
+					Name:    "test",
+					Version: "1.0.0",
+				},
+			})
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set(SessionIDHeader, "test-session")
+			_ = json.NewEncoder(w).Encode(Message{
+				JSONRPC: "2.0",
+				ID:      msg.ID,
+				Result:  result,
+			})
+		case "notifications/initialized":
+			initialized.Store(true)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "unexpected method", http.StatusBadRequest)
+		}
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(t.Context(), "test", Server{BaseURL: ts.URL})
+	if err != nil {
+		t.Fatalf("failed to initialize client: %v", err)
+	}
+	defer client.Close(false)
+
+	if !initialized.Load() {
+		t.Fatal("expected notifications/initialized")
+	}
+}
+
+func TestHTTPClientNoContentMessageHandling(t *testing.T) {
+	tests := []struct {
+		name    string
+		message Message
+		wantErr bool
+	}{
+		{
+			name: "notification",
+			message: Message{
+				JSONRPC: "2.0",
+				Method:  "notifications/test",
+			},
+		},
+		{
+			name: "response",
+			message: Message{
+				JSONRPC: "2.0",
+				ID:      1,
+				Result:  json.RawMessage(`{}`),
+			},
+		},
+		{
+			name: "request",
+			message: Message{
+				JSONRPC: "2.0",
+				ID:      1,
+				Method:  "ping",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer ts.Close()
+
+			client, err := newHTTPClient("test", Server{BaseURL: ts.URL}, HTTPClientOptions{}, &SessionState{ID: "test-session"}, nil, false)
+			if err != nil {
+				t.Fatalf("newHTTPClient failed: %v", err)
+			}
+			if err := client.Start(t.Context(), func(context.Context, Message) {}); err != nil {
+				t.Fatalf("failed to start client: %v", err)
+			}
+			defer client.Close(false)
+
+			err = client.Send(t.Context(), tt.message)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected request with no response to fail")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected message with no response to succeed: %v", err)
+			}
+		})
+	}
+}
 
 func TestHTTPClientPassthroughHeaders(t *testing.T) {
 	incoming := httptest.NewRequest(http.MethodPost, "http://nanobot.example/mcp", nil)

--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -768,11 +768,38 @@ func AuthCodeURL(conf *oauth2.Config, urlFromMetadata, resourceURL, state, verif
 	return conf.AuthCodeURL(state, authCodeURLOpts...), nil
 }
 
+type resourceIdentifier string
+
+func (r *resourceIdentifier) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) > 0 && data[0] == '[' {
+		var resources []json.RawMessage
+		if err := json.Unmarshal(data, &resources); err != nil {
+			return err
+		}
+		if len(resources) != 1 {
+			return fmt.Errorf("resource array must contain exactly one identifier")
+		}
+		data = resources[0]
+	}
+
+	var resource string
+	if err := json.Unmarshal(data, &resource); err != nil {
+		return fmt.Errorf("resource must be a string or singleton string array: %w", err)
+	}
+	if resource == "" {
+		return fmt.Errorf("resource identifier must not be empty")
+	}
+
+	*r = resourceIdentifier(resource)
+	return nil
+}
+
 // protectedResourceMetadata represents OAuth 2.0 Protected Resource Metadata
 // as defined in RFC 8707
 type protectedResourceMetadata struct {
 	// REQUIRED. The protected resource's resource identifier
-	Resource string `json:"resource"`
+	Resource resourceIdentifier `json:"resource"`
 
 	// OPTIONAL. JSON array containing a list of OAuth authorization server issuer identifiers
 	AuthorizationServers []string `json:"authorization_servers,omitempty"`

--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -775,7 +775,7 @@ func (r *resourceIdentifier) UnmarshalJSON(data []byte) error {
 	if len(data) > 0 && data[0] == '[' {
 		var resources []json.RawMessage
 		if err := json.Unmarshal(data, &resources); err != nil {
-			return err
+			return fmt.Errorf("resource must be a string or singleton string array: %w", err)
 		}
 		if len(resources) != 1 {
 			return fmt.Errorf("resource array must contain exactly one identifier")

--- a/pkg/mcp/oauth_test.go
+++ b/pkg/mcp/oauth_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -120,6 +121,101 @@ func TestGetOAuthMetadata(t *testing.T) {
 	}
 	if !slices.Equal(clientRegistration.GrantTypes, []string{"authorization_code"}) {
 		t.Fatalf("unexpected grant types: %v", clientRegistration.GrantTypes)
+	}
+}
+
+func TestParseProtectedResourceMetadataResourceForms(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		json string
+	}{
+		{
+			name: "string",
+			json: `{"resource":"https://example.com/mcp"}`,
+		},
+		{
+			name: "singleton array",
+			json: `{"resource":["https://example.com/mcp"]}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata, err := parseProtectedResourceMetadata(strings.NewReader(tt.json))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(metadata.Resource) != "https://example.com/mcp" {
+				t.Fatalf("unexpected resource: %q", metadata.Resource)
+			}
+
+			encoded, err := json.Marshal(metadata)
+			if err != nil {
+				t.Fatalf("failed to marshal protected resource metadata: %v", err)
+			}
+			var output struct {
+				Resource string `json:"resource"`
+			}
+			if err := json.Unmarshal(encoded, &output); err != nil {
+				t.Fatalf("resource was not marshaled as a string: %v", err)
+			}
+			if output.Resource != "https://example.com/mcp" {
+				t.Fatalf("unexpected marshaled resource: %q", output.Resource)
+			}
+		})
+	}
+}
+
+func TestParseProtectedResourceMetadataRejectsInvalidResourceShapes(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		resource string
+	}{
+		{
+			name:     "empty string",
+			resource: `""`,
+		},
+		{
+			name:     "empty array",
+			resource: `[]`,
+		},
+		{
+			name:     "multiple resources",
+			resource: `["https://example.com/one","https://example.com/two"]`,
+		},
+		{
+			name:     "empty array resource",
+			resource: `[""]`,
+		},
+		{
+			name:     "number",
+			resource: `42`,
+		},
+		{
+			name:     "boolean",
+			resource: `true`,
+		},
+		{
+			name:     "null",
+			resource: `null`,
+		},
+		{
+			name:     "object",
+			resource: `{}`,
+		},
+		{
+			name:     "non-string array element",
+			resource: `[42]`,
+		},
+		{
+			name:     "null array element",
+			resource: `[null]`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseProtectedResourceMetadata(strings.NewReader(`{"resource":` + tt.resource + `}`))
+			if err == nil {
+				t.Fatal("expected invalid resource to be rejected")
+			}
+		})
 	}
 }
 

--- a/pkg/mcp/wellknown.go
+++ b/pkg/mcp/wellknown.go
@@ -24,7 +24,7 @@ func (h *HTTPServer) protectedMetadata(w http.ResponseWriter, r *http.Request) {
 	if host == "" {
 		host = r.Host
 	}
-	protectedResourceMetadata.Resource = strings.TrimSuffix(fmt.Sprintf("%s://%s/%s", scheme, host, r.PathValue("path")), "/")
+	protectedResourceMetadata.Resource = resourceIdentifier(strings.TrimSuffix(fmt.Sprintf("%s://%s/%s", scheme, host, r.PathValue("path")), "/"))
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(protectedResourceMetadata); err != nil {


### PR DESCRIPTION
## Summary

- accept RFC 9728 string resource identifiers and GitLab's singleton-array form
- reject empty, multiple, and non-string resource values without silently selecting one
- preserve singular internal resource values and normal string JSON output
- accept `204 No Content` only for JSON-RPC notifications and responses, while continuing to reject it for requests that require a response

Related GitLab issue: https://gitlab.com/gitlab-org/gitlab/-/work_items/596356

## Protected resource metadata

[RFC 9728](https://www.rfc-editor.org/rfc/rfc9728.html#section-2) defines `resource` as a singular resource identifier. GitLab currently publishes it as a singleton array:

```bash
curl -s "https://gitlab.com/.well-known/oauth-protected-resource/api/v4/mcp" | jq
```

```json
{
  "resource": [
    "https://gitlab.com/api/v4/mcp"
  ],
  "authorization_servers": [
    "https://gitlab.com"
  ],
  "scopes_supported": [
    "mcp"
  ]
}
```

Nanobot now accepts that specific compatibility form while retaining the RFC-compliant string representation internally and on output.

## No-content notifications

GitLab responds to `notifications/initialized` with `204 No Content` instead of the MCP-specified `202 Accepted`. [RFC 9110 section 15.3.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.5) defines 204 as a successful response with no additional content, which is safe for JSON-RPC notifications and responses because they do not expect a response body.

The exception remains narrow: JSON-RPC requests still reject 204 because they require a JSON or SSE response.

## Testing

- `go test ./pkg/mcp`
- Manually tested with Obot + GitLab MCP